### PR TITLE
Fixed content-type of thumb when unencrypted;

### DIFF
--- a/services/Odin.Hosting/Controllers/Base/Drive/DriveStorageControllerBase.cs
+++ b/services/Odin.Hosting/Controllers/Base/Drive/DriveStorageControllerBase.cs
@@ -125,7 +125,7 @@ namespace Odin.Hosting.Controllers.Base.Drive
 
             var result = new FileStreamResult(thumbPayload, header.FileMetadata.PayloadIsEncrypted
                     ? "application/octet-stream"
-                    : header.FileMetadata.ContentType);
+                    : thumbHeader.ContentType);
 
             return result;
         }


### PR DESCRIPTION
I might have missed some other place where the same things happens, but I'm not sure..