### PR TITLE
GenericMemoryCache: use MemoryCacheEntryOptions

### DIFF
--- a/src/apps/Odin.Hosting/Controllers/Home/Service/HomeCachingService.cs
+++ b/src/apps/Odin.Hosting/Controllers/Home/Service/HomeCachingService.cs
@@ -60,7 +60,7 @@ namespace Odin.Hosting.Controllers.Home.Service
                     var collection = await _fsResolver.ResolveFileSystem().Query.GetBatchCollection(request, odinContext);
                     return collection;
                 },
-                TimeSpan.FromSeconds(_config.Host.HomePageCachingExpirationSeconds));
+                Expiration.Relative(TimeSpan.FromSeconds(_config.Host.HomePageCachingExpirationSeconds)));
 
             return result!;
         }

--- a/src/apps/Odin.SetupHelper/DnsProbe.cs
+++ b/src/apps/Odin.SetupHelper/DnsProbe.cs
@@ -41,7 +41,7 @@ public class DnsProbe(IGenericMemoryCache cache, IAuthoritativeDnsLookup authori
         if (aRecord != null)
         {
             result = new ResolveIpResult(aRecord.Address.ToString(), $"Resolved {domainName} to {aRecord.Address}");
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
         
@@ -61,7 +61,7 @@ public class DnsProbe(IGenericMemoryCache cache, IAuthoritativeDnsLookup authori
             if (aRecord != null)
             {
                 result = new ResolveIpResult(aRecord.Address.ToString(), $"Resolved {domainName} to {aRecord.Address}");
-                cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+                cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
                 return result;
             }
     
@@ -69,7 +69,7 @@ public class DnsProbe(IGenericMemoryCache cache, IAuthoritativeDnsLookup authori
         }
         
         result = new ResolveIpResult("", $"Did not find neither A nor CNAME record for {domainName} at authoritative name servers");
-        cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+        cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
         return result;
     }
     
@@ -88,19 +88,19 @@ public class DnsProbe(IGenericMemoryCache cache, IAuthoritativeDnsLookup authori
         if (authoritativeResult.Exception != null)
         {
             result = new AuthorityResult("", authoritativeResult.Exception.Message);  
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
 
         if (authoritativeResult.AuthoritativeNameServer == "")
         {
             result = new AuthorityResult("", $"No authoritative name server found for {domainName}");
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
     
         result = new AuthorityResult(authoritativeResult.AuthoritativeNameServer, $"Authoritative name server found for {domainName}");
-        cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+        cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
         return result;
     }
     

--- a/src/apps/Odin.SetupHelper/HttpProbe.cs
+++ b/src/apps/Odin.SetupHelper/HttpProbe.cs
@@ -49,34 +49,34 @@ public class HttpProbe(IHttpClientFactory httpClientFactory, IGenericMemoryCache
                 {
                     
                     result = new HttpProbeResult(true, $"Successfully probed {scheme}://{domainName}:{port}");
-                    cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+                    cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
                     return result;
 
                 }
                 result = new HttpProbeResult(false, $"Successfully probed {scheme}://{domainName}:{port}, but received unexpected response");
-                cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+                cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
                 return result;
             }
             result = new HttpProbeResult(false, $"Failed to probe {scheme}://{domainName}:{port}, {domainName} says: {response.ReasonPhrase}");
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
         catch (HttpRequestException e)
         {
             result = new HttpProbeResult(false, $"Failed to probe {scheme}://{domainName}:{port}: {e.Message}");
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
         catch (TaskCanceledException)
         {
             result = new HttpProbeResult(false, $"Failed to probe {scheme}://{domainName}:{port}: time out");
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
         catch (Exception)
         {
             result = new HttpProbeResult(false, $"Failed to probe {scheme}://{domainName}:{port}: unknown server error");
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
         

--- a/src/apps/Odin.SetupHelper/TcpProbe.cs
+++ b/src/apps/Odin.SetupHelper/TcpProbe.cs
@@ -61,13 +61,13 @@ public class TcpProbe(IGenericMemoryCache cache)
                 result = new TcpProbeResult(false, $"Successfully connected to {ipOrDomain}:{port}, but did not get the expected response");    
             }
             
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
         catch (Exception ex)
         {
             result = new TcpProbeResult(false, $"Failed to connect to {ipOrDomain}:{port}: {ex.Message}");
-            cache.Set(cacheKey, result, TimeSpan.FromSeconds(5));
+            cache.Set(cacheKey, result, Expiration.Relative(TimeSpan.FromSeconds(5)));
             return result;
         }
     }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCache.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Odin.Core.Cache;
 using Odin.Core.Exceptions;
 using Odin.Core.Storage.Database.Identity.Connection;
@@ -22,53 +23,53 @@ public class TableKeyValueCache(
         cache.Remove(key);
     }
 
-    public async Task<KeyValueRecord?> GetAsync(byte[] key, TimeSpan lifespan)
+    public async Task<KeyValueRecord?> GetAsync(byte[] key, MemoryCacheEntryOptions options)
     {
         NoTransactionCheck();
 
         if (cache.TryGet<KeyValueRecord?>(key, out var record))
         {
-            cache.Set(key, record, lifespan);
+            cache.Set(key, record, options);
             return record;
         }
 
         record = await table.GetAsync(key);
-        cache.Set(key, record, lifespan);
+        cache.Set(key, record, options);
         return record;
     }
 
     //
 
-    public async Task<int> InsertAsync(KeyValueRecord record, TimeSpan lifespan)
+    public async Task<int> InsertAsync(KeyValueRecord record, MemoryCacheEntryOptions options)
     {
         NoTransactionCheck();
 
         var affectedRows = await table.InsertAsync(record);
-        cache.Set(record.key, record, lifespan);
+        cache.Set(record.key, record, options);
 
         return affectedRows;
     }
 
     //
 
-    public async Task<int> UpdateAsync(KeyValueRecord record, TimeSpan lifespan)
+    public async Task<int> UpdateAsync(KeyValueRecord record, MemoryCacheEntryOptions options)
     {
         NoTransactionCheck();
 
         var affectedRows = await table.UpdateAsync(record);
-        cache.Set(record.key, record, lifespan);
+        cache.Set(record.key, record, options);
 
         return affectedRows;
     }
 
     //
 
-    public async Task<int> UpsertAsync(KeyValueRecord record, TimeSpan lifespan)
+    public async Task<int> UpsertAsync(KeyValueRecord record, MemoryCacheEntryOptions options)
     {
         NoTransactionCheck();
 
         var affectedRows = await table.UpsertAsync(record);
-        cache.Set(record.key, record, lifespan);
+        cache.Set(record.key, record, options);
 
         return affectedRows;
     }

--- a/src/services/Odin.Services/Authentication/YouAuth/YouAuthUnifiedService.cs
+++ b/src/services/Odin.Services/Authentication/YouAuth/YouAuthUnifiedService.cs
@@ -26,7 +26,7 @@ public sealed class YouAuthUnifiedService : IYouAuthUnifiedService
     private readonly IAppRegistrationService _appRegistrationService;
     private readonly YouAuthDomainRegistrationService _domainRegistrationService;
     private readonly CircleNetworkService _circleNetwork;
-    private readonly IGenericMemoryCache<YouAuthUnifiedService> _encryptedTokens;
+    private readonly IGenericMemoryCache<YouAuthUnifiedService> _encryptedTokens; // SEB:TODO does not scale
     private readonly SharedConcurrentDictionary<YouAuthUnifiedService, string, bool> _tempConsent;
 
     public YouAuthUnifiedService(
@@ -197,7 +197,7 @@ public sealed class YouAuthUnifiedService : IYouAuthUnifiedService
             clientAuthTokenCipher,
             clientAuthTokenIv);
 
-        _encryptedTokens.Set(exchangeSharedSecretDigest, encryptedTokenExchange, TimeSpan.FromMinutes(5));
+        _encryptedTokens.Set(exchangeSharedSecretDigest, encryptedTokenExchange, Expiration.Relative(TimeSpan.FromMinutes(5)));
 
         return (keyPair.PublicKeyJwkBase64Url(), Convert.ToBase64String(exchangeSalt));
     }

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableKeyValueCacheTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableKeyValueCacheTests.cs
@@ -26,13 +26,13 @@ public class TableKeyValueCacheTests : IocTestBase
         var k1 = Guid.NewGuid().ToByteArray();
         var v1 = Guid.NewGuid().ToByteArray();
 
-        var record = await tblKeyValueCache.GetAsync(k1, TimeSpan.FromSeconds(1));
+        var record = await tblKeyValueCache.GetAsync(k1, Expiration.Sliding(TimeSpan.FromSeconds(1)));
         Assert.IsNull(record);
 
         record = new KeyValueRecord { key = k1, data = v1 };
-        await tblKeyValueCache.InsertAsync(record, TimeSpan.FromSeconds(1));
+        await tblKeyValueCache.InsertAsync(record, Expiration.Sliding(TimeSpan.FromSeconds(1)));
 
-        record = await tblKeyValueCache.GetAsync(k1, TimeSpan.FromSeconds(1));
+        record = await tblKeyValueCache.GetAsync(k1, Expiration.Sliding(TimeSpan.FromSeconds(1)));
         Assert.IsNotNull(record);
 
         var cache = scope.Resolve<IGenericMemoryCache<TableKeyValueCache>>();
@@ -41,11 +41,11 @@ public class TableKeyValueCacheTests : IocTestBase
         cache.Remove(k1);
         Assert.IsFalse(cache.Contains(k1));
 
-        record = await tblKeyValueCache.GetAsync(k1, TimeSpan.FromSeconds(1));
+        record = await tblKeyValueCache.GetAsync(k1, Expiration.Sliding(TimeSpan.FromSeconds(1)));
         Assert.IsNotNull(record);
 
         await tblKeyValueCache.DeleteAsync(k1);
-        record = await tblKeyValueCache.GetAsync(k1, TimeSpan.FromSeconds(1));
+        record = await tblKeyValueCache.GetAsync(k1, Expiration.Sliding(TimeSpan.FromSeconds(1)));
         Assert.IsNull(record);
     }
 

--- a/tests/core/Odin.Core.Tests/Cache/GenericMemoryCacheTest.cs
+++ b/tests/core/Odin.Core.Tests/Cache/GenericMemoryCacheTest.cs
@@ -19,14 +19,14 @@ public class GenericMemoryCacheTest
         // Arrange
         var cache = new GenericMemoryCache();
 
-        cache.Set("foo", "bar", TimeSpan.FromSeconds(10));
+        cache.Set("foo", "bar", Expiration.Relative(TimeSpan.FromSeconds(10)));
         {
             var hit = cache.TryGet("foo", out var value);
             Assert.IsTrue(hit);
             Assert.AreEqual("bar", value);
         }
 
-        cache.Set("foo", new SampleValue(), TimeSpan.FromSeconds(10));
+        cache.Set("foo", new SampleValue(), Expiration.Relative(TimeSpan.FromSeconds(10)));
         {
             var hit = cache.TryGet<SampleValue>("foo", out var value);
             Assert.IsTrue(hit);
@@ -34,14 +34,14 @@ public class GenericMemoryCacheTest
         }
 
         var key = RandomNumberGenerator.GetBytes(16);
-        cache.Set(key, "bar", TimeSpan.FromSeconds(10));
+        cache.Set(key, "bar", Expiration.Relative(TimeSpan.FromSeconds(10)));
         {
             var hit = cache.TryGet(key, out var value);
             Assert.IsTrue(hit);
             Assert.AreEqual("bar", value);
         }
 
-        cache.Set(key, new SampleValue(), TimeSpan.FromSeconds(10));
+        cache.Set(key, new SampleValue(), Expiration.Relative(TimeSpan.FromSeconds(10)));
         {
             var hit = cache.TryGet<SampleValue>(key, out var value);
             Assert.IsTrue(hit);
@@ -65,7 +65,7 @@ public class GenericMemoryCacheTest
             {
                 factoryCallCount++;
                 return "bar";
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.AreEqual("bar", value);
             Assert.AreEqual(1, factoryCallCount);
         }
@@ -75,7 +75,7 @@ public class GenericMemoryCacheTest
             {
                 factoryCallCount++;
                 return "bar";
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.AreEqual("bar", value);
             Assert.AreEqual(0, factoryCallCount);
         }
@@ -88,7 +88,7 @@ public class GenericMemoryCacheTest
         {
             var exception = Assert.Throws<InvalidCastException>(() =>
             {
-                cache.GetOrCreate("foo", () => new SampleValue(), TimeSpan.FromSeconds(10));
+                cache.GetOrCreate("foo", () => new SampleValue(), Expiration.Relative(TimeSpan.FromSeconds(10)));
             });
             Assert.AreEqual("The item with key 'foo' cannot be cast to type SampleValue.", exception!.Message);
         }
@@ -96,7 +96,7 @@ public class GenericMemoryCacheTest
         cache.Remove("foo");
 
         {
-            var value = cache.GetOrCreate("foo", () => new SampleValue(), TimeSpan.FromSeconds(10));
+            var value = cache.GetOrCreate("foo", () => new SampleValue(), Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.AreEqual("bar", value!.Name);
         }
         {
@@ -123,7 +123,7 @@ public class GenericMemoryCacheTest
                 await Task.Delay(1);
                 factoryCallCount++;
                 return "bar";
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.AreEqual("bar", value);
             Assert.AreEqual(1, factoryCallCount);
         }
@@ -134,7 +134,7 @@ public class GenericMemoryCacheTest
                 await Task.Delay(1);
                 factoryCallCount++;
                 return "bar";
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.AreEqual("bar", value);
             Assert.AreEqual(0, factoryCallCount);
         }
@@ -151,7 +151,7 @@ public class GenericMemoryCacheTest
                 {
                     await Task.Delay(1);
                     return new SampleValue();
-                }, TimeSpan.FromSeconds(10));
+                }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             });
             Assert.AreEqual("The item with key 'foo' cannot be cast to type SampleValue.", exception!.Message);
         }
