### PR TITLE
Added empty QueryBatchCursorInit when undefined CursorState;

### DIFF
--- a/Youverse.Hosting/Controllers/QueryBatchResultOptionsRequest.cs
+++ b/Youverse.Hosting/Controllers/QueryBatchResultOptionsRequest.cs
@@ -22,10 +22,9 @@ public class QueryBatchResultOptionsRequest
 
     public Core.Services.Drive.Query.QueryBatchResultOptions ToQueryBatchResultOptions()
     {
-        
         return new Core.Services.Drive.Query.QueryBatchResultOptions()
         {
-            Cursor =  new QueryBatchCursor(this.CursorState),
+            Cursor =  this.CursorState == null ?  new QueryBatchCursor() : new QueryBatchCursor(this.CursorState),
             MaxRecords = this.MaxRecords,
             IncludeJsonContent = this.IncludeMetadataHeader
         };


### PR DESCRIPTION
When doing a QueryBatch to server with a cursorState that is undefined, I was getting a 500, 'Invalid Cursor State'. It can be resolved by this..

Probably not the best way forward, but I'll leave that to you two ;-)