### PR TITLE
Adding serilog filter to exclude sslv2 probe errors

### DIFF
--- a/lib/Odin.Core/Logging/LogLevelOverwrite/Serilog/LogLevelOverwriteSink.cs
+++ b/lib/Odin.Core/Logging/LogLevelOverwrite/Serilog/LogLevelOverwriteSink.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Odin.Core.Logging.LogLevelOverwrite.Serilog;
+
+public static class LogLevelModifierSinkExtensions
+{
+    public static LoggerConfiguration LogLevelModifier(
+        this LoggerSinkConfiguration loggerSinkConfiguration,
+        Action<LoggerSinkConfiguration> configure)
+    {
+        return LoggerSinkConfiguration.Wrap(loggerSinkConfiguration, sink =>
+            new LogLevelModifierSink(sink), configure, LevelAlias.Minimum, null);
+    }
+}
+
+//
+
+public class LogLevelModifierSink : ILogEventSink
+{
+    private readonly ILogEventSink _targetSink;
+
+    //
+
+    public LogLevelModifierSink(ILogEventSink targetSink)
+    {
+        _targetSink = targetSink ?? throw new ArgumentNullException(nameof(targetSink));
+    }
+
+    //
+
+    public void Emit(LogEvent logEvent)
+    {
+        var newLogLevel = ChangeLogLevel(logEvent);
+        if (newLogLevel == logEvent.Level)
+        {
+            _targetSink.Emit(logEvent);
+        }
+        else
+        {
+            var newLogEvent = new LogEvent(
+                logEvent.Timestamp,
+                newLogLevel,
+                logEvent.Exception,
+                logEvent.MessageTemplate,
+                logEvent.Properties.Select(p => new LogEventProperty(p.Key, p.Value))
+            );
+            _targetSink.Emit(newLogEvent);
+        }
+    }
+
+    //
+
+    private static LogEventLevel ChangeLogLevel(LogEvent logEvent)
+    {
+        if (logEvent.Exception != null &&
+            logEvent.Exception.GetType() == typeof(NotSupportedException) &&
+            logEvent.Exception.Message == "The server mode SSL must use a certificate with the associated private key.")
+        {
+            return LogEventLevel.Warning;
+        }
+
+        return logEvent.Level;
+    }
+}


### PR DESCRIPTION
An exception is thrown deep within the bowels of Kestrel when a bot is probing sslv2 support. We can't catch the exception and it is logged as an error. This PR downgrades the error to a warning while keeping the exception details.