### PR TITLE
Move treat-warning-as-error to CI

### DIFF
--- a/.github/workflows/deploy-to-demo.yml
+++ b/.github/workflows/deploy-to-demo.yml
@@ -22,7 +22,7 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore --warnaserror
       
    # - name: Test
    #   run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build
         #        working-directory: ./dotyoucore
-        run: dotnet build --no-restore dotyoucore/DotYouCore.sln
+        run: dotnet build --no-restore --warnaserror dotyoucore/DotYouCore.sln
 
       - name: Test
         #        working-directory: ./dotyoucore

--- a/.github/workflows/lib-on-ubuntu.yml
+++ b/.github/workflows/lib-on-ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build
         #        working-directory: ./dotyoucore
-        run: dotnet build --no-restore lib/lib.sln
+        run: dotnet build --no-restore --warnaserror lib/lib.sln
 
       - name: Test
         #        working-directory: ./dotyoucore

--- a/.github/workflows/services-on-ubuntu.yml
+++ b/.github/workflows/services-on-ubuntu.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build
         #working-directory: dotyoucore
-        run: dotnet build --no-restore services/dotyoucore.sln
+        run: dotnet build --no-restore --warnaserror services/dotyoucore.sln
 
       - name: Test
         #working-directory: dotyoucore

--- a/lib/CommonProjectConfig.targets
+++ b/lib/CommonProjectConfig.targets
@@ -10,6 +10,5 @@ Usage
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <NoWarn>CS1591</NoWarn>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/services/Youverse.Hosting/Dockerfile
+++ b/services/Youverse.Hosting/Dockerfile
@@ -15,7 +15,7 @@ COPY ["services/Youverse.Core.Services.Background/Youverse.Core.Services.Backgro
 RUN dotnet restore "services/Youverse.Hosting/Youverse.Hosting.csproj"
 COPY . .
 
-RUN dotnet build "services/Youverse.Hosting/Youverse.Hosting.csproj" -c Release -o /app/build
+RUN dotnet build --warnaserror "services/Youverse.Hosting/Youverse.Hosting.csproj" -c Release -o /app/build
 
 FROM build AS publish
 #RUN dotnet publish "Youverse.Hosting/Youverse.Hosting.csproj" -c Release -o /app/publish


### PR DESCRIPTION
Allow warnings when working on code, but CI build will fail if there are warnings