@@ -163,7 +163,7 @@ public class GenericMemoryCacheTest
             {
                 await Task.Delay(1);
                 return new SampleValue();
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.AreEqual("bar", value!.Name);
         }
         {
@@ -189,7 +189,7 @@ public class GenericMemoryCacheTest
             {
                 factoryCallCount++;
                 return null;
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.IsNull(value);
             Assert.AreEqual(1, factoryCallCount);
         }
@@ -199,7 +199,7 @@ public class GenericMemoryCacheTest
             {
                 factoryCallCount++;
                 return null;
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.IsNull(value);
             Assert.AreEqual(0, factoryCallCount);
         }
@@ -227,7 +227,7 @@ public class GenericMemoryCacheTest
                 await Task.Delay(1);
                 factoryCallCount++;
                 return null;
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.IsNull(value);
             Assert.AreEqual(1, factoryCallCount);
         }
@@ -238,7 +238,7 @@ public class GenericMemoryCacheTest
                 await Task.Delay(1);
                 factoryCallCount++;
                 return null;
-            }, TimeSpan.FromSeconds(10));
+            }, Expiration.Relative(TimeSpan.FromSeconds(10)));
             Assert.IsNull(value);
             Assert.AreEqual(0, factoryCallCount);
         }
@@ -258,14 +258,14 @@ public class GenericMemoryCacheTest
     {
         var cache = new GenericMemoryCache();
 
-        cache.Set("foo", null, TimeSpan.FromSeconds(10));
+        cache.Set("foo", null, Expiration.Relative(TimeSpan.FromSeconds(10)));
         {
             var hit = cache.TryGet("foo", out var value);
             Assert.IsTrue(hit);
             Assert.IsNull(value);
         }
 
-        cache.Set("foo", null, TimeSpan.FromSeconds(10));
+        cache.Set("foo", null, Expiration.Relative(TimeSpan.FromSeconds(10)));
         {
             var hit = cache.TryGet<SampleValue>("foo", out var value);
             Assert.IsTrue(hit);
@@ -306,7 +306,7 @@ public class GenericMemoryCacheTest
         // Arrange
         var cache = new GenericMemoryCache();
 
-        cache.Set("foo", new SampleValue(), TimeSpan.FromMilliseconds(10));
+        cache.Set("foo", new SampleValue(), Expiration.Relative(TimeSpan.FromMilliseconds(10)));
         {
             var hit = cache.TryGet<SampleValue>("foo", out var value);
             Assert.IsTrue(hit);
@@ -314,14 +314,14 @@ public class GenericMemoryCacheTest
         }
 
         var key = RandomNumberGenerator.GetBytes(16);
-        cache.Set(key, new SampleValue(), TimeSpan.FromMilliseconds(10));
+        cache.Set(key, new SampleValue(), Expiration.Relative(TimeSpan.FromMilliseconds(10)));
         {
             var hit = cache.TryGet<SampleValue>(key, out var value);
             Assert.IsTrue(hit);
             Assert.AreEqual("bar", value!.Name);
         }
 
-        cache.Set("zig", new SampleValue(), DateTimeOffset.Now + TimeSpan.FromMilliseconds(10));
+        cache.Set("zig", new SampleValue(), Expiration.Absolute(DateTimeOffset.Now + TimeSpan.FromMilliseconds(10)));
         {
             var hit = cache.TryGet<SampleValue>("zig", out var value);
             Assert.IsTrue(hit);
@@ -329,14 +329,14 @@ public class GenericMemoryCacheTest
         }
 
         var key2 = RandomNumberGenerator.GetBytes(16);
-        cache.Set(key2, new SampleValue(), DateTimeOffset.Now + TimeSpan.FromMilliseconds(10));
+        cache.Set(key2, new SampleValue(), Expiration.Absolute(DateTimeOffset.Now + TimeSpan.FromMilliseconds(10)));
         {
             var hit = cache.TryGet<SampleValue>(key2, out var value);
             Assert.IsTrue(hit);
             Assert.AreEqual("bar", value!.Name);
         }
 
-        var darth = cache.GetOrCreate("darth", () => "bar", TimeSpan.FromMilliseconds(10));
+        var darth = cache.GetOrCreate("darth", () => "bar", Expiration.Relative(TimeSpan.FromMilliseconds(10)));
         Assert.AreEqual("bar", darth);
 
         Thread.Sleep(200);
@@ -384,7 +384,7 @@ public class GenericMemoryCacheTest
         var cache = new GenericMemoryCache();
 
         {
-            cache.Set("foo", new SampleValue(), TimeSpan.FromMilliseconds(100));
+            cache.Set("foo", new SampleValue(), Expiration.Relative(TimeSpan.FromMilliseconds(100)));
 
             var exception = Assert.Throws<InvalidCastException>(() =>
             {
@@ -395,7 +395,7 @@ public class GenericMemoryCacheTest
 
         {
             var key = RandomNumberGenerator.GetBytes(16);
-            cache.Set(key, new SampleValue(), TimeSpan.FromMilliseconds(100));
+            cache.Set(key, new SampleValue(), Expiration.Relative(TimeSpan.FromMilliseconds(100)));
 
             var exception = Assert.Throws<InvalidCastException>(() =>
             {
@@ -416,7 +416,7 @@ public class GenericMemoryCacheTest
         var cache = new GenericMemoryCache();
 
         var key = RandomNumberGenerator.GetBytes(16);
-        cache.Set(key, new SomeConcreteClass(), TimeSpan.FromMilliseconds(100));
+        cache.Set(key, new SomeConcreteClass(), Expiration.Relative(TimeSpan.FromMilliseconds(100)));
 
         {
             var hit = cache.TryGet<ISomeInterface>(key, out var value);
@@ -442,7 +442,7 @@ public class GenericMemoryCacheTest
         var cache = new GenericMemoryCache();
 
         var key = RandomNumberGenerator.GetBytes(16);
-        cache.Set(key, new SomeConcreteClass(), TimeSpan.FromMilliseconds(100));
+        cache.Set(key, new SomeConcreteClass(), Expiration.Relative(TimeSpan.FromMilliseconds(100)));
 
         {
             var hit = cache.TryGet<SomeAbstractClass>(key, out var value);
@@ -468,7 +468,7 @@ public class GenericMemoryCacheTest
         var cache = new GenericMemoryCache();
 
         var key = RandomNumberGenerator.GetBytes(16);
-        cache.Set(key, "bar", TimeSpan.FromSeconds(10));
+        cache.Set(key, "bar", Expiration.Relative(TimeSpan.FromSeconds(10)));
         var hit = cache.TryGet(key, out var value);
         Assert.IsTrue(hit);
         Assert.AreEqual("bar", value);
@@ -494,7 +494,7 @@ public class GenericMemoryCacheTest
         var cache = new GenericMemoryCache();
 
         var key = RandomNumberGenerator.GetBytes(16);
-        cache.Set(key, "bar", TimeSpan.FromSeconds(10));
+        cache.Set(key, "bar", Expiration.Relative(TimeSpan.FromSeconds(10)));
         var hit = cache.TryGet(key, out var value);
         Assert.IsTrue(hit);
         Assert.AreEqual("bar", value);
@@ -568,12 +568,12 @@ public class GenericMemoryCacheTest
 
         {
             var cache = serviceProvider.GetRequiredService<IGenericMemoryCache<GenericMemoryCacheTest>>();
-            cache.Set("aaa", "aaa", TimeSpan.FromSeconds(10));
+            cache.Set("aaa", "aaa", Expiration.Relative(TimeSpan.FromSeconds(10)));
         }
 
         {
             var cache = serviceProvider.GetRequiredService<IGenericMemoryCache<SampleValue>>();
-            cache.Set("111", "111", TimeSpan.FromSeconds(10));
+            cache.Set("111", "111", Expiration.Relative(TimeSpan.FromSeconds(10)));
         }
 
         {
@@ -671,7 +671,7 @@ public class GenericMemoryCacheTest
 
         public void Store(string key, string value)
         {
-            cache.Set(key, value, TimeSpan.FromSeconds(10));
+            cache.Set(key, value, Expiration.Relative(TimeSpan.FromSeconds(10)));
         }
     }
 
@@ -685,7 +685,7 @@ public class GenericMemoryCacheTest
 
         public void Store(string key, string value)
         {
-            cache.Set(key, value, TimeSpan.FromSeconds(10));
+            cache.Set(key, value, Expiration.Relative(TimeSpan.FromSeconds(10)));
         }
     }
 


### PR DESCRIPTION
use MemoryCacheEntryOptions directly instead of redundant wrappers