### PR TITLE
Temporary shared-secret redirect hack

### DIFF
--- a/services/Odin.Core.Services/Authentication/YouAuth/YouAuthDefaults.cs
+++ b/services/Odin.Core.Services/Authentication/YouAuth/YouAuthDefaults.cs
@@ -8,6 +8,7 @@ namespace Odin.Core.Services.Authentication.YouAuth
         public const string Initiator = "initiator";
         public const string ReturnUrl = "returnUrl";
         public const string Subject = "subject";
+        public const string SharedSecret = "ss64";
         
         public const string XTokenCookieName = "XT32";
 

--- a/services/Odin.Hosting/Controllers/Anonymous/YouAuthApiPathConstants.cs
+++ b/services/Odin.Hosting/Controllers/Anonymous/YouAuthApiPathConstants.cs
@@ -8,6 +8,9 @@
 
         public const string ValidateAuthorizationCodeRequestMethodName = "validate-ac-req";
         public const string ValidateAuthorizationCodeRequestPath = AuthV1 + "/" + ValidateAuthorizationCodeRequestMethodName;
+        
+        public const string FinalizeBridgeRequestMethodName = "finalize-bridge";
+        public const string FinalizeBridgeRequestRequestPath = AuthV1 + "/" + FinalizeBridgeRequestMethodName;        
 
         public const string IsAuthenticatedMethodName = "is-authenticated";
         public const string DeleteTokenMethodName = "delete-token";

--- a/services/Odin.Hosting/Controllers/Anonymous/YouAuthController.cs
+++ b/services/Odin.Hosting/Controllers/Anonymous/YouAuthController.cs
@@ -58,12 +58,26 @@ namespace Odin.Hosting.Controllers.Anonymous
             //TODO: RSA Encrypt shared secret
             var shareSecret64 = Convert.ToBase64String(clientAccessToken?.SharedSecret.GetKey() ?? Array.Empty<byte>());
             clientAccessToken?.Wipe();
+            
+            // SEB:NOTE before brigde-hack:
+            //var handlerUrl = $"/home/youauth/finalize?ss64={HttpUtility.UrlEncode(shareSecret64)}&returnUrl={HttpUtility.UrlEncode(returnUrl)}";
 
-            var handlerUrl = $"/home/youauth/finalize?ss64={HttpUtility.UrlEncode(shareSecret64)}&returnUrl={HttpUtility.UrlEncode(returnUrl)}";
+            var handlerUrl = $"https://{Request.Host}{YouAuthApiPathConstants.FinalizeBridgeRequestRequestPath}?ss64={HttpUtility.UrlEncode(shareSecret64)}&returnUrl={HttpUtility.UrlEncode(returnUrl)}";
             return Redirect(handlerUrl);
-            // return Ok(handlerUrl);
         }
-
+        
+        //
+        
+        [HttpGet(YouAuthApiPathConstants.FinalizeBridgeRequestMethodName)]
+        public ActionResult FinalizeBridgeRequest(
+            [FromQuery(Name = YouAuthDefaults.SharedSecret)]
+            string ss64,
+            [FromQuery(Name = YouAuthDefaults.ReturnUrl)]
+            string returnUrl)
+        {
+            var handlerUrl = $"https://{_currentTenant}/home/youauth/finalize?ss64={ss64}&returnUrl={returnUrl}";
+            return Redirect(handlerUrl);
+        }
 
         //
 


### PR DESCRIPTION
YouAuth: once the home cookie has been written to api.frodo.me, do a double redirect (api.frodo.me -> frodo.me) so that the frontend can pick up the shared secret and store it in local storage on the correct origin (e.g. frodo.me instead of api.frodo.me)