### PR TITLE
Experimentos

### DIFF
--- a/src/apps/Odin.KeyChain/KeyChainDatabaseUtil.cs
+++ b/src/apps/Odin.KeyChain/KeyChainDatabaseUtil.cs
@@ -117,7 +117,7 @@ namespace Odin.KeyChain
         {
             using (var sqlcmd = db.CreateCommand())
             {
-                sqlcmd.CommandText = "SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM keyChain ORDER BY rowid ASC;";
+                sqlcmd.CommandText = "SELECT rowid,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM keyChain ORDER BY rowid ASC;";
 
                 using (var rdr = await conn.ExecuteReaderAsync(sqlcmd, System.Data.CommandBehavior.SingleRow))
                 {

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCRUD.cs
@@ -102,11 +102,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS appGrants;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS appGrants("
                    +"identityId BYTEA NOT NULL, "
@@ -114,9 +109,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"appId BYTEA NOT NULL, "
                    +"circleId BYTEA NOT NULL, "
                    +"data BYTEA  "
-                   + rowid
                    +", PRIMARY KEY (identityId,odinHashId,appId,circleId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCRUD.cs
@@ -372,7 +372,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected AppGrantsRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid odinHashId)
+        protected AppGrantsRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid odinHashId)
         {
             var result = new List<AppGrantsRecord>();
 #pragma warning disable CS0168
@@ -397,7 +397,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,appId,circleId,data FROM appGrants " +
-                                             "WHERE identityId = @identityId AND odinHashId = @odinHashId;";
+                                             "WHERE identityId = @identityId AND odinHashId = @odinHashId;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -418,7 +419,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<AppGrantsRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader0(rdr, identityId,odinHashId));
+                            result.Add(ReadRecordFromReader0(rdr,identityId,odinHashId));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -428,7 +429,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected AppGrantsRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid odinHashId,Guid appId,Guid circleId)
+        protected AppGrantsRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid odinHashId,Guid appId,Guid circleId)
         {
             var result = new List<AppGrantsRecord>();
 #pragma warning disable CS0168
@@ -456,7 +457,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId,data FROM appGrants " +
-                                             "WHERE identityId = @identityId AND odinHashId = @odinHashId AND appId = @appId AND circleId = @circleId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND odinHashId = @odinHashId AND appId = @appId AND circleId = @circleId LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -482,7 +484,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableAppGrantsCRUD", identityId.ToString()+odinHashId.ToString()+appId.ToString()+circleId.ToString(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,odinHashId,appId,circleId);
+                        var r = ReadRecordFromReader1(rdr,identityId,odinHashId,appId,circleId);
                         _cache.AddOrUpdate("TableAppGrantsCRUD", identityId.ToString()+odinHashId.ToString()+appId.ToString()+circleId.ToString(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCRUD.cs
@@ -102,6 +102,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS appGrants;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS appGrants("
                    +"identityId BYTEA NOT NULL, "
@@ -110,7 +113,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"circleId BYTEA NOT NULL, "
                    +"data BYTEA  "
                    +", PRIMARY KEY (identityId,odinHashId,appId,circleId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCRUD.cs
@@ -490,5 +490,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
+        protected virtual async Task<(List<AppGrantsRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,odinHashId,appId,circleId,data FROM appGrants " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<AppGrantsRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsOldCRUD.cs
@@ -1,0 +1,541 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class AppGrantsOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _odinHashId;
+        public Guid odinHashId
+        {
+           get {
+                   return _odinHashId;
+               }
+           set {
+                  _odinHashId = value;
+               }
+        }
+        private Guid _appId;
+        public Guid appId
+        {
+           get {
+                   return _appId;
+               }
+           set {
+                  _appId = value;
+               }
+        }
+        private Guid _circleId;
+        public Guid circleId
+        {
+           get {
+                   return _circleId;
+               }
+           set {
+                  _circleId = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+    } // End of class AppGrantsOldRecord
+
+    public abstract class TableAppGrantsOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableAppGrantsOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS AppGrantsOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS AppGrantsOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"odinHashId BYTEA NOT NULL, "
+                   +"appId BYTEA NOT NULL, "
+                   +"circleId BYTEA NOT NULL, "
+                   +"data BYTEA  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,odinHashId,appId,circleId)"
+                   +");"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(AppGrantsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.odinHashId.AssertGuidNotEmpty("Guid parameter odinHashId cannot be set to Empty GUID.");
+            item.appId.AssertGuidNotEmpty("Guid parameter appId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO AppGrantsOld (identityId,odinHashId,appId,circleId,data) " +
+                                             "VALUES (@identityId,@odinHashId,@appId,@circleId,@data)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@odinHashId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@appId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@circleId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.odinHashId.ToByteArray();
+                insertParam3.Value = item.appId.ToByteArray();
+                insertParam4.Value = item.circleId.ToByteArray();
+                insertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableAppGrantsOldCRUD", item.identityId.ToString()+item.odinHashId.ToString()+item.appId.ToString()+item.circleId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(AppGrantsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.odinHashId.AssertGuidNotEmpty("Guid parameter odinHashId cannot be set to Empty GUID.");
+            item.appId.AssertGuidNotEmpty("Guid parameter appId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO AppGrantsOld (identityId,odinHashId,appId,circleId,data) " +
+                                             "VALUES (@identityId,@odinHashId,@appId,@circleId,@data) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@odinHashId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@appId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@circleId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.odinHashId.ToByteArray();
+                insertParam3.Value = item.appId.ToByteArray();
+                insertParam4.Value = item.circleId.ToByteArray();
+                insertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableAppGrantsOldCRUD", item.identityId.ToString()+item.odinHashId.ToString()+item.appId.ToString()+item.circleId.ToString(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(AppGrantsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.odinHashId.AssertGuidNotEmpty("Guid parameter odinHashId cannot be set to Empty GUID.");
+            item.appId.AssertGuidNotEmpty("Guid parameter appId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO AppGrantsOld (identityId,odinHashId,appId,circleId,data) " +
+                                             "VALUES (@identityId,@odinHashId,@appId,@circleId,@data)"+
+                                             "ON CONFLICT (identityId,odinHashId,appId,circleId) DO UPDATE "+
+                                             "SET data = @data "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@odinHashId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@appId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@circleId";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam5);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.odinHashId.ToByteArray();
+                upsertParam3.Value = item.appId.ToByteArray();
+                upsertParam4.Value = item.circleId.ToByteArray();
+                upsertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.AddOrUpdate("TableAppGrantsOldCRUD", item.identityId.ToString()+item.odinHashId.ToString()+item.appId.ToString()+item.circleId.ToString(), item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(AppGrantsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.odinHashId.AssertGuidNotEmpty("Guid parameter odinHashId cannot be set to Empty GUID.");
+            item.appId.AssertGuidNotEmpty("Guid parameter appId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE AppGrantsOld " +
+                                             "SET data = @data "+
+                                             "WHERE (identityId = @identityId AND odinHashId = @odinHashId AND appId = @appId AND circleId = @circleId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@odinHashId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@appId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@circleId";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam5);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.odinHashId.ToByteArray();
+                updateParam3.Value = item.appId.ToByteArray();
+                updateParam4.Value = item.circleId.ToByteArray();
+                updateParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableAppGrantsOldCRUD", item.identityId.ToString()+item.odinHashId.ToString()+item.appId.ToString()+item.circleId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE appGrants RENAME TO AppGrantsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM AppGrantsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("odinHashId");
+            sl.Add("appId");
+            sl.Add("circleId");
+            sl.Add("data");
+            return sl;
+        }
+
+        // SELECT identityId,odinHashId,appId,circleId,data
+        public AppGrantsOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<AppGrantsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AppGrantsOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.odinHashId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.appId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.circleId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid odinHashId,Guid appId,Guid circleId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM AppGrantsOld " +
+                                             "WHERE identityId = @identityId AND odinHashId = @odinHashId AND appId = @appId AND circleId = @circleId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@odinHashId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@appId";
+                delete0Command.Parameters.Add(delete0Param3);
+                var delete0Param4 = delete0Command.CreateParameter();
+                delete0Param4.ParameterName = "@circleId";
+                delete0Command.Parameters.Add(delete0Param4);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = odinHashId.ToByteArray();
+                delete0Param3.Value = appId.ToByteArray();
+                delete0Param4.Value = circleId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableAppGrantsOldCRUD", identityId.ToString()+odinHashId.ToString()+appId.ToString()+circleId.ToString());
+                return count;
+            }
+        }
+
+        public AppGrantsOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid odinHashId)
+        {
+            var result = new List<AppGrantsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AppGrantsOldRecord();
+            item.identityId = identityId;
+            item.odinHashId = odinHashId;
+            item.appId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.circleId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<AppGrantsOldRecord>> GetByOdinHashIdAsync(Guid identityId,Guid odinHashId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT appId,circleId,data FROM AppGrantsOld " +
+                                             "WHERE identityId = @identityId AND odinHashId = @odinHashId;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@odinHashId";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = odinHashId.ToByteArray();
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableAppGrantsOldCRUD", identityId.ToString()+odinHashId.ToString(), null);
+                            return new List<AppGrantsOldRecord>();
+                        }
+                        var result = new List<AppGrantsOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr,identityId,odinHashId));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public AppGrantsOldRecord ReadRecordFromReader1(DbDataReader rdr)
+        {
+            var result = new List<AppGrantsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AppGrantsOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.odinHashId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.appId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.circleId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<AppGrantsOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT identityId,odinHashId,appId,circleId,data FROM AppGrantsOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<AppGrantsOldRecord>();
+                        }
+                        var result = new List<AppGrantsOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader1(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public AppGrantsOldRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,Guid odinHashId,Guid appId,Guid circleId)
+        {
+            var result = new List<AppGrantsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AppGrantsOldRecord();
+            item.identityId = identityId;
+            item.odinHashId = odinHashId;
+            item.appId = appId;
+            item.circleId = circleId;
+            item.dataNoLengthCheck = (rdr[0] == DBNull.Value) ? null : (byte[])(rdr[0]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<AppGrantsOldRecord> GetAsync(Guid identityId,Guid odinHashId,Guid appId,Guid circleId)
+        {
+            var (hit, cacheObject) = _cache.Get("TableAppGrantsOldCRUD", identityId.ToString()+odinHashId.ToString()+appId.ToString()+circleId.ToString());
+            if (hit)
+                return (AppGrantsOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT data FROM AppGrantsOld " +
+                                             "WHERE identityId = @identityId AND odinHashId = @odinHashId AND appId = @appId AND circleId = @circleId LIMIT 1;"+
+                                             ";";
+                var get2Param1 = get2Command.CreateParameter();
+                get2Param1.ParameterName = "@identityId";
+                get2Command.Parameters.Add(get2Param1);
+                var get2Param2 = get2Command.CreateParameter();
+                get2Param2.ParameterName = "@odinHashId";
+                get2Command.Parameters.Add(get2Param2);
+                var get2Param3 = get2Command.CreateParameter();
+                get2Param3.ParameterName = "@appId";
+                get2Command.Parameters.Add(get2Param3);
+                var get2Param4 = get2Command.CreateParameter();
+                get2Param4.ParameterName = "@circleId";
+                get2Command.Parameters.Add(get2Param4);
+
+                get2Param1.Value = identityId.ToByteArray();
+                get2Param2.Value = odinHashId.ToByteArray();
+                get2Param3.Value = appId.ToByteArray();
+                get2Param4.Value = circleId.ToByteArray();
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableAppGrantsOldCRUD", identityId.ToString()+odinHashId.ToString()+appId.ToString()+circleId.ToString(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader2(rdr,identityId,odinHashId,appId,circleId);
+                        _cache.AddOrUpdate("TableAppGrantsOldCRUD", identityId.ToString()+odinHashId.ToString()+appId.ToString()+circleId.ToString(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
@@ -160,6 +160,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             else
                    rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS AppNotifications("
                    +rowid
@@ -172,7 +173,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,notificationId)"
-                   +") ;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableAppNotificationsCRUD ON AppNotifications(identityId,created);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
@@ -173,7 +173,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,notificationId)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableAppNotificationsCRUD ON AppNotifications(identityId,created);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0AppNotifications ON AppNotifications(identityId,created);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -476,7 +476,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected AppNotificationsRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid notificationId)
+        protected AppNotificationsRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid notificationId)
         {
             var result = new List<AppNotificationsRecord>();
 #pragma warning disable CS0168
@@ -507,7 +507,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,unread,senderId,timestamp,data,created,modified FROM AppNotifications " +
-                                             "WHERE identityId = @identityId AND notificationId = @notificationId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND notificationId = @notificationId LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -525,7 +526,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableAppNotificationsCRUD", identityId.ToString()+notificationId.ToString(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,notificationId);
+                        var r = ReadRecordFromReader0(rdr,identityId,notificationId);
                         _cache.AddOrUpdate("TableAppNotificationsCRUD", identityId.ToString()+notificationId.ToString(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
@@ -156,10 +156,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
             else
-                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
-            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS AppNotifications("

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
@@ -595,5 +595,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using 
         } // PagingGet
 
+        protected virtual async Task<(List<AppNotificationsRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,notificationId,unread,senderId,timestamp,data,created,modified FROM AppNotifications " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<AppNotificationsRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class AppNotificationsRecord
     {
-        private Int64 _rowId;
-        public Int64 rowId
+        private long _rowId;
+        public long rowId
         {
            get {
                    return _rowId;
@@ -156,11 +156,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
+                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS AppNotifications("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"notificationId BYTEA NOT NULL UNIQUE, "
                    +"unread BIGINT NOT NULL, "
@@ -169,9 +171,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"data BYTEA , "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   + rowid
-                   +", PRIMARY KEY (identityId,notificationId)"
-                   +");"
+                   +", UNIQUE(identityId,notificationId)"
+                   +") ;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableAppNotificationsCRUD ON AppNotifications(identityId,created);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class AppNotificationsRecord
     {
-        private long _rowId;
-        public long rowId
+        private Int64 _rowId;
+        public Int64 rowId
         {
            get {
                    return _rowId;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsOldCRUD.cs
@@ -1,0 +1,664 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class AppNotificationsOldRecord
+    {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _notificationId;
+        public Guid notificationId
+        {
+           get {
+                   return _notificationId;
+               }
+           set {
+                  _notificationId = value;
+               }
+        }
+        private Int32 _unread;
+        public Int32 unread
+        {
+           get {
+                   return _unread;
+               }
+           set {
+                  _unread = value;
+               }
+        }
+        private string _senderId;
+        public string senderId
+        {
+           get {
+                   return _senderId;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _senderId = value;
+               }
+        }
+        internal string senderIdNoLengthCheck
+        {
+           get {
+                   return _senderId;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _senderId = value;
+               }
+        }
+        private UnixTimeUtc _timestamp;
+        public UnixTimeUtc timestamp
+        {
+           get {
+                   return _timestamp;
+               }
+           set {
+                  _timestamp = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65000) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class AppNotificationsOldRecord
+
+    public abstract class TableAppNotificationsOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableAppNotificationsOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS AppNotificationsOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS AppNotificationsOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"notificationId BYTEA NOT NULL UNIQUE, "
+                   +"unread BIGINT NOT NULL, "
+                   +"senderId TEXT , "
+                   +"timestamp BIGINT NOT NULL, "
+                   +"data BYTEA , "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,notificationId)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0AppNotificationsOld ON AppNotificationsOld(identityId,created);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(AppNotificationsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.notificationId.AssertGuidNotEmpty("Guid parameter notificationId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO AppNotificationsOld (identityId,notificationId,unread,senderId,timestamp,data,created,modified) " +
+                                             "VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@notificationId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@unread";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@senderId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@timestamp";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam8);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.notificationId.ToByteArray();
+                insertParam3.Value = item.unread;
+                insertParam4.Value = item.senderId ?? (object)DBNull.Value;
+                insertParam5.Value = item.timestamp.milliseconds;
+                insertParam6.Value = item.data ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam7.Value = now.milliseconds;
+                item.modified = null;
+                insertParam8.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.created = now;
+                    _cache.AddOrUpdate("TableAppNotificationsOldCRUD", item.identityId.ToString()+item.notificationId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(AppNotificationsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.notificationId.AssertGuidNotEmpty("Guid parameter notificationId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO AppNotificationsOld (identityId,notificationId,unread,senderId,timestamp,data,created,modified) " +
+                                             "VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@notificationId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@unread";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@senderId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@timestamp";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam8);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.notificationId.ToByteArray();
+                insertParam3.Value = item.unread;
+                insertParam4.Value = item.senderId ?? (object)DBNull.Value;
+                insertParam5.Value = item.timestamp.milliseconds;
+                insertParam6.Value = item.data ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam7.Value = now.milliseconds;
+                item.modified = null;
+                insertParam8.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    item.created = now;
+                   _cache.AddOrUpdate("TableAppNotificationsOldCRUD", item.identityId.ToString()+item.notificationId.ToString(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(AppNotificationsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.notificationId.AssertGuidNotEmpty("Guid parameter notificationId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO AppNotificationsOld (identityId,notificationId,unread,senderId,timestamp,data,created) " +
+                                             "VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,@created)"+
+                                             "ON CONFLICT (identityId,notificationId) DO UPDATE "+
+                                             "SET unread = @unread,senderId = @senderId,timestamp = @timestamp,data = @data,modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@notificationId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@unread";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@senderId";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@timestamp";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam7);
+                var upsertParam8 = upsertCommand.CreateParameter();
+                upsertParam8.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam8);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.notificationId.ToByteArray();
+                upsertParam3.Value = item.unread;
+                upsertParam4.Value = item.senderId ?? (object)DBNull.Value;
+                upsertParam5.Value = item.timestamp.milliseconds;
+                upsertParam6.Value = item.data ?? (object)DBNull.Value;
+                upsertParam7.Value = now.milliseconds;
+                upsertParam8.Value = now.milliseconds;
+                await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   _cache.AddOrUpdate("TableAppNotificationsOldCRUD", item.identityId.ToString()+item.notificationId.ToString(), item);
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(AppNotificationsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.notificationId.AssertGuidNotEmpty("Guid parameter notificationId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE AppNotificationsOld " +
+                                             "SET unread = @unread,senderId = @senderId,timestamp = @timestamp,data = @data,modified = @modified "+
+                                             "WHERE (identityId = @identityId AND notificationId = @notificationId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@notificationId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@unread";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@senderId";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@timestamp";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam7);
+                var updateParam8 = updateCommand.CreateParameter();
+                updateParam8.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam8);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.notificationId.ToByteArray();
+                updateParam3.Value = item.unread;
+                updateParam4.Value = item.senderId ?? (object)DBNull.Value;
+                updateParam5.Value = item.timestamp.milliseconds;
+                updateParam6.Value = item.data ?? (object)DBNull.Value;
+                updateParam7.Value = now.milliseconds;
+                updateParam8.Value = now.milliseconds;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.modified = now;
+                    _cache.AddOrUpdate("TableAppNotificationsOldCRUD", item.identityId.ToString()+item.notificationId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE AppNotifications RENAME TO AppNotificationsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM AppNotificationsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("rowId");
+            sl.Add("identityId");
+            sl.Add("notificationId");
+            sl.Add("unread");
+            sl.Add("senderId");
+            sl.Add("timestamp");
+            sl.Add("data");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        // SELECT rowId,identityId,notificationId,unread,senderId,timestamp,data,created,modified
+        public AppNotificationsOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<AppNotificationsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AppNotificationsOldRecord();
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.notificationId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.unread = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.senderIdNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (string)rdr[4];
+            item.timestamp = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
+            item.dataNoLengthCheck = (rdr[6] == DBNull.Value) ? null : (byte[])(rdr[6]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            item.created = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[7]);
+            item.modified = (rdr[8] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[8]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid notificationId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM AppNotificationsOld " +
+                                             "WHERE identityId = @identityId AND notificationId = @notificationId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@notificationId";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = notificationId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableAppNotificationsOldCRUD", identityId.ToString()+notificationId.ToString());
+                return count;
+            }
+        }
+
+        public AppNotificationsOldRecord ReadRecordFromReader0(DbDataReader rdr)
+        {
+            var result = new List<AppNotificationsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AppNotificationsOldRecord();
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.notificationId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.unread = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.senderIdNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (string)rdr[4];
+            item.timestamp = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
+            item.dataNoLengthCheck = (rdr[6] == DBNull.Value) ? null : (byte[])(rdr[6]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            item.created = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[7]);
+            item.modified = (rdr[8] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[8]);
+            return item;
+       }
+
+        public virtual async Task<List<AppNotificationsOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT rowId,identityId,notificationId,unread,senderId,timestamp,data,created,modified FROM AppNotificationsOld " +
+                                             "ORDER BY rowId ASC "+
+                                             ";";
+
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<AppNotificationsOldRecord>();
+                        }
+                        var result = new List<AppNotificationsOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public AppNotificationsOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid notificationId)
+        {
+            var result = new List<AppNotificationsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AppNotificationsOldRecord();
+            item.identityId = identityId;
+            item.notificationId = notificationId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.unread = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
+            item.senderIdNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (string)rdr[2];
+            item.timestamp = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            item.created = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
+            item.modified = (rdr[6] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[6]);
+            return item;
+       }
+
+        public virtual async Task<AppNotificationsOldRecord> GetAsync(Guid identityId,Guid notificationId)
+        {
+            var (hit, cacheObject) = _cache.Get("TableAppNotificationsOldCRUD", identityId.ToString()+notificationId.ToString());
+            if (hit)
+                return (AppNotificationsOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT rowId,unread,senderId,timestamp,data,created,modified FROM AppNotificationsOld " +
+                                             "WHERE identityId = @identityId AND notificationId = @notificationId LIMIT 1;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@notificationId";
+                get1Command.Parameters.Add(get1Param2);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = notificationId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableAppNotificationsOldCRUD", identityId.ToString()+notificationId.ToString(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr,identityId,notificationId);
+                        _cache.AddOrUpdate("TableAppNotificationsOldCRUD", identityId.ToString()+notificationId.ToString(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<(List<AppNotificationsOldRecord>, UnixTimeUtc? nextCursor, long nextRowId)> PagingByCreatedAsync(int count, Guid identityId, UnixTimeUtc? inCursor, long? rowid)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = new UnixTimeUtc(long.MaxValue);
+            if (rowid == null)
+                rowid = long.MaxValue;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging7Command = cn.CreateCommand();
+            {
+                getPaging7Command.CommandText = "SELECT rowId,identityId,notificationId,unread,senderId,timestamp,data,created,modified FROM AppNotificationsOld " +
+                                            "WHERE (identityId = @identityId) AND created <= @created AND rowId < @rowId ORDER BY created DESC , rowId DESC LIMIT @count;";
+                var getPaging7Param1 = getPaging7Command.CreateParameter();
+                getPaging7Param1.ParameterName = "@created";
+                getPaging7Command.Parameters.Add(getPaging7Param1);
+                var getPaging7Param2 = getPaging7Command.CreateParameter();
+                getPaging7Param2.ParameterName = "@rowId";
+                getPaging7Command.Parameters.Add(getPaging7Param2);
+                var getPaging7Param3 = getPaging7Command.CreateParameter();
+                getPaging7Param3.ParameterName = "@count";
+                getPaging7Command.Parameters.Add(getPaging7Param3);
+                var getPaging7Param4 = getPaging7Command.CreateParameter();
+                getPaging7Param4.ParameterName = "@identityId";
+                getPaging7Command.Parameters.Add(getPaging7Param4);
+
+                getPaging7Param1.Value = inCursor?.milliseconds;
+                getPaging7Param2.Value = rowid;
+                getPaging7Param3.Value = count+1;
+                getPaging7Param4.Value = identityId.ToByteArray();
+
+                {
+                    await using (var rdr = await getPaging7Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<AppNotificationsOldRecord>();
+                        UnixTimeUtc? nextCursor;
+                        long nextRowId;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].created;
+                                nextRowId = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                            nextRowId = 0;
+                        }
+                        return (result, nextCursor, nextRowId);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
@@ -106,20 +106,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS circle;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS circle("
                    +"identityId BYTEA NOT NULL, "
                    +"circleName TEXT NOT NULL, "
                    +"circleId BYTEA NOT NULL UNIQUE, "
                    +"data BYTEA  "
-                   + rowid
                    +", PRIMARY KEY (identityId,circleId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -390,26 +384,26 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 inCursor = Guid.Empty;
 
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var getPaging3Command = cn.CreateCommand();
+            await using var getPaging2Command = cn.CreateCommand();
             {
-                getPaging3Command.CommandText = "SELECT identityId,circleName,circleId,data FROM circle " +
+                getPaging2Command.CommandText = "SELECT identityId,circleName,circleId,data FROM circle " +
                                             "WHERE (identityId = @identityId) AND circleId > @circleId  ORDER BY circleId ASC  LIMIT @count;";
-                var getPaging3Param1 = getPaging3Command.CreateParameter();
-                getPaging3Param1.ParameterName = "@circleId";
-                getPaging3Command.Parameters.Add(getPaging3Param1);
-                var getPaging3Param2 = getPaging3Command.CreateParameter();
-                getPaging3Param2.ParameterName = "@count";
-                getPaging3Command.Parameters.Add(getPaging3Param2);
-                var getPaging3Param3 = getPaging3Command.CreateParameter();
-                getPaging3Param3.ParameterName = "@identityId";
-                getPaging3Command.Parameters.Add(getPaging3Param3);
+                var getPaging2Param1 = getPaging2Command.CreateParameter();
+                getPaging2Param1.ParameterName = "@circleId";
+                getPaging2Command.Parameters.Add(getPaging2Param1);
+                var getPaging2Param2 = getPaging2Command.CreateParameter();
+                getPaging2Param2.ParameterName = "@count";
+                getPaging2Command.Parameters.Add(getPaging2Param2);
+                var getPaging2Param3 = getPaging2Command.CreateParameter();
+                getPaging2Param3.ParameterName = "@identityId";
+                getPaging2Command.Parameters.Add(getPaging2Param3);
 
-                getPaging3Param1.Value = inCursor?.ToByteArray();
-                getPaging3Param2.Value = count+1;
-                getPaging3Param3.Value = identityId.ToByteArray();
+                getPaging2Param1.Value = inCursor?.ToByteArray();
+                getPaging2Param2.Value = count+1;
+                getPaging2Param3.Value = identityId.ToByteArray();
 
                 {
-                    await using (var rdr = await getPaging3Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    await using (var rdr = await getPaging2Command.ExecuteReaderAsync(CommandBehavior.Default))
                     {
                         var result = new List<CircleRecord>();
                         Guid? nextCursor;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
@@ -341,7 +341,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected CircleRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid circleId)
+        protected CircleRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid circleId)
         {
             var result = new List<CircleRecord>();
 #pragma warning disable CS0168
@@ -368,7 +368,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,circleName,data FROM circle " +
-                                             "WHERE identityId = @identityId AND circleId = @circleId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND circleId = @circleId LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -386,7 +387,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableCircleCRUD", identityId.ToString()+circleId.ToString(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,circleId);
+                        var r = ReadRecordFromReader0(rdr,identityId,circleId);
                         _cache.AddOrUpdate("TableCircleCRUD", identityId.ToString()+circleId.ToString(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
@@ -106,6 +106,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS circle;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS circle("
                    +"identityId BYTEA NOT NULL, "
@@ -113,7 +116,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"circleId BYTEA NOT NULL UNIQUE, "
                    +"data BYTEA  "
                    +", PRIMARY KEY (identityId,circleId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
@@ -27,6 +27,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
                   _identityId = value;
                }
         }
+        private Guid _circleId;
+        public Guid circleId
+        {
+           get {
+                   return _circleId;
+               }
+           set {
+                  _circleId = value;
+               }
+        }
         private string _circleName;
         public string circleName
         {
@@ -49,16 +59,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                     if (value == null) throw new Exception("Cannot be null");
                     if (value?.Length < 2) throw new Exception("Too short");
                   _circleName = value;
-               }
-        }
-        private Guid _circleId;
-        public Guid circleId
-        {
-           get {
-                   return _circleId;
-               }
-           set {
-                  _circleId = value;
                }
         }
         private byte[] _data;
@@ -112,8 +112,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS circle("
                    +"identityId BYTEA NOT NULL, "
-                   +"circleName TEXT NOT NULL, "
                    +"circleId BYTEA NOT NULL UNIQUE, "
+                   +"circleName TEXT NOT NULL, "
                    +"data BYTEA  "
                    +", PRIMARY KEY (identityId,circleId)"
                    +$"){wori};"
@@ -128,23 +128,23 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                insertCommand.CommandText = "INSERT INTO circle (identityId,circleName,circleId,data) " +
-                                             "VALUES (@identityId,@circleName,@circleId,@data)";
+                insertCommand.CommandText = "INSERT INTO circle (identityId,circleId,circleName,data) " +
+                                             "VALUES (@identityId,@circleId,@circleName,@data)";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
                 insertCommand.Parameters.Add(insertParam1);
                 var insertParam2 = insertCommand.CreateParameter();
-                insertParam2.ParameterName = "@circleName";
+                insertParam2.ParameterName = "@circleId";
                 insertCommand.Parameters.Add(insertParam2);
                 var insertParam3 = insertCommand.CreateParameter();
-                insertParam3.ParameterName = "@circleId";
+                insertParam3.ParameterName = "@circleName";
                 insertCommand.Parameters.Add(insertParam3);
                 var insertParam4 = insertCommand.CreateParameter();
                 insertParam4.ParameterName = "@data";
                 insertCommand.Parameters.Add(insertParam4);
                 insertParam1.Value = item.identityId.ToByteArray();
-                insertParam2.Value = item.circleName;
-                insertParam3.Value = item.circleId.ToByteArray();
+                insertParam2.Value = item.circleId.ToByteArray();
+                insertParam3.Value = item.circleName;
                 insertParam4.Value = item.data ?? (object)DBNull.Value;
                 var count = await insertCommand.ExecuteNonQueryAsync();
                 if (count > 0)
@@ -162,24 +162,24 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                insertCommand.CommandText = "INSERT INTO circle (identityId,circleName,circleId,data) " +
-                                             "VALUES (@identityId,@circleName,@circleId,@data) " +
+                insertCommand.CommandText = "INSERT INTO circle (identityId,circleId,circleName,data) " +
+                                             "VALUES (@identityId,@circleId,@circleName,@data) " +
                                              "ON CONFLICT DO NOTHING";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
                 insertCommand.Parameters.Add(insertParam1);
                 var insertParam2 = insertCommand.CreateParameter();
-                insertParam2.ParameterName = "@circleName";
+                insertParam2.ParameterName = "@circleId";
                 insertCommand.Parameters.Add(insertParam2);
                 var insertParam3 = insertCommand.CreateParameter();
-                insertParam3.ParameterName = "@circleId";
+                insertParam3.ParameterName = "@circleName";
                 insertCommand.Parameters.Add(insertParam3);
                 var insertParam4 = insertCommand.CreateParameter();
                 insertParam4.ParameterName = "@data";
                 insertCommand.Parameters.Add(insertParam4);
                 insertParam1.Value = item.identityId.ToByteArray();
-                insertParam2.Value = item.circleName;
-                insertParam3.Value = item.circleId.ToByteArray();
+                insertParam2.Value = item.circleId.ToByteArray();
+                insertParam3.Value = item.circleName;
                 insertParam4.Value = item.data ?? (object)DBNull.Value;
                 var count = await insertCommand.ExecuteNonQueryAsync();
                 if (count > 0)
@@ -197,8 +197,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var upsertCommand = cn.CreateCommand();
             {
-                upsertCommand.CommandText = "INSERT INTO circle (identityId,circleName,circleId,data) " +
-                                             "VALUES (@identityId,@circleName,@circleId,@data)"+
+                upsertCommand.CommandText = "INSERT INTO circle (identityId,circleId,circleName,data) " +
+                                             "VALUES (@identityId,@circleId,@circleName,@data)"+
                                              "ON CONFLICT (identityId,circleId) DO UPDATE "+
                                              "SET circleName = @circleName,data = @data "+
                                              ";";
@@ -206,17 +206,17 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 upsertParam1.ParameterName = "@identityId";
                 upsertCommand.Parameters.Add(upsertParam1);
                 var upsertParam2 = upsertCommand.CreateParameter();
-                upsertParam2.ParameterName = "@circleName";
+                upsertParam2.ParameterName = "@circleId";
                 upsertCommand.Parameters.Add(upsertParam2);
                 var upsertParam3 = upsertCommand.CreateParameter();
-                upsertParam3.ParameterName = "@circleId";
+                upsertParam3.ParameterName = "@circleName";
                 upsertCommand.Parameters.Add(upsertParam3);
                 var upsertParam4 = upsertCommand.CreateParameter();
                 upsertParam4.ParameterName = "@data";
                 upsertCommand.Parameters.Add(upsertParam4);
                 upsertParam1.Value = item.identityId.ToByteArray();
-                upsertParam2.Value = item.circleName;
-                upsertParam3.Value = item.circleId.ToByteArray();
+                upsertParam2.Value = item.circleId.ToByteArray();
+                upsertParam3.Value = item.circleName;
                 upsertParam4.Value = item.data ?? (object)DBNull.Value;
                 var count = await upsertCommand.ExecuteNonQueryAsync();
                 if (count > 0)
@@ -238,17 +238,17 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 updateParam1.ParameterName = "@identityId";
                 updateCommand.Parameters.Add(updateParam1);
                 var updateParam2 = updateCommand.CreateParameter();
-                updateParam2.ParameterName = "@circleName";
+                updateParam2.ParameterName = "@circleId";
                 updateCommand.Parameters.Add(updateParam2);
                 var updateParam3 = updateCommand.CreateParameter();
-                updateParam3.ParameterName = "@circleId";
+                updateParam3.ParameterName = "@circleName";
                 updateCommand.Parameters.Add(updateParam3);
                 var updateParam4 = updateCommand.CreateParameter();
                 updateParam4.ParameterName = "@data";
                 updateCommand.Parameters.Add(updateParam4);
                 updateParam1.Value = item.identityId.ToByteArray();
-                updateParam2.Value = item.circleName;
-                updateParam3.Value = item.circleId.ToByteArray();
+                updateParam2.Value = item.circleId.ToByteArray();
+                updateParam3.Value = item.circleName;
                 updateParam4.Value = item.data ?? (object)DBNull.Value;
                 var count = await updateCommand.ExecuteNonQueryAsync();
                 if (count > 0)
@@ -278,13 +278,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
         {
             var sl = new List<string>();
             sl.Add("identityId");
-            sl.Add("circleName");
             sl.Add("circleId");
+            sl.Add("circleName");
             sl.Add("data");
             return sl;
         }
 
-        // SELECT identityId,circleName,circleId,data
+        // SELECT identityId,circleId,circleName,data
         protected CircleRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<CircleRecord>();
@@ -294,8 +294,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var guid = new byte[16];
             var item = new CircleRecord();
             item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.circleNameNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
-            item.circleId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.circleId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.circleNameNoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[2];
             item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
@@ -387,26 +387,26 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 inCursor = Guid.Empty;
 
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var getPaging2Command = cn.CreateCommand();
+            await using var getPaging1Command = cn.CreateCommand();
             {
-                getPaging2Command.CommandText = "SELECT identityId,circleName,circleId,data FROM circle " +
+                getPaging1Command.CommandText = "SELECT identityId,circleId,circleName,data FROM circle " +
                                             "WHERE (identityId = @identityId) AND circleId > @circleId  ORDER BY circleId ASC  LIMIT @count;";
-                var getPaging2Param1 = getPaging2Command.CreateParameter();
-                getPaging2Param1.ParameterName = "@circleId";
-                getPaging2Command.Parameters.Add(getPaging2Param1);
-                var getPaging2Param2 = getPaging2Command.CreateParameter();
-                getPaging2Param2.ParameterName = "@count";
-                getPaging2Command.Parameters.Add(getPaging2Param2);
-                var getPaging2Param3 = getPaging2Command.CreateParameter();
-                getPaging2Param3.ParameterName = "@identityId";
-                getPaging2Command.Parameters.Add(getPaging2Param3);
+                var getPaging1Param1 = getPaging1Command.CreateParameter();
+                getPaging1Param1.ParameterName = "@circleId";
+                getPaging1Command.Parameters.Add(getPaging1Param1);
+                var getPaging1Param2 = getPaging1Command.CreateParameter();
+                getPaging1Param2.ParameterName = "@count";
+                getPaging1Command.Parameters.Add(getPaging1Param2);
+                var getPaging1Param3 = getPaging1Command.CreateParameter();
+                getPaging1Param3.ParameterName = "@identityId";
+                getPaging1Command.Parameters.Add(getPaging1Param3);
 
-                getPaging2Param1.Value = inCursor?.ToByteArray();
-                getPaging2Param2.Value = count+1;
-                getPaging2Param3.Value = identityId.ToByteArray();
+                getPaging1Param1.Value = inCursor?.ToByteArray();
+                getPaging1Param2.Value = count+1;
+                getPaging1Param3.Value = identityId.ToByteArray();
 
                 {
-                    await using (var rdr = await getPaging2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    await using (var rdr = await getPaging1Command.ExecuteReaderAsync(CommandBehavior.Default))
                     {
                         var result = new List<CircleRecord>();
                         Guid? nextCursor;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
@@ -17,6 +17,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class CircleRecord
     {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private Guid _identityId;
         public Guid identityId
         {
@@ -106,16 +116,20 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS circle;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
-            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
-                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS circle("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"circleId BYTEA NOT NULL UNIQUE, "
                    +"circleName TEXT NOT NULL, "
                    +"data BYTEA  "
-                   +", PRIMARY KEY (identityId,circleId)"
+                   +", UNIQUE(identityId,circleId)"
                    +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
@@ -277,6 +291,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("identityId");
             sl.Add("circleId");
             sl.Add("circleName");
@@ -284,7 +299,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return sl;
         }
 
-        // SELECT identityId,circleId,circleName,data
+        // SELECT rowId,identityId,circleId,circleName,data
         protected CircleRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<CircleRecord>();
@@ -293,10 +308,11 @@ namespace Odin.Core.Storage.Database.Identity.Table
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new CircleRecord();
-            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.circleId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
-            item.circleNameNoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[2];
-            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.circleId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.circleNameNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[3];
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -335,8 +351,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new CircleRecord();
             item.identityId = identityId;
             item.circleId = circleId;
-            item.circleNameNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[0];
-            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.circleNameNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -350,7 +367,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT circleName,data FROM circle " +
+                get0Command.CommandText = "SELECT rowId,circleName,data FROM circle " +
                                              "WHERE identityId = @identityId AND circleId = @circleId LIMIT 1;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
@@ -387,26 +404,26 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 inCursor = Guid.Empty;
 
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var getPaging1Command = cn.CreateCommand();
+            await using var getPaging2Command = cn.CreateCommand();
             {
-                getPaging1Command.CommandText = "SELECT identityId,circleId,circleName,data FROM circle " +
+                getPaging2Command.CommandText = "SELECT rowId,identityId,circleId,circleName,data FROM circle " +
                                             "WHERE (identityId = @identityId) AND circleId > @circleId  ORDER BY circleId ASC  LIMIT @count;";
-                var getPaging1Param1 = getPaging1Command.CreateParameter();
-                getPaging1Param1.ParameterName = "@circleId";
-                getPaging1Command.Parameters.Add(getPaging1Param1);
-                var getPaging1Param2 = getPaging1Command.CreateParameter();
-                getPaging1Param2.ParameterName = "@count";
-                getPaging1Command.Parameters.Add(getPaging1Param2);
-                var getPaging1Param3 = getPaging1Command.CreateParameter();
-                getPaging1Param3.ParameterName = "@identityId";
-                getPaging1Command.Parameters.Add(getPaging1Param3);
+                var getPaging2Param1 = getPaging2Command.CreateParameter();
+                getPaging2Param1.ParameterName = "@circleId";
+                getPaging2Command.Parameters.Add(getPaging2Param1);
+                var getPaging2Param2 = getPaging2Command.CreateParameter();
+                getPaging2Param2.ParameterName = "@count";
+                getPaging2Command.Parameters.Add(getPaging2Param2);
+                var getPaging2Param3 = getPaging2Command.CreateParameter();
+                getPaging2Param3.ParameterName = "@identityId";
+                getPaging2Command.Parameters.Add(getPaging2Param3);
 
-                getPaging1Param1.Value = inCursor?.ToByteArray();
-                getPaging1Param2.Value = count+1;
-                getPaging1Param3.Value = identityId.ToByteArray();
+                getPaging2Param1.Value = inCursor?.ToByteArray();
+                getPaging2Param2.Value = count+1;
+                getPaging2Param3.Value = identityId.ToByteArray();
 
                 {
-                    await using (var rdr = await getPaging1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    await using (var rdr = await getPaging2Command.ExecuteReaderAsync(CommandBehavior.Default))
                     {
                         var result = new List<CircleRecord>();
                         Guid? nextCursor;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCRUD.cs
@@ -447,5 +447,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using 
         } // PagingGet
 
+        protected virtual async Task<(List<CircleRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,circleId,circleName,data FROM circle " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<CircleRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCRUD.cs
@@ -92,6 +92,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS circleMember;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS circleMember("
                    +"identityId BYTEA NOT NULL, "
@@ -99,7 +102,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"memberId BYTEA NOT NULL, "
                    +"data BYTEA  "
                    +", PRIMARY KEY (identityId,circleId,memberId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCRUD.cs
@@ -335,7 +335,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected CircleMemberRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid circleId)
+        protected CircleMemberRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid circleId)
         {
             var result = new List<CircleMemberRecord>();
 #pragma warning disable CS0168
@@ -359,7 +359,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,memberId,data FROM circleMember " +
-                                             "WHERE identityId = @identityId AND circleId = @circleId;";
+                                             "WHERE identityId = @identityId AND circleId = @circleId;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -380,7 +381,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<CircleMemberRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader0(rdr, identityId,circleId));
+                            result.Add(ReadRecordFromReader0(rdr,identityId,circleId));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -390,7 +391,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected CircleMemberRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid memberId)
+        protected CircleMemberRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid memberId)
         {
             var result = new List<CircleMemberRecord>();
 #pragma warning disable CS0168
@@ -414,7 +415,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId,circleId,data FROM circleMember " +
-                                             "WHERE identityId = @identityId AND memberId = @memberId;";
+                                             "WHERE identityId = @identityId AND memberId = @memberId;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -435,7 +437,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<CircleMemberRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader1(rdr, identityId,memberId));
+                            result.Add(ReadRecordFromReader1(rdr,identityId,memberId));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -445,7 +447,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected CircleMemberRecord ReadRecordFromReader2(DbDataReader rdr, Guid identityId,Guid circleId,Guid memberId)
+        protected CircleMemberRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,Guid circleId,Guid memberId)
         {
             var result = new List<CircleMemberRecord>();
 #pragma warning disable CS0168
@@ -472,7 +474,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get2Command = cn.CreateCommand();
             {
                 get2Command.CommandText = "SELECT rowId,data FROM circleMember " +
-                                             "WHERE identityId = @identityId AND circleId = @circleId AND memberId = @memberId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND circleId = @circleId AND memberId = @memberId LIMIT 1;"+
+                                             ";";
                 var get2Param1 = get2Command.CreateParameter();
                 get2Param1.ParameterName = "@identityId";
                 get2Command.Parameters.Add(get2Param1);
@@ -494,7 +497,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableCircleMemberCRUD", identityId.ToString()+circleId.ToString()+memberId.ToString(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader2(rdr, identityId,circleId,memberId);
+                        var r = ReadRecordFromReader2(rdr,identityId,circleId,memberId);
                         _cache.AddOrUpdate("TableCircleMemberCRUD", identityId.ToString()+circleId.ToString()+memberId.ToString(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCRUD.cs
@@ -17,6 +17,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class CircleMemberRecord
     {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private Guid _identityId;
         public Guid identityId
         {
@@ -92,16 +102,20 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS circleMember;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
-            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
-                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS circleMember("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"circleId BYTEA NOT NULL, "
                    +"memberId BYTEA NOT NULL, "
                    +"data BYTEA  "
-                   +", PRIMARY KEY (identityId,circleId,memberId)"
+                   +", UNIQUE(identityId,circleId,memberId)"
                    +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
@@ -267,6 +281,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("identityId");
             sl.Add("circleId");
             sl.Add("memberId");
@@ -274,7 +289,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return sl;
         }
 
-        // SELECT identityId,circleId,memberId,data
+        // SELECT rowId,identityId,circleId,memberId,data
         protected CircleMemberRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<CircleMemberRecord>();
@@ -283,10 +298,11 @@ namespace Odin.Core.Storage.Database.Identity.Table
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new CircleMemberRecord();
-            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.circleId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
-            item.memberId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
-            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.circleId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.memberId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -330,7 +346,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.identityId = identityId;
             item.circleId = circleId;
             item.memberId = memberId;
-            item.dataNoLengthCheck = (rdr[0] == DBNull.Value) ? null : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -344,7 +361,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT data FROM circleMember " +
+                get0Command.CommandText = "SELECT rowId,data FROM circleMember " +
                                              "WHERE identityId = @identityId AND circleId = @circleId AND memberId = @memberId LIMIT 1;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
@@ -385,8 +402,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new CircleMemberRecord();
             item.identityId = identityId;
             item.circleId = circleId;
-            item.memberId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.memberId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -397,7 +415,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get1Command = cn.CreateCommand();
             {
-                get1Command.CommandText = "SELECT memberId,data FROM circleMember " +
+                get1Command.CommandText = "SELECT rowId,memberId,data FROM circleMember " +
                                              "WHERE identityId = @identityId AND circleId = @circleId;";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
@@ -439,8 +457,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new CircleMemberRecord();
             item.identityId = identityId;
             item.memberId = memberId;
-            item.circleId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.circleId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -451,7 +470,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get2Command = cn.CreateCommand();
             {
-                get2Command.CommandText = "SELECT circleId,data FROM circleMember " +
+                get2Command.CommandText = "SELECT rowId,circleId,data FROM circleMember " +
                                              "WHERE identityId = @identityId AND memberId = @memberId;";
                 var get2Param1 = get2Command.CreateParameter();
                 get2Param1.ParameterName = "@identityId";

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCRUD.cs
@@ -92,20 +92,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS circleMember;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS circleMember("
                    +"identityId BYTEA NOT NULL, "
                    +"circleId BYTEA NOT NULL, "
                    +"memberId BYTEA NOT NULL, "
                    +"data BYTEA  "
-                   + rowid
                    +", PRIMARY KEY (identityId,circleId,memberId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberOldCRUD.cs
@@ -1,0 +1,552 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class CircleMemberOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _circleId;
+        public Guid circleId
+        {
+           get {
+                   return _circleId;
+               }
+           set {
+                  _circleId = value;
+               }
+        }
+        private Guid _memberId;
+        public Guid memberId
+        {
+           get {
+                   return _memberId;
+               }
+           set {
+                  _memberId = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+    } // End of class CircleMemberOldRecord
+
+    public abstract class TableCircleMemberOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableCircleMemberOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS CircleMemberOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS CircleMemberOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"circleId BYTEA NOT NULL, "
+                   +"memberId BYTEA NOT NULL, "
+                   +"data BYTEA  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,circleId,memberId)"
+                   +");"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(CircleMemberOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            item.memberId.AssertGuidNotEmpty("Guid parameter memberId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO CircleMemberOld (identityId,circleId,memberId,data) " +
+                                             "VALUES (@identityId,@circleId,@memberId,@data)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@circleId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@memberId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.circleId.ToByteArray();
+                insertParam3.Value = item.memberId.ToByteArray();
+                insertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableCircleMemberOldCRUD", item.identityId.ToString()+item.circleId.ToString()+item.memberId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(CircleMemberOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            item.memberId.AssertGuidNotEmpty("Guid parameter memberId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO CircleMemberOld (identityId,circleId,memberId,data) " +
+                                             "VALUES (@identityId,@circleId,@memberId,@data) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@circleId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@memberId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.circleId.ToByteArray();
+                insertParam3.Value = item.memberId.ToByteArray();
+                insertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableCircleMemberOldCRUD", item.identityId.ToString()+item.circleId.ToString()+item.memberId.ToString(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(CircleMemberOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            item.memberId.AssertGuidNotEmpty("Guid parameter memberId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO CircleMemberOld (identityId,circleId,memberId,data) " +
+                                             "VALUES (@identityId,@circleId,@memberId,@data)"+
+                                             "ON CONFLICT (identityId,circleId,memberId) DO UPDATE "+
+                                             "SET data = @data "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@circleId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@memberId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam4);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.circleId.ToByteArray();
+                upsertParam3.Value = item.memberId.ToByteArray();
+                upsertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.AddOrUpdate("TableCircleMemberOldCRUD", item.identityId.ToString()+item.circleId.ToString()+item.memberId.ToString(), item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(CircleMemberOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            item.memberId.AssertGuidNotEmpty("Guid parameter memberId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE CircleMemberOld " +
+                                             "SET data = @data "+
+                                             "WHERE (identityId = @identityId AND circleId = @circleId AND memberId = @memberId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@circleId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@memberId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam4);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.circleId.ToByteArray();
+                updateParam3.Value = item.memberId.ToByteArray();
+                updateParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableCircleMemberOldCRUD", item.identityId.ToString()+item.circleId.ToString()+item.memberId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE circleMember RENAME TO CircleMemberOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM CircleMemberOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("circleId");
+            sl.Add("memberId");
+            sl.Add("data");
+            return sl;
+        }
+
+        // SELECT identityId,circleId,memberId,data
+        public CircleMemberOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<CircleMemberOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new CircleMemberOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.circleId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.memberId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid circleId,Guid memberId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM CircleMemberOld " +
+                                             "WHERE identityId = @identityId AND circleId = @circleId AND memberId = @memberId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@circleId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@memberId";
+                delete0Command.Parameters.Add(delete0Param3);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = circleId.ToByteArray();
+                delete0Param3.Value = memberId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableCircleMemberOldCRUD", identityId.ToString()+circleId.ToString()+memberId.ToString());
+                return count;
+            }
+        }
+
+        public CircleMemberOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid circleId)
+        {
+            var result = new List<CircleMemberOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new CircleMemberOldRecord();
+            item.identityId = identityId;
+            item.circleId = circleId;
+            item.memberId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<CircleMemberOldRecord>> GetCircleMembersAsync(Guid identityId,Guid circleId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT memberId,data FROM CircleMemberOld " +
+                                             "WHERE identityId = @identityId AND circleId = @circleId;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@circleId";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = circleId.ToByteArray();
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableCircleMemberOldCRUD", identityId.ToString()+circleId.ToString(), null);
+                            return new List<CircleMemberOldRecord>();
+                        }
+                        var result = new List<CircleMemberOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr,identityId,circleId));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public CircleMemberOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid memberId)
+        {
+            var result = new List<CircleMemberOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new CircleMemberOldRecord();
+            item.identityId = identityId;
+            item.memberId = memberId;
+            item.circleId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<CircleMemberOldRecord>> GetMemberCirclesAndDataAsync(Guid identityId,Guid memberId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT circleId,data FROM CircleMemberOld " +
+                                             "WHERE identityId = @identityId AND memberId = @memberId;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@memberId";
+                get1Command.Parameters.Add(get1Param2);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = memberId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableCircleMemberOldCRUD", identityId.ToString()+memberId.ToString(), null);
+                            return new List<CircleMemberOldRecord>();
+                        }
+                        var result = new List<CircleMemberOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader1(rdr,identityId,memberId));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public CircleMemberOldRecord ReadRecordFromReader2(DbDataReader rdr)
+        {
+            var result = new List<CircleMemberOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new CircleMemberOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.circleId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.memberId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<CircleMemberOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT identityId,circleId,memberId,data FROM CircleMemberOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<CircleMemberOldRecord>();
+                        }
+                        var result = new List<CircleMemberOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader2(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public CircleMemberOldRecord ReadRecordFromReader3(DbDataReader rdr,Guid identityId,Guid circleId,Guid memberId)
+        {
+            var result = new List<CircleMemberOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new CircleMemberOldRecord();
+            item.identityId = identityId;
+            item.circleId = circleId;
+            item.memberId = memberId;
+            item.dataNoLengthCheck = (rdr[0] == DBNull.Value) ? null : (byte[])(rdr[0]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<CircleMemberOldRecord> GetAsync(Guid identityId,Guid circleId,Guid memberId)
+        {
+            var (hit, cacheObject) = _cache.Get("TableCircleMemberOldCRUD", identityId.ToString()+circleId.ToString()+memberId.ToString());
+            if (hit)
+                return (CircleMemberOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get3Command = cn.CreateCommand();
+            {
+                get3Command.CommandText = "SELECT data FROM CircleMemberOld " +
+                                             "WHERE identityId = @identityId AND circleId = @circleId AND memberId = @memberId LIMIT 1;"+
+                                             ";";
+                var get3Param1 = get3Command.CreateParameter();
+                get3Param1.ParameterName = "@identityId";
+                get3Command.Parameters.Add(get3Param1);
+                var get3Param2 = get3Command.CreateParameter();
+                get3Param2.ParameterName = "@circleId";
+                get3Command.Parameters.Add(get3Param2);
+                var get3Param3 = get3Command.CreateParameter();
+                get3Param3.ParameterName = "@memberId";
+                get3Command.Parameters.Add(get3Param3);
+
+                get3Param1.Value = identityId.ToByteArray();
+                get3Param2.Value = circleId.ToByteArray();
+                get3Param3.Value = memberId.ToByteArray();
+                {
+                    using (var rdr = await get3Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableCircleMemberOldCRUD", identityId.ToString()+circleId.ToString()+memberId.ToString(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader3(rdr,identityId,circleId,memberId);
+                        _cache.AddOrUpdate("TableCircleMemberOldCRUD", identityId.ToString()+circleId.ToString()+memberId.ToString(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleOldCRUD.cs
@@ -1,0 +1,497 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class CircleOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private string _circleName;
+        public string circleName
+        {
+           get {
+                   return _circleName;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 2) throw new Exception("Too short");
+                    if (value?.Length > 80) throw new Exception("Too long");
+                  _circleName = value;
+               }
+        }
+        internal string circleNameNoLengthCheck
+        {
+           get {
+                   return _circleName;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 2) throw new Exception("Too short");
+                  _circleName = value;
+               }
+        }
+        private Guid _circleId;
+        public Guid circleId
+        {
+           get {
+                   return _circleId;
+               }
+           set {
+                  _circleId = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65000) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+    } // End of class CircleOldRecord
+
+    public abstract class TableCircleOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableCircleOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS CircleOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS CircleOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"circleName TEXT NOT NULL, "
+                   +"circleId BYTEA NOT NULL UNIQUE, "
+                   +"data BYTEA  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,circleId)"
+                   +");"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(CircleOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO CircleOld (identityId,circleName,circleId,data) " +
+                                             "VALUES (@identityId,@circleName,@circleId,@data)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@circleName";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@circleId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.circleName;
+                insertParam3.Value = item.circleId.ToByteArray();
+                insertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableCircleOldCRUD", item.identityId.ToString()+item.circleId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(CircleOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO CircleOld (identityId,circleName,circleId,data) " +
+                                             "VALUES (@identityId,@circleName,@circleId,@data) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@circleName";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@circleId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.circleName;
+                insertParam3.Value = item.circleId.ToByteArray();
+                insertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableCircleOldCRUD", item.identityId.ToString()+item.circleId.ToString(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(CircleOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO CircleOld (identityId,circleName,circleId,data) " +
+                                             "VALUES (@identityId,@circleName,@circleId,@data)"+
+                                             "ON CONFLICT (identityId,circleId) DO UPDATE "+
+                                             "SET circleName = @circleName,data = @data "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@circleName";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@circleId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam4);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.circleName;
+                upsertParam3.Value = item.circleId.ToByteArray();
+                upsertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.AddOrUpdate("TableCircleOldCRUD", item.identityId.ToString()+item.circleId.ToString(), item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(CircleOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.circleId.AssertGuidNotEmpty("Guid parameter circleId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE CircleOld " +
+                                             "SET circleName = @circleName,data = @data "+
+                                             "WHERE (identityId = @identityId AND circleId = @circleId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@circleName";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@circleId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam4);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.circleName;
+                updateParam3.Value = item.circleId.ToByteArray();
+                updateParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableCircleOldCRUD", item.identityId.ToString()+item.circleId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE circle RENAME TO CircleOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM CircleOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("circleName");
+            sl.Add("circleId");
+            sl.Add("data");
+            return sl;
+        }
+
+        // SELECT identityId,circleName,circleId,data
+        public CircleOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<CircleOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new CircleOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.circleNameNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.circleId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid circleId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM CircleOld " +
+                                             "WHERE identityId = @identityId AND circleId = @circleId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@circleId";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = circleId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableCircleOldCRUD", identityId.ToString()+circleId.ToString());
+                return count;
+            }
+        }
+
+        public CircleOldRecord ReadRecordFromReader0(DbDataReader rdr)
+        {
+            var result = new List<CircleOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new CircleOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.circleNameNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.circleId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<CircleOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT identityId,circleName,circleId,data FROM CircleOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<CircleOldRecord>();
+                        }
+                        var result = new List<CircleOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public CircleOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid circleId)
+        {
+            var result = new List<CircleOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new CircleOldRecord();
+            item.identityId = identityId;
+            item.circleId = circleId;
+            item.circleNameNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[0];
+            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<CircleOldRecord> GetAsync(Guid identityId,Guid circleId)
+        {
+            var (hit, cacheObject) = _cache.Get("TableCircleOldCRUD", identityId.ToString()+circleId.ToString());
+            if (hit)
+                return (CircleOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT circleName,data FROM CircleOld " +
+                                             "WHERE identityId = @identityId AND circleId = @circleId LIMIT 1;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@circleId";
+                get1Command.Parameters.Add(get1Param2);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = circleId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableCircleOldCRUD", identityId.ToString()+circleId.ToString(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr,identityId,circleId);
+                        _cache.AddOrUpdate("TableCircleOldCRUD", identityId.ToString()+circleId.ToString(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<(List<CircleOldRecord>, Guid? nextCursor)> PagingByCircleIdAsync(int count, Guid identityId, Guid? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = Guid.Empty;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging3Command = cn.CreateCommand();
+            {
+                getPaging3Command.CommandText = "SELECT identityId,circleName,circleId,data FROM CircleOld " +
+                                            "WHERE (identityId = @identityId) AND circleId > @circleId  ORDER BY circleId ASC  LIMIT @count;";
+                var getPaging3Param1 = getPaging3Command.CreateParameter();
+                getPaging3Param1.ParameterName = "@circleId";
+                getPaging3Command.Parameters.Add(getPaging3Param1);
+                var getPaging3Param2 = getPaging3Command.CreateParameter();
+                getPaging3Param2.ParameterName = "@count";
+                getPaging3Command.Parameters.Add(getPaging3Param2);
+                var getPaging3Param3 = getPaging3Command.CreateParameter();
+                getPaging3Param3.ParameterName = "@identityId";
+                getPaging3Command.Parameters.Add(getPaging3Param3);
+
+                getPaging3Param1.Value = inCursor?.ToByteArray();
+                getPaging3Param2.Value = count+1;
+                getPaging3Param3.Value = identityId.ToByteArray();
+
+                {
+                    await using (var rdr = await getPaging3Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<CircleOldRecord>();
+                        Guid? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].circleId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
@@ -158,10 +158,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
             else
-                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
-            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS connections("

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
@@ -162,6 +162,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             else
                    rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS connections("
                    +rowid
@@ -174,7 +175,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,identity)"
-                   +") ;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableConnectionsCRUD ON connections(identityId,created);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class ConnectionsRecord
     {
-        private long _rowId;
-        public long rowId
+        private Int64 _rowId;
+        public Int64 rowId
         {
            get {
                    return _rowId;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
@@ -769,5 +769,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using 
         } // PagingGet
 
+        protected virtual async Task<(List<ConnectionsRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,identity,displayName,status,accessIsRevoked,data,created,modified FROM connections " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<ConnectionsRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class ConnectionsRecord
     {
-        private Int64 _rowId;
-        public Int64 rowId
+        private long _rowId;
+        public long rowId
         {
            get {
                    return _rowId;
@@ -158,11 +158,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
+                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS connections("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"identity TEXT NOT NULL, "
                    +"displayName TEXT NOT NULL, "
@@ -171,9 +173,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"data BYTEA , "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   + rowid
-                   +", PRIMARY KEY (identityId,identity)"
-                   +");"
+                   +", UNIQUE(identityId,identity)"
+                   +") ;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableConnectionsCRUD ON connections(identityId,created);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCRUD.cs
@@ -175,7 +175,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,identity)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableConnectionsCRUD ON connections(identityId,created);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0connections ON connections(identityId,created);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -474,7 +474,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected ConnectionsRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,OdinId identity)
+        protected ConnectionsRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,OdinId identity)
         {
             var result = new List<ConnectionsRecord>();
 #pragma warning disable CS0168
@@ -505,7 +505,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,displayName,status,accessIsRevoked,data,created,modified FROM connections " +
-                                             "WHERE identityId = @identityId AND identity = @identity LIMIT 1;";
+                                             "WHERE identityId = @identityId AND identity = @identity LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -523,7 +524,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableConnectionsCRUD", identityId.ToString()+identity.DomainName, null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,identity);
+                        var r = ReadRecordFromReader0(rdr,identityId,identity);
                         _cache.AddOrUpdate("TableConnectionsCRUD", identityId.ToString()+identity.DomainName, r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsOldCRUD.cs
@@ -1,0 +1,838 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class ConnectionsOldRecord
+    {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private OdinId _identity;
+        public OdinId identity
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                  _identity = value;
+               }
+        }
+        private string _displayName;
+        public string displayName
+        {
+           get {
+                   return _displayName;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 80) throw new Exception("Too long");
+                  _displayName = value;
+               }
+        }
+        internal string displayNameNoLengthCheck
+        {
+           get {
+                   return _displayName;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _displayName = value;
+               }
+        }
+        private Int32 _status;
+        public Int32 status
+        {
+           get {
+                   return _status;
+               }
+           set {
+                  _status = value;
+               }
+        }
+        private Int32 _accessIsRevoked;
+        public Int32 accessIsRevoked
+        {
+           get {
+                   return _accessIsRevoked;
+               }
+           set {
+                  _accessIsRevoked = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class ConnectionsOldRecord
+
+    public abstract class TableConnectionsOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableConnectionsOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS ConnectionsOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS ConnectionsOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"identity TEXT NOT NULL, "
+                   +"displayName TEXT NOT NULL, "
+                   +"status BIGINT NOT NULL, "
+                   +"accessIsRevoked BIGINT NOT NULL, "
+                   +"data BYTEA , "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,identity)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0ConnectionsOld ON ConnectionsOld(identityId,created);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(ConnectionsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO ConnectionsOld (identityId,identity,displayName,status,accessIsRevoked,data,created,modified) " +
+                                             "VALUES (@identityId,@identity,@displayName,@status,@accessIsRevoked,@data,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@displayName";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@status";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@accessIsRevoked";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam8);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.identity.DomainName;
+                insertParam3.Value = item.displayName;
+                insertParam4.Value = item.status;
+                insertParam5.Value = item.accessIsRevoked;
+                insertParam6.Value = item.data ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam7.Value = now.milliseconds;
+                item.modified = null;
+                insertParam8.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.created = now;
+                    _cache.AddOrUpdate("TableConnectionsOldCRUD", item.identityId.ToString()+item.identity.DomainName, item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(ConnectionsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO ConnectionsOld (identityId,identity,displayName,status,accessIsRevoked,data,created,modified) " +
+                                             "VALUES (@identityId,@identity,@displayName,@status,@accessIsRevoked,@data,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@displayName";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@status";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@accessIsRevoked";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam8);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.identity.DomainName;
+                insertParam3.Value = item.displayName;
+                insertParam4.Value = item.status;
+                insertParam5.Value = item.accessIsRevoked;
+                insertParam6.Value = item.data ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam7.Value = now.milliseconds;
+                item.modified = null;
+                insertParam8.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    item.created = now;
+                   _cache.AddOrUpdate("TableConnectionsOldCRUD", item.identityId.ToString()+item.identity.DomainName, item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(ConnectionsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO ConnectionsOld (identityId,identity,displayName,status,accessIsRevoked,data,created) " +
+                                             "VALUES (@identityId,@identity,@displayName,@status,@accessIsRevoked,@data,@created)"+
+                                             "ON CONFLICT (identityId,identity) DO UPDATE "+
+                                             "SET displayName = @displayName,status = @status,accessIsRevoked = @accessIsRevoked,data = @data,modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@identity";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@displayName";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@status";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@accessIsRevoked";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam7);
+                var upsertParam8 = upsertCommand.CreateParameter();
+                upsertParam8.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam8);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.identity.DomainName;
+                upsertParam3.Value = item.displayName;
+                upsertParam4.Value = item.status;
+                upsertParam5.Value = item.accessIsRevoked;
+                upsertParam6.Value = item.data ?? (object)DBNull.Value;
+                upsertParam7.Value = now.milliseconds;
+                upsertParam8.Value = now.milliseconds;
+                await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   _cache.AddOrUpdate("TableConnectionsOldCRUD", item.identityId.ToString()+item.identity.DomainName, item);
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(ConnectionsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE ConnectionsOld " +
+                                             "SET displayName = @displayName,status = @status,accessIsRevoked = @accessIsRevoked,data = @data,modified = @modified "+
+                                             "WHERE (identityId = @identityId AND identity = @identity)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@identity";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@displayName";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@status";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@accessIsRevoked";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam7);
+                var updateParam8 = updateCommand.CreateParameter();
+                updateParam8.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam8);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.identity.DomainName;
+                updateParam3.Value = item.displayName;
+                updateParam4.Value = item.status;
+                updateParam5.Value = item.accessIsRevoked;
+                updateParam6.Value = item.data ?? (object)DBNull.Value;
+                updateParam7.Value = now.milliseconds;
+                updateParam8.Value = now.milliseconds;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.modified = now;
+                    _cache.AddOrUpdate("TableConnectionsOldCRUD", item.identityId.ToString()+item.identity.DomainName, item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE connections RENAME TO ConnectionsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM ConnectionsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("rowId");
+            sl.Add("identityId");
+            sl.Add("identity");
+            sl.Add("displayName");
+            sl.Add("status");
+            sl.Add("accessIsRevoked");
+            sl.Add("data");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        // SELECT rowId,identityId,identity,displayName,status,accessIsRevoked,data,created,modified
+        public ConnectionsOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<ConnectionsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new ConnectionsOldRecord();
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.identity = (rdr[2] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[2]);
+            item.displayNameNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[3];
+            item.status = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.accessIsRevoked = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.dataNoLengthCheck = (rdr[6] == DBNull.Value) ? null : (byte[])(rdr[6]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            item.created = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[7]);
+            item.modified = (rdr[8] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[8]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,OdinId identity)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM ConnectionsOld " +
+                                             "WHERE identityId = @identityId AND identity = @identity";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@identity";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = identity.DomainName;
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableConnectionsOldCRUD", identityId.ToString()+identity.DomainName);
+                return count;
+            }
+        }
+
+        public ConnectionsOldRecord ReadRecordFromReader0(DbDataReader rdr)
+        {
+            var result = new List<ConnectionsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new ConnectionsOldRecord();
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.identity = (rdr[2] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[2]);
+            item.displayNameNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[3];
+            item.status = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.accessIsRevoked = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.dataNoLengthCheck = (rdr[6] == DBNull.Value) ? null : (byte[])(rdr[6]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            item.created = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[7]);
+            item.modified = (rdr[8] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[8]);
+            return item;
+       }
+
+        public virtual async Task<List<ConnectionsOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT rowId,identityId,identity,displayName,status,accessIsRevoked,data,created,modified FROM ConnectionsOld " +
+                                             "ORDER BY rowId ASC "+
+                                             ";";
+
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<ConnectionsOldRecord>();
+                        }
+                        var result = new List<ConnectionsOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public ConnectionsOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,OdinId identity)
+        {
+            var result = new List<ConnectionsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new ConnectionsOldRecord();
+            item.identityId = identityId;
+            item.identity = identity;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.displayNameNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.status = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
+            item.accessIsRevoked = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            item.created = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
+            item.modified = (rdr[6] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[6]);
+            return item;
+       }
+
+        public virtual async Task<ConnectionsOldRecord> GetAsync(Guid identityId,OdinId identity)
+        {
+            var (hit, cacheObject) = _cache.Get("TableConnectionsOldCRUD", identityId.ToString()+identity.DomainName);
+            if (hit)
+                return (ConnectionsOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT rowId,displayName,status,accessIsRevoked,data,created,modified FROM ConnectionsOld " +
+                                             "WHERE identityId = @identityId AND identity = @identity LIMIT 1;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@identity";
+                get1Command.Parameters.Add(get1Param2);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = identity.DomainName;
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableConnectionsOldCRUD", identityId.ToString()+identity.DomainName, null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr,identityId,identity);
+                        _cache.AddOrUpdate("TableConnectionsOldCRUD", identityId.ToString()+identity.DomainName, r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<(List<ConnectionsOldRecord>, string nextCursor)> PagingByIdentityAsync(int count, Guid identityId, string inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = "";
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging2Command = cn.CreateCommand();
+            {
+                getPaging2Command.CommandText = "SELECT rowId,identityId,identity,displayName,status,accessIsRevoked,data,created,modified FROM ConnectionsOld " +
+                                            "WHERE (identityId = @identityId) AND identity > @identity  ORDER BY identity ASC  LIMIT @count;";
+                var getPaging2Param1 = getPaging2Command.CreateParameter();
+                getPaging2Param1.ParameterName = "@identity";
+                getPaging2Command.Parameters.Add(getPaging2Param1);
+                var getPaging2Param2 = getPaging2Command.CreateParameter();
+                getPaging2Param2.ParameterName = "@count";
+                getPaging2Command.Parameters.Add(getPaging2Param2);
+                var getPaging2Param3 = getPaging2Command.CreateParameter();
+                getPaging2Param3.ParameterName = "@identityId";
+                getPaging2Command.Parameters.Add(getPaging2Param3);
+
+                getPaging2Param1.Value = inCursor;
+                getPaging2Param2.Value = count+1;
+                getPaging2Param3.Value = identityId.ToByteArray();
+
+                {
+                    await using (var rdr = await getPaging2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<ConnectionsOldRecord>();
+                        string nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].identity;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
+        public virtual async Task<(List<ConnectionsOldRecord>, string nextCursor)> PagingByIdentityAsync(int count, Guid identityId,Int32 status, string inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = "";
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging2Command = cn.CreateCommand();
+            {
+                getPaging2Command.CommandText = "SELECT rowId,identityId,identity,displayName,status,accessIsRevoked,data,created,modified FROM ConnectionsOld " +
+                                            "WHERE (identityId = @identityId AND status = @status) AND identity > @identity  ORDER BY identity ASC  LIMIT @count;";
+                var getPaging2Param1 = getPaging2Command.CreateParameter();
+                getPaging2Param1.ParameterName = "@identity";
+                getPaging2Command.Parameters.Add(getPaging2Param1);
+                var getPaging2Param2 = getPaging2Command.CreateParameter();
+                getPaging2Param2.ParameterName = "@count";
+                getPaging2Command.Parameters.Add(getPaging2Param2);
+                var getPaging2Param3 = getPaging2Command.CreateParameter();
+                getPaging2Param3.ParameterName = "@identityId";
+                getPaging2Command.Parameters.Add(getPaging2Param3);
+                var getPaging2Param4 = getPaging2Command.CreateParameter();
+                getPaging2Param4.ParameterName = "@status";
+                getPaging2Command.Parameters.Add(getPaging2Param4);
+
+                getPaging2Param1.Value = inCursor;
+                getPaging2Param2.Value = count+1;
+                getPaging2Param3.Value = identityId.ToByteArray();
+                getPaging2Param4.Value = status;
+
+                {
+                    await using (var rdr = await getPaging2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<ConnectionsOldRecord>();
+                        string nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].identity;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
+        public virtual async Task<(List<ConnectionsOldRecord>, UnixTimeUtc? nextCursor, long nextRowId)> PagingByCreatedAsync(int count, Guid identityId,Int32 status, UnixTimeUtc? inCursor, long? rowid)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = new UnixTimeUtc(long.MaxValue);
+            if (rowid == null)
+                rowid = long.MaxValue;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging7Command = cn.CreateCommand();
+            {
+                getPaging7Command.CommandText = "SELECT rowId,identityId,identity,displayName,status,accessIsRevoked,data,created,modified FROM ConnectionsOld " +
+                                            "WHERE (identityId = @identityId AND status = @status) AND created <= @created AND rowId < @rowId ORDER BY created DESC , rowId DESC LIMIT @count;";
+                var getPaging7Param1 = getPaging7Command.CreateParameter();
+                getPaging7Param1.ParameterName = "@created";
+                getPaging7Command.Parameters.Add(getPaging7Param1);
+                var getPaging7Param2 = getPaging7Command.CreateParameter();
+                getPaging7Param2.ParameterName = "@rowId";
+                getPaging7Command.Parameters.Add(getPaging7Param2);
+                var getPaging7Param3 = getPaging7Command.CreateParameter();
+                getPaging7Param3.ParameterName = "@count";
+                getPaging7Command.Parameters.Add(getPaging7Param3);
+                var getPaging7Param4 = getPaging7Command.CreateParameter();
+                getPaging7Param4.ParameterName = "@identityId";
+                getPaging7Command.Parameters.Add(getPaging7Param4);
+                var getPaging7Param5 = getPaging7Command.CreateParameter();
+                getPaging7Param5.ParameterName = "@status";
+                getPaging7Command.Parameters.Add(getPaging7Param5);
+
+                getPaging7Param1.Value = inCursor?.milliseconds;
+                getPaging7Param2.Value = rowid;
+                getPaging7Param3.Value = count+1;
+                getPaging7Param4.Value = identityId.ToByteArray();
+                getPaging7Param5.Value = status;
+
+                {
+                    await using (var rdr = await getPaging7Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<ConnectionsOldRecord>();
+                        UnixTimeUtc? nextCursor;
+                        long nextRowId;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].created;
+                                nextRowId = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                            nextRowId = 0;
+                        }
+                        return (result, nextCursor, nextRowId);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
+        public virtual async Task<(List<ConnectionsOldRecord>, UnixTimeUtc? nextCursor, long nextRowId)> PagingByCreatedAsync(int count, Guid identityId, UnixTimeUtc? inCursor, long? rowid)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = new UnixTimeUtc(long.MaxValue);
+            if (rowid == null)
+                rowid = long.MaxValue;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging7Command = cn.CreateCommand();
+            {
+                getPaging7Command.CommandText = "SELECT rowId,identityId,identity,displayName,status,accessIsRevoked,data,created,modified FROM ConnectionsOld " +
+                                            "WHERE (identityId = @identityId) AND created <= @created AND rowId < @rowId ORDER BY created DESC , rowId DESC LIMIT @count;";
+                var getPaging7Param1 = getPaging7Command.CreateParameter();
+                getPaging7Param1.ParameterName = "@created";
+                getPaging7Command.Parameters.Add(getPaging7Param1);
+                var getPaging7Param2 = getPaging7Command.CreateParameter();
+                getPaging7Param2.ParameterName = "@rowId";
+                getPaging7Command.Parameters.Add(getPaging7Param2);
+                var getPaging7Param3 = getPaging7Command.CreateParameter();
+                getPaging7Param3.ParameterName = "@count";
+                getPaging7Command.Parameters.Add(getPaging7Param3);
+                var getPaging7Param4 = getPaging7Command.CreateParameter();
+                getPaging7Param4.ParameterName = "@identityId";
+                getPaging7Command.Parameters.Add(getPaging7Param4);
+
+                getPaging7Param1.Value = inCursor?.milliseconds;
+                getPaging7Param2.Value = rowid;
+                getPaging7Param3.Value = count+1;
+                getPaging7Param4.Value = identityId.ToByteArray();
+
+                {
+                    await using (var rdr = await getPaging7Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<ConnectionsOldRecord>();
+                        UnixTimeUtc? nextCursor;
+                        long nextRowId;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].created;
+                                nextRowId = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                            nextRowId = 0;
+                        }
+                        return (result, nextCursor, nextRowId);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
@@ -78,6 +78,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveAclIndex;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveAclIndex("
                    +"identityId BYTEA NOT NULL, "
@@ -85,7 +88,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"fileId BYTEA NOT NULL, "
                    +"aclMemberId BYTEA NOT NULL "
                    +", PRIMARY KEY (identityId,driveId,fileId,aclMemberId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveAclIndexCRUD ON driveAclIndex(identityId,driveId,aclMemberId);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
@@ -78,20 +78,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveAclIndex;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveAclIndex("
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
                    +"fileId BYTEA NOT NULL, "
                    +"aclMemberId BYTEA NOT NULL "
-                   + rowid
                    +", PRIMARY KEY (identityId,driveId,fileId,aclMemberId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveAclIndexCRUD ON driveAclIndex(identityId,driveId,aclMemberId);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
@@ -17,6 +17,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class DriveAclIndexRecord
     {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private Guid _identityId;
         public Guid identityId
         {
@@ -78,16 +88,20 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveAclIndex;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
-            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
-                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveAclIndex("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
                    +"fileId BYTEA NOT NULL, "
                    +"aclMemberId BYTEA NOT NULL "
-                   +", PRIMARY KEY (identityId,driveId,fileId,aclMemberId)"
+                   +", UNIQUE(identityId,driveId,fileId,aclMemberId)"
                    +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
@@ -252,6 +266,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("identityId");
             sl.Add("driveId");
             sl.Add("fileId");
@@ -278,7 +293,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        // SELECT identityId,driveId,fileId,aclMemberId
+        // SELECT rowId,identityId,driveId,fileId,aclMemberId
         protected DriveAclIndexRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<DriveAclIndexRecord>();
@@ -287,10 +302,11 @@ namespace Odin.Core.Storage.Database.Identity.Table
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new DriveAclIndexRecord();
-            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
-            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
-            item.aclMemberId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.fileId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.aclMemberId = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[4]);
             return item;
        }
 
@@ -360,6 +376,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.driveId = driveId;
             item.fileId = fileId;
             item.aclMemberId = aclMemberId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
             return item;
        }
 
@@ -368,7 +385,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT identityId,driveId,fileId,aclMemberId FROM driveAclIndex " +
+                get0Command.CommandText = "SELECT rowId FROM driveAclIndex " +
                                              "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId LIMIT 1;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
@@ -89,7 +89,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"aclMemberId BYTEA NOT NULL "
                    +", PRIMARY KEY (identityId,driveId,fileId,aclMemberId)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableDriveAclIndexCRUD ON driveAclIndex(identityId,driveId,aclMemberId);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
@@ -370,7 +370,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT aclMemberId FROM driveAclIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -416,7 +417,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected DriveAclIndexRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
+        protected DriveAclIndexRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
         {
             var result = new List<DriveAclIndexRecord>();
 #pragma warning disable CS0168
@@ -438,7 +439,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId FROM driveAclIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -463,7 +465,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,aclMemberId);
+                        var r = ReadRecordFromReader1(rdr,identityId,driveId,fileId,aclMemberId);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexCRUD.cs
@@ -310,13 +310,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return item;
        }
 
-        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
+        protected virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var delete0Command = cn.CreateCommand();
             {
                 delete0Command.CommandText = "DELETE FROM driveAclIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
                 var delete0Param1 = delete0Command.CreateParameter();
                 delete0Param1.ParameterName = "@identityId";
                 delete0Command.Parameters.Add(delete0Param1);
@@ -326,26 +326,22 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var delete0Param3 = delete0Command.CreateParameter();
                 delete0Param3.ParameterName = "@fileId";
                 delete0Command.Parameters.Add(delete0Param3);
-                var delete0Param4 = delete0Command.CreateParameter();
-                delete0Param4.ParameterName = "@aclMemberId";
-                delete0Command.Parameters.Add(delete0Param4);
 
                 delete0Param1.Value = identityId.ToByteArray();
                 delete0Param2.Value = driveId.ToByteArray();
                 delete0Param3.Value = fileId.ToByteArray();
-                delete0Param4.Value = aclMemberId.ToByteArray();
                 var count = await delete0Command.ExecuteNonQueryAsync();
                 return count;
             }
         }
 
-        protected virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
+        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var delete1Command = cn.CreateCommand();
             {
                 delete1Command.CommandText = "DELETE FROM driveAclIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId";
                 var delete1Param1 = delete1Command.CreateParameter();
                 delete1Param1.ParameterName = "@identityId";
                 delete1Command.Parameters.Add(delete1Param1);
@@ -355,38 +351,26 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var delete1Param3 = delete1Command.CreateParameter();
                 delete1Param3.ParameterName = "@fileId";
                 delete1Command.Parameters.Add(delete1Param3);
+                var delete1Param4 = delete1Command.CreateParameter();
+                delete1Param4.ParameterName = "@aclMemberId";
+                delete1Command.Parameters.Add(delete1Param4);
 
                 delete1Param1.Value = identityId.ToByteArray();
                 delete1Param2.Value = driveId.ToByteArray();
                 delete1Param3.Value = fileId.ToByteArray();
+                delete1Param4.Value = aclMemberId.ToByteArray();
                 var count = await delete1Command.ExecuteNonQueryAsync();
                 return count;
             }
         }
 
-        protected DriveAclIndexRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
-        {
-            var result = new List<DriveAclIndexRecord>();
-#pragma warning disable CS0168
-            long bytesRead;
-#pragma warning restore CS0168
-            var guid = new byte[16];
-            var item = new DriveAclIndexRecord();
-            item.identityId = identityId;
-            item.driveId = driveId;
-            item.fileId = fileId;
-            item.aclMemberId = aclMemberId;
-            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
-            return item;
-       }
-
-        protected virtual async Task<DriveAclIndexRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
+        protected virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT rowId FROM driveAclIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId LIMIT 1;";
+                get0Command.CommandText = "SELECT aclMemberId FROM driveAclIndex " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -396,50 +380,12 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var get0Param3 = get0Command.CreateParameter();
                 get0Param3.ParameterName = "@fileId";
                 get0Command.Parameters.Add(get0Param3);
-                var get0Param4 = get0Command.CreateParameter();
-                get0Param4.ParameterName = "@aclMemberId";
-                get0Command.Parameters.Add(get0Param4);
 
                 get0Param1.Value = identityId.ToByteArray();
                 get0Param2.Value = driveId.ToByteArray();
                 get0Param3.Value = fileId.ToByteArray();
-                get0Param4.Value = aclMemberId.ToByteArray();
                 {
-                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
-                    {
-                        if (await rdr.ReadAsync() == false)
-                        {
-                            return null;
-                        }
-                        var r = ReadRecordFromReader0(rdr, identityId,driveId,fileId,aclMemberId);
-                        return r;
-                    } // using
-                } //
-            } // using
-        }
-
-        protected virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
-        {
-            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var get1Command = cn.CreateCommand();
-            {
-                get1Command.CommandText = "SELECT aclMemberId FROM driveAclIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
-                var get1Param1 = get1Command.CreateParameter();
-                get1Param1.ParameterName = "@identityId";
-                get1Command.Parameters.Add(get1Param1);
-                var get1Param2 = get1Command.CreateParameter();
-                get1Param2.ParameterName = "@driveId";
-                get1Command.Parameters.Add(get1Param2);
-                var get1Param3 = get1Command.CreateParameter();
-                get1Param3.ParameterName = "@fileId";
-                get1Command.Parameters.Add(get1Param3);
-
-                get1Param1.Value = identityId.ToByteArray();
-                get1Param2.Value = driveId.ToByteArray();
-                get1Param3.Value = fileId.ToByteArray();
-                {
-                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
                     {
                         Guid result0tmp;
                         var thelistresult = new List<Guid>();
@@ -469,6 +415,109 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 } //
             } // using
         }
+
+        protected DriveAclIndexRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
+        {
+            var result = new List<DriveAclIndexRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveAclIndexRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.aclMemberId = aclMemberId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            return item;
+       }
+
+        protected virtual async Task<DriveAclIndexRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT rowId FROM driveAclIndex " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId LIMIT 1;";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@fileId";
+                get1Command.Parameters.Add(get1Param3);
+                var get1Param4 = get1Command.CreateParameter();
+                get1Param4.ParameterName = "@aclMemberId";
+                get1Command.Parameters.Add(get1Param4);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = driveId.ToByteArray();
+                get1Param3.Value = fileId.ToByteArray();
+                get1Param4.Value = aclMemberId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,aclMemberId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        protected virtual async Task<(List<DriveAclIndexRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,driveId,fileId,aclMemberId FROM driveAclIndex " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<DriveAclIndexRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
 
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveAclIndexOldCRUD.cs
@@ -1,0 +1,520 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class DriveAclIndexOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private Guid _fileId;
+        public Guid fileId
+        {
+           get {
+                   return _fileId;
+               }
+           set {
+                  _fileId = value;
+               }
+        }
+        private Guid _aclMemberId;
+        public Guid aclMemberId
+        {
+           get {
+                   return _aclMemberId;
+               }
+           set {
+                  _aclMemberId = value;
+               }
+        }
+    } // End of class DriveAclIndexOldRecord
+
+    public abstract class TableDriveAclIndexOldCRUD
+    {
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableDriveAclIndexOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS DriveAclIndexOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS DriveAclIndexOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL, "
+                   +"aclMemberId BYTEA NOT NULL "
+                   + rowid
+                   +", PRIMARY KEY (identityId,driveId,fileId,aclMemberId)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0DriveAclIndexOld ON DriveAclIndexOld(identityId,driveId,aclMemberId);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(DriveAclIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.aclMemberId.AssertGuidNotEmpty("Guid parameter aclMemberId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveAclIndexOld (identityId,driveId,fileId,aclMemberId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@aclMemberId)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@aclMemberId";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.aclMemberId.ToByteArray();
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DriveAclIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.aclMemberId.AssertGuidNotEmpty("Guid parameter aclMemberId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveAclIndexOld (identityId,driveId,fileId,aclMemberId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@aclMemberId) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@aclMemberId";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.aclMemberId.ToByteArray();
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DriveAclIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.aclMemberId.AssertGuidNotEmpty("Guid parameter aclMemberId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO DriveAclIndexOld (identityId,driveId,fileId,aclMemberId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@aclMemberId)"+
+                                             "ON CONFLICT (identityId,driveId,fileId,aclMemberId) DO UPDATE "+
+                                             "SET  "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@fileId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@aclMemberId";
+                upsertCommand.Parameters.Add(upsertParam4);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.driveId.ToByteArray();
+                upsertParam3.Value = item.fileId.ToByteArray();
+                upsertParam4.Value = item.aclMemberId.ToByteArray();
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(DriveAclIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.aclMemberId.AssertGuidNotEmpty("Guid parameter aclMemberId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE DriveAclIndexOld " +
+                                             "SET  "+
+                                             "WHERE (identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@fileId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@aclMemberId";
+                updateCommand.Parameters.Add(updateParam4);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.driveId.ToByteArray();
+                updateParam3.Value = item.fileId.ToByteArray();
+                updateParam4.Value = item.aclMemberId.ToByteArray();
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE driveAclIndex RENAME TO DriveAclIndexOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM DriveAclIndexOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("driveId");
+            sl.Add("fileId");
+            sl.Add("aclMemberId");
+            return sl;
+        }
+
+        public virtual async Task<int> GetDriveCountAsync(Guid driveId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountDriveCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountDriveCommand.CommandText = "SELECT COUNT(*) FROM DriveAclIndexOld WHERE driveId = $driveId;";
+                var getCountDriveParam1 = getCountDriveCommand.CreateParameter();
+                getCountDriveParam1.ParameterName = "$driveId";
+                getCountDriveCommand.Parameters.Add(getCountDriveParam1);
+                getCountDriveParam1.Value = driveId.ToByteArray();
+                var count = await getCountDriveCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            } // using
+        }
+
+        // SELECT identityId,driveId,fileId,aclMemberId
+        public DriveAclIndexOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<DriveAclIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveAclIndexOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.aclMemberId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM DriveAclIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@fileId";
+                delete0Command.Parameters.Add(delete0Param3);
+                var delete0Param4 = delete0Command.CreateParameter();
+                delete0Param4.ParameterName = "@aclMemberId";
+                delete0Command.Parameters.Add(delete0Param4);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = driveId.ToByteArray();
+                delete0Param3.Value = fileId.ToByteArray();
+                delete0Param4.Value = aclMemberId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete1Command = cn.CreateCommand();
+            {
+                delete1Command.CommandText = "DELETE FROM DriveAclIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                var delete1Param1 = delete1Command.CreateParameter();
+                delete1Param1.ParameterName = "@identityId";
+                delete1Command.Parameters.Add(delete1Param1);
+                var delete1Param2 = delete1Command.CreateParameter();
+                delete1Param2.ParameterName = "@driveId";
+                delete1Command.Parameters.Add(delete1Param2);
+                var delete1Param3 = delete1Command.CreateParameter();
+                delete1Param3.ParameterName = "@fileId";
+                delete1Command.Parameters.Add(delete1Param3);
+
+                delete1Param1.Value = identityId.ToByteArray();
+                delete1Param2.Value = driveId.ToByteArray();
+                delete1Param3.Value = fileId.ToByteArray();
+                var count = await delete1Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public DriveAclIndexOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
+        {
+            var result = new List<DriveAclIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveAclIndexOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.aclMemberId = aclMemberId;
+            return item;
+       }
+
+        public virtual async Task<DriveAclIndexOldRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid aclMemberId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT identityId,driveId,fileId,aclMemberId FROM DriveAclIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND aclMemberId = @aclMemberId LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@driveId";
+                get0Command.Parameters.Add(get0Param2);
+                var get0Param3 = get0Command.CreateParameter();
+                get0Param3.ParameterName = "@fileId";
+                get0Command.Parameters.Add(get0Param3);
+                var get0Param4 = get0Command.CreateParameter();
+                get0Param4.ParameterName = "@aclMemberId";
+                get0Command.Parameters.Add(get0Param4);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = driveId.ToByteArray();
+                get0Param3.Value = fileId.ToByteArray();
+                get0Param4.Value = aclMemberId.ToByteArray();
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,identityId,driveId,fileId,aclMemberId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT aclMemberId FROM DriveAclIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@fileId";
+                get1Command.Parameters.Add(get1Param3);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = driveId.ToByteArray();
+                get1Param3.Value = fileId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        Guid result0tmp;
+                        var thelistresult = new List<Guid>();
+                        if (!await rdr.ReadAsync()) {
+                            return thelistresult;
+                        }
+                    byte[] tmpbuf = new byte[65535+1];
+                    var guid = new byte[16];
+                    while (true)
+                    {
+
+                        if (rdr[0] == DBNull.Value)
+                            throw new Exception("Impossible, item is null in DB, but set as NOT NULL");
+                        else
+                        {
+                            guid = (byte[]) rdr[0];
+                            if (guid.Length != 16)
+                                throw new Exception("Not a GUID in aclMemberId...");
+                            result0tmp = new Guid(guid);
+                        }
+                        thelistresult.Add(result0tmp);
+                        if (!await rdr.ReadAsync())
+                           break;
+                    } // while
+                    return thelistresult;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveAclIndexOldRecord ReadRecordFromReader2(DbDataReader rdr)
+        {
+            var result = new List<DriveAclIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveAclIndexOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.aclMemberId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            return item;
+       }
+
+        public virtual async Task<List<DriveAclIndexOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT identityId,driveId,fileId,aclMemberId FROM DriveAclIndexOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<DriveAclIndexOldRecord>();
+                        }
+                        var result = new List<DriveAclIndexOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader2(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
@@ -310,13 +310,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return item;
        }
 
-        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        protected virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var delete0Command = cn.CreateCommand();
             {
                 delete0Command.CommandText = "DELETE FROM driveLocalTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
                 var delete0Param1 = delete0Command.CreateParameter();
                 delete0Param1.ParameterName = "@identityId";
                 delete0Command.Parameters.Add(delete0Param1);
@@ -326,26 +326,22 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var delete0Param3 = delete0Command.CreateParameter();
                 delete0Param3.ParameterName = "@fileId";
                 delete0Command.Parameters.Add(delete0Param3);
-                var delete0Param4 = delete0Command.CreateParameter();
-                delete0Param4.ParameterName = "@tagId";
-                delete0Command.Parameters.Add(delete0Param4);
 
                 delete0Param1.Value = identityId.ToByteArray();
                 delete0Param2.Value = driveId.ToByteArray();
                 delete0Param3.Value = fileId.ToByteArray();
-                delete0Param4.Value = tagId.ToByteArray();
                 var count = await delete0Command.ExecuteNonQueryAsync();
                 return count;
             }
         }
 
-        protected virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
+        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var delete1Command = cn.CreateCommand();
             {
                 delete1Command.CommandText = "DELETE FROM driveLocalTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId";
                 var delete1Param1 = delete1Command.CreateParameter();
                 delete1Param1.ParameterName = "@identityId";
                 delete1Command.Parameters.Add(delete1Param1);
@@ -355,38 +351,26 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var delete1Param3 = delete1Command.CreateParameter();
                 delete1Param3.ParameterName = "@fileId";
                 delete1Command.Parameters.Add(delete1Param3);
+                var delete1Param4 = delete1Command.CreateParameter();
+                delete1Param4.ParameterName = "@tagId";
+                delete1Command.Parameters.Add(delete1Param4);
 
                 delete1Param1.Value = identityId.ToByteArray();
                 delete1Param2.Value = driveId.ToByteArray();
                 delete1Param3.Value = fileId.ToByteArray();
+                delete1Param4.Value = tagId.ToByteArray();
                 var count = await delete1Command.ExecuteNonQueryAsync();
                 return count;
             }
         }
 
-        protected DriveLocalTagIndexRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid tagId)
-        {
-            var result = new List<DriveLocalTagIndexRecord>();
-#pragma warning disable CS0168
-            long bytesRead;
-#pragma warning restore CS0168
-            var guid = new byte[16];
-            var item = new DriveLocalTagIndexRecord();
-            item.identityId = identityId;
-            item.driveId = driveId;
-            item.fileId = fileId;
-            item.tagId = tagId;
-            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
-            return item;
-       }
-
-        protected virtual async Task<DriveLocalTagIndexRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        protected virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT rowId FROM driveLocalTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;";
+                get0Command.CommandText = "SELECT tagId FROM driveLocalTagIndex " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -396,50 +380,12 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var get0Param3 = get0Command.CreateParameter();
                 get0Param3.ParameterName = "@fileId";
                 get0Command.Parameters.Add(get0Param3);
-                var get0Param4 = get0Command.CreateParameter();
-                get0Param4.ParameterName = "@tagId";
-                get0Command.Parameters.Add(get0Param4);
 
                 get0Param1.Value = identityId.ToByteArray();
                 get0Param2.Value = driveId.ToByteArray();
                 get0Param3.Value = fileId.ToByteArray();
-                get0Param4.Value = tagId.ToByteArray();
                 {
-                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
-                    {
-                        if (await rdr.ReadAsync() == false)
-                        {
-                            return null;
-                        }
-                        var r = ReadRecordFromReader0(rdr, identityId,driveId,fileId,tagId);
-                        return r;
-                    } // using
-                } //
-            } // using
-        }
-
-        protected virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
-        {
-            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var get1Command = cn.CreateCommand();
-            {
-                get1Command.CommandText = "SELECT tagId FROM driveLocalTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
-                var get1Param1 = get1Command.CreateParameter();
-                get1Param1.ParameterName = "@identityId";
-                get1Command.Parameters.Add(get1Param1);
-                var get1Param2 = get1Command.CreateParameter();
-                get1Param2.ParameterName = "@driveId";
-                get1Command.Parameters.Add(get1Param2);
-                var get1Param3 = get1Command.CreateParameter();
-                get1Param3.ParameterName = "@fileId";
-                get1Command.Parameters.Add(get1Param3);
-
-                get1Param1.Value = identityId.ToByteArray();
-                get1Param2.Value = driveId.ToByteArray();
-                get1Param3.Value = fileId.ToByteArray();
-                {
-                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
                     {
                         Guid result0tmp;
                         var thelistresult = new List<Guid>();
@@ -469,6 +415,109 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 } //
             } // using
         }
+
+        protected DriveLocalTagIndexRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            var result = new List<DriveLocalTagIndexRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveLocalTagIndexRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.tagId = tagId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            return item;
+       }
+
+        protected virtual async Task<DriveLocalTagIndexRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT rowId FROM driveLocalTagIndex " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@fileId";
+                get1Command.Parameters.Add(get1Param3);
+                var get1Param4 = get1Command.CreateParameter();
+                get1Param4.ParameterName = "@tagId";
+                get1Command.Parameters.Add(get1Param4);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = driveId.ToByteArray();
+                get1Param3.Value = fileId.ToByteArray();
+                get1Param4.Value = tagId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,tagId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        protected virtual async Task<(List<DriveLocalTagIndexRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,driveId,fileId,tagId FROM driveLocalTagIndex " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<DriveLocalTagIndexRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
 
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
@@ -89,7 +89,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"tagId BYTEA NOT NULL "
                    +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableDriveLocalTagIndexCRUD ON driveLocalTagIndex(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
@@ -78,20 +78,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveLocalTagIndex;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveLocalTagIndex("
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
                    +"fileId BYTEA NOT NULL, "
                    +"tagId BYTEA NOT NULL "
-                   + rowid
                    +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveLocalTagIndexCRUD ON driveLocalTagIndex(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
@@ -78,6 +78,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveLocalTagIndex;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveLocalTagIndex("
                    +"identityId BYTEA NOT NULL, "
@@ -85,7 +88,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"fileId BYTEA NOT NULL, "
                    +"tagId BYTEA NOT NULL "
                    +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveLocalTagIndexCRUD ON driveLocalTagIndex(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexCRUD.cs
@@ -370,7 +370,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT tagId FROM driveLocalTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -416,7 +417,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected DriveLocalTagIndexRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        protected DriveLocalTagIndexRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,Guid tagId)
         {
             var result = new List<DriveLocalTagIndexRecord>();
 #pragma warning disable CS0168
@@ -438,7 +439,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId FROM driveLocalTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -463,7 +465,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,tagId);
+                        var r = ReadRecordFromReader1(rdr,identityId,driveId,fileId,tagId);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndexOldCRUD.cs
@@ -1,0 +1,520 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class DriveLocalTagIndexOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private Guid _fileId;
+        public Guid fileId
+        {
+           get {
+                   return _fileId;
+               }
+           set {
+                  _fileId = value;
+               }
+        }
+        private Guid _tagId;
+        public Guid tagId
+        {
+           get {
+                   return _tagId;
+               }
+           set {
+                  _tagId = value;
+               }
+        }
+    } // End of class DriveLocalTagIndexOldRecord
+
+    public abstract class TableDriveLocalTagIndexOldCRUD
+    {
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableDriveLocalTagIndexOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS DriveLocalTagIndexOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS DriveLocalTagIndexOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL, "
+                   +"tagId BYTEA NOT NULL "
+                   + rowid
+                   +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0DriveLocalTagIndexOld ON DriveLocalTagIndexOld(identityId,driveId,fileId);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(DriveLocalTagIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.tagId.AssertGuidNotEmpty("Guid parameter tagId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveLocalTagIndexOld (identityId,driveId,fileId,tagId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@tagId)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@tagId";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.tagId.ToByteArray();
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DriveLocalTagIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.tagId.AssertGuidNotEmpty("Guid parameter tagId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveLocalTagIndexOld (identityId,driveId,fileId,tagId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@tagId) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@tagId";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.tagId.ToByteArray();
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DriveLocalTagIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.tagId.AssertGuidNotEmpty("Guid parameter tagId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO DriveLocalTagIndexOld (identityId,driveId,fileId,tagId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@tagId)"+
+                                             "ON CONFLICT (identityId,driveId,fileId,tagId) DO UPDATE "+
+                                             "SET  "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@fileId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@tagId";
+                upsertCommand.Parameters.Add(upsertParam4);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.driveId.ToByteArray();
+                upsertParam3.Value = item.fileId.ToByteArray();
+                upsertParam4.Value = item.tagId.ToByteArray();
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(DriveLocalTagIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.tagId.AssertGuidNotEmpty("Guid parameter tagId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE DriveLocalTagIndexOld " +
+                                             "SET  "+
+                                             "WHERE (identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@fileId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@tagId";
+                updateCommand.Parameters.Add(updateParam4);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.driveId.ToByteArray();
+                updateParam3.Value = item.fileId.ToByteArray();
+                updateParam4.Value = item.tagId.ToByteArray();
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE driveLocalTagIndex RENAME TO DriveLocalTagIndexOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM DriveLocalTagIndexOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("driveId");
+            sl.Add("fileId");
+            sl.Add("tagId");
+            return sl;
+        }
+
+        public virtual async Task<int> GetDriveCountAsync(Guid driveId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountDriveCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountDriveCommand.CommandText = "SELECT COUNT(*) FROM DriveLocalTagIndexOld WHERE driveId = $driveId;";
+                var getCountDriveParam1 = getCountDriveCommand.CreateParameter();
+                getCountDriveParam1.ParameterName = "$driveId";
+                getCountDriveCommand.Parameters.Add(getCountDriveParam1);
+                getCountDriveParam1.Value = driveId.ToByteArray();
+                var count = await getCountDriveCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            } // using
+        }
+
+        // SELECT identityId,driveId,fileId,tagId
+        public DriveLocalTagIndexOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<DriveLocalTagIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveLocalTagIndexOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.tagId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM DriveLocalTagIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@fileId";
+                delete0Command.Parameters.Add(delete0Param3);
+                var delete0Param4 = delete0Command.CreateParameter();
+                delete0Param4.ParameterName = "@tagId";
+                delete0Command.Parameters.Add(delete0Param4);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = driveId.ToByteArray();
+                delete0Param3.Value = fileId.ToByteArray();
+                delete0Param4.Value = tagId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete1Command = cn.CreateCommand();
+            {
+                delete1Command.CommandText = "DELETE FROM DriveLocalTagIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                var delete1Param1 = delete1Command.CreateParameter();
+                delete1Param1.ParameterName = "@identityId";
+                delete1Command.Parameters.Add(delete1Param1);
+                var delete1Param2 = delete1Command.CreateParameter();
+                delete1Param2.ParameterName = "@driveId";
+                delete1Command.Parameters.Add(delete1Param2);
+                var delete1Param3 = delete1Command.CreateParameter();
+                delete1Param3.ParameterName = "@fileId";
+                delete1Command.Parameters.Add(delete1Param3);
+
+                delete1Param1.Value = identityId.ToByteArray();
+                delete1Param2.Value = driveId.ToByteArray();
+                delete1Param3.Value = fileId.ToByteArray();
+                var count = await delete1Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public DriveLocalTagIndexOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            var result = new List<DriveLocalTagIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveLocalTagIndexOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.tagId = tagId;
+            return item;
+       }
+
+        public virtual async Task<DriveLocalTagIndexOldRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT identityId,driveId,fileId,tagId FROM DriveLocalTagIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@driveId";
+                get0Command.Parameters.Add(get0Param2);
+                var get0Param3 = get0Command.CreateParameter();
+                get0Param3.ParameterName = "@fileId";
+                get0Command.Parameters.Add(get0Param3);
+                var get0Param4 = get0Command.CreateParameter();
+                get0Param4.ParameterName = "@tagId";
+                get0Command.Parameters.Add(get0Param4);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = driveId.ToByteArray();
+                get0Param3.Value = fileId.ToByteArray();
+                get0Param4.Value = tagId.ToByteArray();
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,identityId,driveId,fileId,tagId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT tagId FROM DriveLocalTagIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@fileId";
+                get1Command.Parameters.Add(get1Param3);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = driveId.ToByteArray();
+                get1Param3.Value = fileId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        Guid result0tmp;
+                        var thelistresult = new List<Guid>();
+                        if (!await rdr.ReadAsync()) {
+                            return thelistresult;
+                        }
+                    byte[] tmpbuf = new byte[65535+1];
+                    var guid = new byte[16];
+                    while (true)
+                    {
+
+                        if (rdr[0] == DBNull.Value)
+                            throw new Exception("Impossible, item is null in DB, but set as NOT NULL");
+                        else
+                        {
+                            guid = (byte[]) rdr[0];
+                            if (guid.Length != 16)
+                                throw new Exception("Not a GUID in tagId...");
+                            result0tmp = new Guid(guid);
+                        }
+                        thelistresult.Add(result0tmp);
+                        if (!await rdr.ReadAsync())
+                           break;
+                    } // while
+                    return thelistresult;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveLocalTagIndexOldRecord ReadRecordFromReader2(DbDataReader rdr)
+        {
+            var result = new List<DriveLocalTagIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveLocalTagIndexOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.tagId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            return item;
+       }
+
+        public virtual async Task<List<DriveLocalTagIndexOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT identityId,driveId,fileId,tagId FROM DriveLocalTagIndexOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<DriveLocalTagIndexOldRecord>();
+                        }
+                        var result = new List<DriveLocalTagIndexOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader2(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class DriveMainIndexRecord
     {
-        private Int64 _rowId;
-        public Int64 rowId
+        private long _rowId;
+        public long rowId
         {
            get {
                    return _rowId;
@@ -444,11 +444,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
+                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveMainIndex("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
                    +"fileId BYTEA NOT NULL, "
@@ -478,13 +480,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"hdrTmpDriveType BYTEA NOT NULL, "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   + rowid
-                   +", PRIMARY KEY (identityId,driveId,fileId)"
+                   +", UNIQUE(identityId,driveId,fileId)"
                    +", UNIQUE(identityId,driveId,uniqueId)"
                    +", UNIQUE(identityId,driveId,globalTransitId)"
                    +", UNIQUE(identityId,hdrVersionTag)"
-                   +");"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,modified);"
+                   +") ;"
+                   +"CREATE INDEX IF NOT EXISTS Idx0TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,created,rowId);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,modified,rowId);"
+                   +"CREATE INDEX IF NOT EXISTS Idx2TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,userDate,rowId);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
@@ -444,10 +444,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
             else
-                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
-            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveMainIndex("

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
@@ -448,6 +448,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             else
                    rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveMainIndex("
                    +rowid
@@ -484,7 +485,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +", UNIQUE(identityId,driveId,uniqueId)"
                    +", UNIQUE(identityId,driveId,globalTransitId)"
                    +", UNIQUE(identityId,hdrVersionTag)"
-                   +") ;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,created,rowId);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,modified,rowId);"
                    +"CREATE INDEX IF NOT EXISTS Idx2TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,userDate,rowId);"

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class DriveMainIndexRecord
     {
-        private long _rowId;
-        public long rowId
+        private Int64 _rowId;
+        public Int64 rowId
         {
            get {
                    return _rowId;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
@@ -1511,5 +1511,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
+        protected virtual async Task<(List<DriveMainIndexRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,driveId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM driveMainIndex " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<DriveMainIndexRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCRUD.cs
@@ -485,9 +485,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +", UNIQUE(identityId,driveId,globalTransitId)"
                    +", UNIQUE(identityId,hdrVersionTag)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,created,rowId);"
-                   +"CREATE INDEX IF NOT EXISTS Idx1TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,modified,rowId);"
-                   +"CREATE INDEX IF NOT EXISTS Idx2TableDriveMainIndexCRUD ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,userDate,rowId);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0driveMainIndex ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,created,rowId);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1driveMainIndex ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,modified,rowId);"
+                   +"CREATE INDEX IF NOT EXISTS Idx2driveMainIndex ON driveMainIndex(identityId,driveId,fileSystemType,requiredSecurityGroup,userDate,rowId);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -1215,7 +1215,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected DriveMainIndexRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid? uniqueId)
+        protected DriveMainIndexRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid? uniqueId)
         {
             var result = new List<DriveMainIndexRecord>();
 #pragma warning disable CS0168
@@ -1262,7 +1262,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM driveMainIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND uniqueId = @uniqueId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND uniqueId = @uniqueId LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -1283,14 +1284,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,driveId,uniqueId);
+                        var r = ReadRecordFromReader0(rdr,identityId,driveId,uniqueId);
                         return r;
                     } // using
                 } //
             } // using
         }
 
-        protected DriveMainIndexRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid? globalTransitId)
+        protected DriveMainIndexRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid driveId,Guid? globalTransitId)
         {
             var result = new List<DriveMainIndexRecord>();
 #pragma warning disable CS0168
@@ -1337,7 +1338,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId,fileId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM driveMainIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND globalTransitId = @globalTransitId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND globalTransitId = @globalTransitId LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -1358,14 +1360,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,driveId,globalTransitId);
+                        var r = ReadRecordFromReader1(rdr,identityId,driveId,globalTransitId);
                         return r;
                     } // using
                 } //
             } // using
         }
 
-        protected DriveMainIndexRecord ReadRecordFromReader2(DbDataReader rdr, Guid identityId,Guid driveId)
+        protected DriveMainIndexRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,Guid driveId)
         {
             var result = new List<DriveMainIndexRecord>();
 #pragma warning disable CS0168
@@ -1412,7 +1414,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get2Command = cn.CreateCommand();
             {
                 get2Command.CommandText = "SELECT rowId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM driveMainIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId LIMIT 1;"+
+                                             ";";
                 var get2Param1 = get2Command.CreateParameter();
                 get2Param1.ParameterName = "@identityId";
                 get2Command.Parameters.Add(get2Param1);
@@ -1429,14 +1432,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader2(rdr, identityId,driveId);
+                        var r = ReadRecordFromReader2(rdr,identityId,driveId);
                         return r;
                     } // using
                 } //
             } // using
         }
 
-        protected DriveMainIndexRecord ReadRecordFromReader3(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId)
+        protected DriveMainIndexRecord ReadRecordFromReader3(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId)
         {
             var result = new List<DriveMainIndexRecord>();
 #pragma warning disable CS0168
@@ -1483,7 +1486,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get3Command = cn.CreateCommand();
             {
                 get3Command.CommandText = "SELECT rowId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM driveMainIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId LIMIT 1;"+
+                                             ";";
                 var get3Param1 = get3Command.CreateParameter();
                 get3Param1.ParameterName = "@identityId";
                 get3Command.Parameters.Add(get3Param1);
@@ -1504,7 +1508,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader3(rdr, identityId,driveId,fileId);
+                        var r = ReadRecordFromReader3(rdr,identityId,driveId,fileId);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexOldCRUD.cs
@@ -1,0 +1,1600 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class DriveMainIndexOldRecord
+    {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private Guid _fileId;
+        public Guid fileId
+        {
+           get {
+                   return _fileId;
+               }
+           set {
+                  _fileId = value;
+               }
+        }
+        private Guid? _globalTransitId;
+        public Guid? globalTransitId
+        {
+           get {
+                   return _globalTransitId;
+               }
+           set {
+                  _globalTransitId = value;
+               }
+        }
+        private Int32 _fileState;
+        public Int32 fileState
+        {
+           get {
+                   return _fileState;
+               }
+           set {
+                  _fileState = value;
+               }
+        }
+        private Int32 _requiredSecurityGroup;
+        public Int32 requiredSecurityGroup
+        {
+           get {
+                   return _requiredSecurityGroup;
+               }
+           set {
+                  _requiredSecurityGroup = value;
+               }
+        }
+        private Int32 _fileSystemType;
+        public Int32 fileSystemType
+        {
+           get {
+                   return _fileSystemType;
+               }
+           set {
+                  _fileSystemType = value;
+               }
+        }
+        private UnixTimeUtc _userDate;
+        public UnixTimeUtc userDate
+        {
+           get {
+                   return _userDate;
+               }
+           set {
+                  _userDate = value;
+               }
+        }
+        private Int32 _fileType;
+        public Int32 fileType
+        {
+           get {
+                   return _fileType;
+               }
+           set {
+                  _fileType = value;
+               }
+        }
+        private Int32 _dataType;
+        public Int32 dataType
+        {
+           get {
+                   return _dataType;
+               }
+           set {
+                  _dataType = value;
+               }
+        }
+        private Int32 _archivalStatus;
+        public Int32 archivalStatus
+        {
+           get {
+                   return _archivalStatus;
+               }
+           set {
+                  _archivalStatus = value;
+               }
+        }
+        private Int32 _historyStatus;
+        public Int32 historyStatus
+        {
+           get {
+                   return _historyStatus;
+               }
+           set {
+                  _historyStatus = value;
+               }
+        }
+        private string _senderId;
+        public string senderId
+        {
+           get {
+                   return _senderId;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _senderId = value;
+               }
+        }
+        internal string senderIdNoLengthCheck
+        {
+           get {
+                   return _senderId;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _senderId = value;
+               }
+        }
+        private Guid? _groupId;
+        public Guid? groupId
+        {
+           get {
+                   return _groupId;
+               }
+           set {
+                  _groupId = value;
+               }
+        }
+        private Guid? _uniqueId;
+        public Guid? uniqueId
+        {
+           get {
+                   return _uniqueId;
+               }
+           set {
+                  _uniqueId = value;
+               }
+        }
+        private Int64 _byteCount;
+        public Int64 byteCount
+        {
+           get {
+                   return _byteCount;
+               }
+           set {
+                  _byteCount = value;
+               }
+        }
+        private string _hdrEncryptedKeyHeader;
+        public string hdrEncryptedKeyHeader
+        {
+           get {
+                   return _hdrEncryptedKeyHeader;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 512) throw new Exception("Too long");
+                  _hdrEncryptedKeyHeader = value;
+               }
+        }
+        internal string hdrEncryptedKeyHeaderNoLengthCheck
+        {
+           get {
+                   return _hdrEncryptedKeyHeader;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _hdrEncryptedKeyHeader = value;
+               }
+        }
+        private Guid _hdrVersionTag;
+        public Guid hdrVersionTag
+        {
+           get {
+                   return _hdrVersionTag;
+               }
+           set {
+                  _hdrVersionTag = value;
+               }
+        }
+        private string _hdrAppData;
+        public string hdrAppData
+        {
+           get {
+                   return _hdrAppData;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 21504) throw new Exception("Too long");
+                  _hdrAppData = value;
+               }
+        }
+        internal string hdrAppDataNoLengthCheck
+        {
+           get {
+                   return _hdrAppData;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _hdrAppData = value;
+               }
+        }
+        private Guid? _hdrLocalVersionTag;
+        public Guid? hdrLocalVersionTag
+        {
+           get {
+                   return _hdrLocalVersionTag;
+               }
+           set {
+                  _hdrLocalVersionTag = value;
+               }
+        }
+        private string _hdrLocalAppData;
+        public string hdrLocalAppData
+        {
+           get {
+                   return _hdrLocalAppData;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 4096) throw new Exception("Too long");
+                  _hdrLocalAppData = value;
+               }
+        }
+        internal string hdrLocalAppDataNoLengthCheck
+        {
+           get {
+                   return _hdrLocalAppData;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _hdrLocalAppData = value;
+               }
+        }
+        private string _hdrReactionSummary;
+        public string hdrReactionSummary
+        {
+           get {
+                   return _hdrReactionSummary;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 4096) throw new Exception("Too long");
+                  _hdrReactionSummary = value;
+               }
+        }
+        internal string hdrReactionSummaryNoLengthCheck
+        {
+           get {
+                   return _hdrReactionSummary;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _hdrReactionSummary = value;
+               }
+        }
+        private string _hdrServerData;
+        public string hdrServerData
+        {
+           get {
+                   return _hdrServerData;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 16384) throw new Exception("Too long");
+                  _hdrServerData = value;
+               }
+        }
+        internal string hdrServerDataNoLengthCheck
+        {
+           get {
+                   return _hdrServerData;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _hdrServerData = value;
+               }
+        }
+        private string _hdrTransferHistory;
+        public string hdrTransferHistory
+        {
+           get {
+                   return _hdrTransferHistory;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 16384) throw new Exception("Too long");
+                  _hdrTransferHistory = value;
+               }
+        }
+        internal string hdrTransferHistoryNoLengthCheck
+        {
+           get {
+                   return _hdrTransferHistory;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _hdrTransferHistory = value;
+               }
+        }
+        private string _hdrFileMetaData;
+        public string hdrFileMetaData
+        {
+           get {
+                   return _hdrFileMetaData;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 16384) throw new Exception("Too long");
+                  _hdrFileMetaData = value;
+               }
+        }
+        internal string hdrFileMetaDataNoLengthCheck
+        {
+           get {
+                   return _hdrFileMetaData;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _hdrFileMetaData = value;
+               }
+        }
+        private Guid _hdrTmpDriveAlias;
+        public Guid hdrTmpDriveAlias
+        {
+           get {
+                   return _hdrTmpDriveAlias;
+               }
+           set {
+                  _hdrTmpDriveAlias = value;
+               }
+        }
+        private Guid _hdrTmpDriveType;
+        public Guid hdrTmpDriveType
+        {
+           get {
+                   return _hdrTmpDriveType;
+               }
+           set {
+                  _hdrTmpDriveType = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class DriveMainIndexOldRecord
+
+    public abstract class TableDriveMainIndexOldCRUD
+    {
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableDriveMainIndexOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS DriveMainIndexOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS DriveMainIndexOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL, "
+                   +"globalTransitId BYTEA , "
+                   +"fileState BIGINT NOT NULL, "
+                   +"requiredSecurityGroup BIGINT NOT NULL, "
+                   +"fileSystemType BIGINT NOT NULL, "
+                   +"userDate BIGINT NOT NULL, "
+                   +"fileType BIGINT NOT NULL, "
+                   +"dataType BIGINT NOT NULL, "
+                   +"archivalStatus BIGINT NOT NULL, "
+                   +"historyStatus BIGINT NOT NULL, "
+                   +"senderId TEXT , "
+                   +"groupId BYTEA , "
+                   +"uniqueId BYTEA , "
+                   +"byteCount BIGINT NOT NULL, "
+                   +"hdrEncryptedKeyHeader TEXT NOT NULL, "
+                   +"hdrVersionTag BYTEA NOT NULL, "
+                   +"hdrAppData TEXT NOT NULL, "
+                   +"hdrLocalVersionTag BYTEA , "
+                   +"hdrLocalAppData TEXT , "
+                   +"hdrReactionSummary TEXT , "
+                   +"hdrServerData TEXT NOT NULL, "
+                   +"hdrTransferHistory TEXT , "
+                   +"hdrFileMetaData TEXT NOT NULL, "
+                   +"hdrTmpDriveAlias BYTEA NOT NULL, "
+                   +"hdrTmpDriveType BYTEA NOT NULL, "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,driveId,fileId)"
+                   +", UNIQUE(identityId,driveId,uniqueId)"
+                   +", UNIQUE(identityId,driveId,globalTransitId)"
+                   +", UNIQUE(identityId,hdrVersionTag)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0DriveMainIndexOld ON DriveMainIndexOld(identityId,driveId,modified);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(DriveMainIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.globalTransitId.AssertGuidNotEmpty("Guid parameter globalTransitId cannot be set to Empty GUID.");
+            item.groupId.AssertGuidNotEmpty("Guid parameter groupId cannot be set to Empty GUID.");
+            item.uniqueId.AssertGuidNotEmpty("Guid parameter uniqueId cannot be set to Empty GUID.");
+            item.hdrVersionTag.AssertGuidNotEmpty("Guid parameter hdrVersionTag cannot be set to Empty GUID.");
+            item.hdrLocalVersionTag.AssertGuidNotEmpty("Guid parameter hdrLocalVersionTag cannot be set to Empty GUID.");
+            item.hdrTmpDriveAlias.AssertGuidNotEmpty("Guid parameter hdrTmpDriveAlias cannot be set to Empty GUID.");
+            item.hdrTmpDriveType.AssertGuidNotEmpty("Guid parameter hdrTmpDriveType cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveMainIndexOld (identityId,driveId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@globalTransitId,@fileState,@requiredSecurityGroup,@fileSystemType,@userDate,@fileType,@dataType,@archivalStatus,@historyStatus,@senderId,@groupId,@uniqueId,@byteCount,@hdrEncryptedKeyHeader,@hdrVersionTag,@hdrAppData,@hdrLocalVersionTag,@hdrLocalAppData,@hdrReactionSummary,@hdrServerData,@hdrTransferHistory,@hdrFileMetaData,@hdrTmpDriveAlias,@hdrTmpDriveType,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@globalTransitId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@fileState";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@requiredSecurityGroup";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@fileSystemType";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@userDate";
+                insertCommand.Parameters.Add(insertParam8);
+                var insertParam9 = insertCommand.CreateParameter();
+                insertParam9.ParameterName = "@fileType";
+                insertCommand.Parameters.Add(insertParam9);
+                var insertParam10 = insertCommand.CreateParameter();
+                insertParam10.ParameterName = "@dataType";
+                insertCommand.Parameters.Add(insertParam10);
+                var insertParam11 = insertCommand.CreateParameter();
+                insertParam11.ParameterName = "@archivalStatus";
+                insertCommand.Parameters.Add(insertParam11);
+                var insertParam12 = insertCommand.CreateParameter();
+                insertParam12.ParameterName = "@historyStatus";
+                insertCommand.Parameters.Add(insertParam12);
+                var insertParam13 = insertCommand.CreateParameter();
+                insertParam13.ParameterName = "@senderId";
+                insertCommand.Parameters.Add(insertParam13);
+                var insertParam14 = insertCommand.CreateParameter();
+                insertParam14.ParameterName = "@groupId";
+                insertCommand.Parameters.Add(insertParam14);
+                var insertParam15 = insertCommand.CreateParameter();
+                insertParam15.ParameterName = "@uniqueId";
+                insertCommand.Parameters.Add(insertParam15);
+                var insertParam16 = insertCommand.CreateParameter();
+                insertParam16.ParameterName = "@byteCount";
+                insertCommand.Parameters.Add(insertParam16);
+                var insertParam17 = insertCommand.CreateParameter();
+                insertParam17.ParameterName = "@hdrEncryptedKeyHeader";
+                insertCommand.Parameters.Add(insertParam17);
+                var insertParam18 = insertCommand.CreateParameter();
+                insertParam18.ParameterName = "@hdrVersionTag";
+                insertCommand.Parameters.Add(insertParam18);
+                var insertParam19 = insertCommand.CreateParameter();
+                insertParam19.ParameterName = "@hdrAppData";
+                insertCommand.Parameters.Add(insertParam19);
+                var insertParam20 = insertCommand.CreateParameter();
+                insertParam20.ParameterName = "@hdrLocalVersionTag";
+                insertCommand.Parameters.Add(insertParam20);
+                var insertParam21 = insertCommand.CreateParameter();
+                insertParam21.ParameterName = "@hdrLocalAppData";
+                insertCommand.Parameters.Add(insertParam21);
+                var insertParam22 = insertCommand.CreateParameter();
+                insertParam22.ParameterName = "@hdrReactionSummary";
+                insertCommand.Parameters.Add(insertParam22);
+                var insertParam23 = insertCommand.CreateParameter();
+                insertParam23.ParameterName = "@hdrServerData";
+                insertCommand.Parameters.Add(insertParam23);
+                var insertParam24 = insertCommand.CreateParameter();
+                insertParam24.ParameterName = "@hdrTransferHistory";
+                insertCommand.Parameters.Add(insertParam24);
+                var insertParam25 = insertCommand.CreateParameter();
+                insertParam25.ParameterName = "@hdrFileMetaData";
+                insertCommand.Parameters.Add(insertParam25);
+                var insertParam26 = insertCommand.CreateParameter();
+                insertParam26.ParameterName = "@hdrTmpDriveAlias";
+                insertCommand.Parameters.Add(insertParam26);
+                var insertParam27 = insertCommand.CreateParameter();
+                insertParam27.ParameterName = "@hdrTmpDriveType";
+                insertCommand.Parameters.Add(insertParam27);
+                var insertParam28 = insertCommand.CreateParameter();
+                insertParam28.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam28);
+                var insertParam29 = insertCommand.CreateParameter();
+                insertParam29.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam29);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.globalTransitId?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam5.Value = item.fileState;
+                insertParam6.Value = item.requiredSecurityGroup;
+                insertParam7.Value = item.fileSystemType;
+                insertParam8.Value = item.userDate.milliseconds;
+                insertParam9.Value = item.fileType;
+                insertParam10.Value = item.dataType;
+                insertParam11.Value = item.archivalStatus;
+                insertParam12.Value = item.historyStatus;
+                insertParam13.Value = item.senderId ?? (object)DBNull.Value;
+                insertParam14.Value = item.groupId?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam15.Value = item.uniqueId?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam16.Value = item.byteCount;
+                insertParam17.Value = item.hdrEncryptedKeyHeader;
+                insertParam18.Value = item.hdrVersionTag.ToByteArray();
+                insertParam19.Value = item.hdrAppData;
+                insertParam20.Value = item.hdrLocalVersionTag?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam21.Value = item.hdrLocalAppData ?? (object)DBNull.Value;
+                insertParam22.Value = item.hdrReactionSummary ?? (object)DBNull.Value;
+                insertParam23.Value = item.hdrServerData;
+                insertParam24.Value = item.hdrTransferHistory ?? (object)DBNull.Value;
+                insertParam25.Value = item.hdrFileMetaData;
+                insertParam26.Value = item.hdrTmpDriveAlias.ToByteArray();
+                insertParam27.Value = item.hdrTmpDriveType.ToByteArray();
+                var now = UnixTimeUtc.Now();
+                insertParam28.Value = now.milliseconds;
+                item.modified = null;
+                insertParam29.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.created = now;
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DriveMainIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.globalTransitId.AssertGuidNotEmpty("Guid parameter globalTransitId cannot be set to Empty GUID.");
+            item.groupId.AssertGuidNotEmpty("Guid parameter groupId cannot be set to Empty GUID.");
+            item.uniqueId.AssertGuidNotEmpty("Guid parameter uniqueId cannot be set to Empty GUID.");
+            item.hdrVersionTag.AssertGuidNotEmpty("Guid parameter hdrVersionTag cannot be set to Empty GUID.");
+            item.hdrLocalVersionTag.AssertGuidNotEmpty("Guid parameter hdrLocalVersionTag cannot be set to Empty GUID.");
+            item.hdrTmpDriveAlias.AssertGuidNotEmpty("Guid parameter hdrTmpDriveAlias cannot be set to Empty GUID.");
+            item.hdrTmpDriveType.AssertGuidNotEmpty("Guid parameter hdrTmpDriveType cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveMainIndexOld (identityId,driveId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@globalTransitId,@fileState,@requiredSecurityGroup,@fileSystemType,@userDate,@fileType,@dataType,@archivalStatus,@historyStatus,@senderId,@groupId,@uniqueId,@byteCount,@hdrEncryptedKeyHeader,@hdrVersionTag,@hdrAppData,@hdrLocalVersionTag,@hdrLocalAppData,@hdrReactionSummary,@hdrServerData,@hdrTransferHistory,@hdrFileMetaData,@hdrTmpDriveAlias,@hdrTmpDriveType,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@globalTransitId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@fileState";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@requiredSecurityGroup";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@fileSystemType";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@userDate";
+                insertCommand.Parameters.Add(insertParam8);
+                var insertParam9 = insertCommand.CreateParameter();
+                insertParam9.ParameterName = "@fileType";
+                insertCommand.Parameters.Add(insertParam9);
+                var insertParam10 = insertCommand.CreateParameter();
+                insertParam10.ParameterName = "@dataType";
+                insertCommand.Parameters.Add(insertParam10);
+                var insertParam11 = insertCommand.CreateParameter();
+                insertParam11.ParameterName = "@archivalStatus";
+                insertCommand.Parameters.Add(insertParam11);
+                var insertParam12 = insertCommand.CreateParameter();
+                insertParam12.ParameterName = "@historyStatus";
+                insertCommand.Parameters.Add(insertParam12);
+                var insertParam13 = insertCommand.CreateParameter();
+                insertParam13.ParameterName = "@senderId";
+                insertCommand.Parameters.Add(insertParam13);
+                var insertParam14 = insertCommand.CreateParameter();
+                insertParam14.ParameterName = "@groupId";
+                insertCommand.Parameters.Add(insertParam14);
+                var insertParam15 = insertCommand.CreateParameter();
+                insertParam15.ParameterName = "@uniqueId";
+                insertCommand.Parameters.Add(insertParam15);
+                var insertParam16 = insertCommand.CreateParameter();
+                insertParam16.ParameterName = "@byteCount";
+                insertCommand.Parameters.Add(insertParam16);
+                var insertParam17 = insertCommand.CreateParameter();
+                insertParam17.ParameterName = "@hdrEncryptedKeyHeader";
+                insertCommand.Parameters.Add(insertParam17);
+                var insertParam18 = insertCommand.CreateParameter();
+                insertParam18.ParameterName = "@hdrVersionTag";
+                insertCommand.Parameters.Add(insertParam18);
+                var insertParam19 = insertCommand.CreateParameter();
+                insertParam19.ParameterName = "@hdrAppData";
+                insertCommand.Parameters.Add(insertParam19);
+                var insertParam20 = insertCommand.CreateParameter();
+                insertParam20.ParameterName = "@hdrLocalVersionTag";
+                insertCommand.Parameters.Add(insertParam20);
+                var insertParam21 = insertCommand.CreateParameter();
+                insertParam21.ParameterName = "@hdrLocalAppData";
+                insertCommand.Parameters.Add(insertParam21);
+                var insertParam22 = insertCommand.CreateParameter();
+                insertParam22.ParameterName = "@hdrReactionSummary";
+                insertCommand.Parameters.Add(insertParam22);
+                var insertParam23 = insertCommand.CreateParameter();
+                insertParam23.ParameterName = "@hdrServerData";
+                insertCommand.Parameters.Add(insertParam23);
+                var insertParam24 = insertCommand.CreateParameter();
+                insertParam24.ParameterName = "@hdrTransferHistory";
+                insertCommand.Parameters.Add(insertParam24);
+                var insertParam25 = insertCommand.CreateParameter();
+                insertParam25.ParameterName = "@hdrFileMetaData";
+                insertCommand.Parameters.Add(insertParam25);
+                var insertParam26 = insertCommand.CreateParameter();
+                insertParam26.ParameterName = "@hdrTmpDriveAlias";
+                insertCommand.Parameters.Add(insertParam26);
+                var insertParam27 = insertCommand.CreateParameter();
+                insertParam27.ParameterName = "@hdrTmpDriveType";
+                insertCommand.Parameters.Add(insertParam27);
+                var insertParam28 = insertCommand.CreateParameter();
+                insertParam28.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam28);
+                var insertParam29 = insertCommand.CreateParameter();
+                insertParam29.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam29);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.globalTransitId?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam5.Value = item.fileState;
+                insertParam6.Value = item.requiredSecurityGroup;
+                insertParam7.Value = item.fileSystemType;
+                insertParam8.Value = item.userDate.milliseconds;
+                insertParam9.Value = item.fileType;
+                insertParam10.Value = item.dataType;
+                insertParam11.Value = item.archivalStatus;
+                insertParam12.Value = item.historyStatus;
+                insertParam13.Value = item.senderId ?? (object)DBNull.Value;
+                insertParam14.Value = item.groupId?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam15.Value = item.uniqueId?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam16.Value = item.byteCount;
+                insertParam17.Value = item.hdrEncryptedKeyHeader;
+                insertParam18.Value = item.hdrVersionTag.ToByteArray();
+                insertParam19.Value = item.hdrAppData;
+                insertParam20.Value = item.hdrLocalVersionTag?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam21.Value = item.hdrLocalAppData ?? (object)DBNull.Value;
+                insertParam22.Value = item.hdrReactionSummary ?? (object)DBNull.Value;
+                insertParam23.Value = item.hdrServerData;
+                insertParam24.Value = item.hdrTransferHistory ?? (object)DBNull.Value;
+                insertParam25.Value = item.hdrFileMetaData;
+                insertParam26.Value = item.hdrTmpDriveAlias.ToByteArray();
+                insertParam27.Value = item.hdrTmpDriveType.ToByteArray();
+                var now = UnixTimeUtc.Now();
+                insertParam28.Value = now.milliseconds;
+                item.modified = null;
+                insertParam29.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    item.created = now;
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DriveMainIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.globalTransitId.AssertGuidNotEmpty("Guid parameter globalTransitId cannot be set to Empty GUID.");
+            item.groupId.AssertGuidNotEmpty("Guid parameter groupId cannot be set to Empty GUID.");
+            item.uniqueId.AssertGuidNotEmpty("Guid parameter uniqueId cannot be set to Empty GUID.");
+            item.hdrVersionTag.AssertGuidNotEmpty("Guid parameter hdrVersionTag cannot be set to Empty GUID.");
+            item.hdrLocalVersionTag.AssertGuidNotEmpty("Guid parameter hdrLocalVersionTag cannot be set to Empty GUID.");
+            item.hdrTmpDriveAlias.AssertGuidNotEmpty("Guid parameter hdrTmpDriveAlias cannot be set to Empty GUID.");
+            item.hdrTmpDriveType.AssertGuidNotEmpty("Guid parameter hdrTmpDriveType cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO DriveMainIndexOld (identityId,driveId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@globalTransitId,@fileState,@requiredSecurityGroup,@fileSystemType,@userDate,@fileType,@dataType,@archivalStatus,@historyStatus,@senderId,@groupId,@uniqueId,@byteCount,@hdrEncryptedKeyHeader,@hdrVersionTag,@hdrAppData,@hdrLocalVersionTag,@hdrLocalAppData,@hdrReactionSummary,@hdrServerData,@hdrTransferHistory,@hdrFileMetaData,@hdrTmpDriveAlias,@hdrTmpDriveType,@created)"+
+                                             "ON CONFLICT (identityId,driveId,fileId) DO UPDATE "+
+                                             "SET globalTransitId = @globalTransitId,fileState = @fileState,requiredSecurityGroup = @requiredSecurityGroup,fileSystemType = @fileSystemType,userDate = @userDate,fileType = @fileType,dataType = @dataType,archivalStatus = @archivalStatus,historyStatus = @historyStatus,senderId = @senderId,groupId = @groupId,uniqueId = @uniqueId,byteCount = @byteCount,hdrEncryptedKeyHeader = @hdrEncryptedKeyHeader,hdrVersionTag = @hdrVersionTag,hdrAppData = @hdrAppData,hdrLocalVersionTag = @hdrLocalVersionTag,hdrLocalAppData = @hdrLocalAppData,hdrReactionSummary = @hdrReactionSummary,hdrServerData = @hdrServerData,hdrTransferHistory = @hdrTransferHistory,hdrFileMetaData = @hdrFileMetaData,hdrTmpDriveAlias = @hdrTmpDriveAlias,hdrTmpDriveType = @hdrTmpDriveType,modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@fileId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@globalTransitId";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@fileState";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@requiredSecurityGroup";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@fileSystemType";
+                upsertCommand.Parameters.Add(upsertParam7);
+                var upsertParam8 = upsertCommand.CreateParameter();
+                upsertParam8.ParameterName = "@userDate";
+                upsertCommand.Parameters.Add(upsertParam8);
+                var upsertParam9 = upsertCommand.CreateParameter();
+                upsertParam9.ParameterName = "@fileType";
+                upsertCommand.Parameters.Add(upsertParam9);
+                var upsertParam10 = upsertCommand.CreateParameter();
+                upsertParam10.ParameterName = "@dataType";
+                upsertCommand.Parameters.Add(upsertParam10);
+                var upsertParam11 = upsertCommand.CreateParameter();
+                upsertParam11.ParameterName = "@archivalStatus";
+                upsertCommand.Parameters.Add(upsertParam11);
+                var upsertParam12 = upsertCommand.CreateParameter();
+                upsertParam12.ParameterName = "@historyStatus";
+                upsertCommand.Parameters.Add(upsertParam12);
+                var upsertParam13 = upsertCommand.CreateParameter();
+                upsertParam13.ParameterName = "@senderId";
+                upsertCommand.Parameters.Add(upsertParam13);
+                var upsertParam14 = upsertCommand.CreateParameter();
+                upsertParam14.ParameterName = "@groupId";
+                upsertCommand.Parameters.Add(upsertParam14);
+                var upsertParam15 = upsertCommand.CreateParameter();
+                upsertParam15.ParameterName = "@uniqueId";
+                upsertCommand.Parameters.Add(upsertParam15);
+                var upsertParam16 = upsertCommand.CreateParameter();
+                upsertParam16.ParameterName = "@byteCount";
+                upsertCommand.Parameters.Add(upsertParam16);
+                var upsertParam17 = upsertCommand.CreateParameter();
+                upsertParam17.ParameterName = "@hdrEncryptedKeyHeader";
+                upsertCommand.Parameters.Add(upsertParam17);
+                var upsertParam18 = upsertCommand.CreateParameter();
+                upsertParam18.ParameterName = "@hdrVersionTag";
+                upsertCommand.Parameters.Add(upsertParam18);
+                var upsertParam19 = upsertCommand.CreateParameter();
+                upsertParam19.ParameterName = "@hdrAppData";
+                upsertCommand.Parameters.Add(upsertParam19);
+                var upsertParam20 = upsertCommand.CreateParameter();
+                upsertParam20.ParameterName = "@hdrLocalVersionTag";
+                upsertCommand.Parameters.Add(upsertParam20);
+                var upsertParam21 = upsertCommand.CreateParameter();
+                upsertParam21.ParameterName = "@hdrLocalAppData";
+                upsertCommand.Parameters.Add(upsertParam21);
+                var upsertParam22 = upsertCommand.CreateParameter();
+                upsertParam22.ParameterName = "@hdrReactionSummary";
+                upsertCommand.Parameters.Add(upsertParam22);
+                var upsertParam23 = upsertCommand.CreateParameter();
+                upsertParam23.ParameterName = "@hdrServerData";
+                upsertCommand.Parameters.Add(upsertParam23);
+                var upsertParam24 = upsertCommand.CreateParameter();
+                upsertParam24.ParameterName = "@hdrTransferHistory";
+                upsertCommand.Parameters.Add(upsertParam24);
+                var upsertParam25 = upsertCommand.CreateParameter();
+                upsertParam25.ParameterName = "@hdrFileMetaData";
+                upsertCommand.Parameters.Add(upsertParam25);
+                var upsertParam26 = upsertCommand.CreateParameter();
+                upsertParam26.ParameterName = "@hdrTmpDriveAlias";
+                upsertCommand.Parameters.Add(upsertParam26);
+                var upsertParam27 = upsertCommand.CreateParameter();
+                upsertParam27.ParameterName = "@hdrTmpDriveType";
+                upsertCommand.Parameters.Add(upsertParam27);
+                var upsertParam28 = upsertCommand.CreateParameter();
+                upsertParam28.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam28);
+                var upsertParam29 = upsertCommand.CreateParameter();
+                upsertParam29.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam29);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.driveId.ToByteArray();
+                upsertParam3.Value = item.fileId.ToByteArray();
+                upsertParam4.Value = item.globalTransitId?.ToByteArray() ?? (object)DBNull.Value;
+                upsertParam5.Value = item.fileState;
+                upsertParam6.Value = item.requiredSecurityGroup;
+                upsertParam7.Value = item.fileSystemType;
+                upsertParam8.Value = item.userDate.milliseconds;
+                upsertParam9.Value = item.fileType;
+                upsertParam10.Value = item.dataType;
+                upsertParam11.Value = item.archivalStatus;
+                upsertParam12.Value = item.historyStatus;
+                upsertParam13.Value = item.senderId ?? (object)DBNull.Value;
+                upsertParam14.Value = item.groupId?.ToByteArray() ?? (object)DBNull.Value;
+                upsertParam15.Value = item.uniqueId?.ToByteArray() ?? (object)DBNull.Value;
+                upsertParam16.Value = item.byteCount;
+                upsertParam17.Value = item.hdrEncryptedKeyHeader;
+                upsertParam18.Value = item.hdrVersionTag.ToByteArray();
+                upsertParam19.Value = item.hdrAppData;
+                upsertParam20.Value = item.hdrLocalVersionTag?.ToByteArray() ?? (object)DBNull.Value;
+                upsertParam21.Value = item.hdrLocalAppData ?? (object)DBNull.Value;
+                upsertParam22.Value = item.hdrReactionSummary ?? (object)DBNull.Value;
+                upsertParam23.Value = item.hdrServerData;
+                upsertParam24.Value = item.hdrTransferHistory ?? (object)DBNull.Value;
+                upsertParam25.Value = item.hdrFileMetaData;
+                upsertParam26.Value = item.hdrTmpDriveAlias.ToByteArray();
+                upsertParam27.Value = item.hdrTmpDriveType.ToByteArray();
+                upsertParam28.Value = now.milliseconds;
+                upsertParam29.Value = now.milliseconds;
+                await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(DriveMainIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.globalTransitId.AssertGuidNotEmpty("Guid parameter globalTransitId cannot be set to Empty GUID.");
+            item.groupId.AssertGuidNotEmpty("Guid parameter groupId cannot be set to Empty GUID.");
+            item.uniqueId.AssertGuidNotEmpty("Guid parameter uniqueId cannot be set to Empty GUID.");
+            item.hdrVersionTag.AssertGuidNotEmpty("Guid parameter hdrVersionTag cannot be set to Empty GUID.");
+            item.hdrLocalVersionTag.AssertGuidNotEmpty("Guid parameter hdrLocalVersionTag cannot be set to Empty GUID.");
+            item.hdrTmpDriveAlias.AssertGuidNotEmpty("Guid parameter hdrTmpDriveAlias cannot be set to Empty GUID.");
+            item.hdrTmpDriveType.AssertGuidNotEmpty("Guid parameter hdrTmpDriveType cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE DriveMainIndexOld " +
+                                             "SET globalTransitId = @globalTransitId,fileState = @fileState,requiredSecurityGroup = @requiredSecurityGroup,fileSystemType = @fileSystemType,userDate = @userDate,fileType = @fileType,dataType = @dataType,archivalStatus = @archivalStatus,historyStatus = @historyStatus,senderId = @senderId,groupId = @groupId,uniqueId = @uniqueId,byteCount = @byteCount,hdrEncryptedKeyHeader = @hdrEncryptedKeyHeader,hdrVersionTag = @hdrVersionTag,hdrAppData = @hdrAppData,hdrLocalVersionTag = @hdrLocalVersionTag,hdrLocalAppData = @hdrLocalAppData,hdrReactionSummary = @hdrReactionSummary,hdrServerData = @hdrServerData,hdrTransferHistory = @hdrTransferHistory,hdrFileMetaData = @hdrFileMetaData,hdrTmpDriveAlias = @hdrTmpDriveAlias,hdrTmpDriveType = @hdrTmpDriveType,modified = @modified "+
+                                             "WHERE (identityId = @identityId AND driveId = @driveId AND fileId = @fileId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@fileId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@globalTransitId";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@fileState";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@requiredSecurityGroup";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@fileSystemType";
+                updateCommand.Parameters.Add(updateParam7);
+                var updateParam8 = updateCommand.CreateParameter();
+                updateParam8.ParameterName = "@userDate";
+                updateCommand.Parameters.Add(updateParam8);
+                var updateParam9 = updateCommand.CreateParameter();
+                updateParam9.ParameterName = "@fileType";
+                updateCommand.Parameters.Add(updateParam9);
+                var updateParam10 = updateCommand.CreateParameter();
+                updateParam10.ParameterName = "@dataType";
+                updateCommand.Parameters.Add(updateParam10);
+                var updateParam11 = updateCommand.CreateParameter();
+                updateParam11.ParameterName = "@archivalStatus";
+                updateCommand.Parameters.Add(updateParam11);
+                var updateParam12 = updateCommand.CreateParameter();
+                updateParam12.ParameterName = "@historyStatus";
+                updateCommand.Parameters.Add(updateParam12);
+                var updateParam13 = updateCommand.CreateParameter();
+                updateParam13.ParameterName = "@senderId";
+                updateCommand.Parameters.Add(updateParam13);
+                var updateParam14 = updateCommand.CreateParameter();
+                updateParam14.ParameterName = "@groupId";
+                updateCommand.Parameters.Add(updateParam14);
+                var updateParam15 = updateCommand.CreateParameter();
+                updateParam15.ParameterName = "@uniqueId";
+                updateCommand.Parameters.Add(updateParam15);
+                var updateParam16 = updateCommand.CreateParameter();
+                updateParam16.ParameterName = "@byteCount";
+                updateCommand.Parameters.Add(updateParam16);
+                var updateParam17 = updateCommand.CreateParameter();
+                updateParam17.ParameterName = "@hdrEncryptedKeyHeader";
+                updateCommand.Parameters.Add(updateParam17);
+                var updateParam18 = updateCommand.CreateParameter();
+                updateParam18.ParameterName = "@hdrVersionTag";
+                updateCommand.Parameters.Add(updateParam18);
+                var updateParam19 = updateCommand.CreateParameter();
+                updateParam19.ParameterName = "@hdrAppData";
+                updateCommand.Parameters.Add(updateParam19);
+                var updateParam20 = updateCommand.CreateParameter();
+                updateParam20.ParameterName = "@hdrLocalVersionTag";
+                updateCommand.Parameters.Add(updateParam20);
+                var updateParam21 = updateCommand.CreateParameter();
+                updateParam21.ParameterName = "@hdrLocalAppData";
+                updateCommand.Parameters.Add(updateParam21);
+                var updateParam22 = updateCommand.CreateParameter();
+                updateParam22.ParameterName = "@hdrReactionSummary";
+                updateCommand.Parameters.Add(updateParam22);
+                var updateParam23 = updateCommand.CreateParameter();
+                updateParam23.ParameterName = "@hdrServerData";
+                updateCommand.Parameters.Add(updateParam23);
+                var updateParam24 = updateCommand.CreateParameter();
+                updateParam24.ParameterName = "@hdrTransferHistory";
+                updateCommand.Parameters.Add(updateParam24);
+                var updateParam25 = updateCommand.CreateParameter();
+                updateParam25.ParameterName = "@hdrFileMetaData";
+                updateCommand.Parameters.Add(updateParam25);
+                var updateParam26 = updateCommand.CreateParameter();
+                updateParam26.ParameterName = "@hdrTmpDriveAlias";
+                updateCommand.Parameters.Add(updateParam26);
+                var updateParam27 = updateCommand.CreateParameter();
+                updateParam27.ParameterName = "@hdrTmpDriveType";
+                updateCommand.Parameters.Add(updateParam27);
+                var updateParam28 = updateCommand.CreateParameter();
+                updateParam28.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam28);
+                var updateParam29 = updateCommand.CreateParameter();
+                updateParam29.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam29);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.driveId.ToByteArray();
+                updateParam3.Value = item.fileId.ToByteArray();
+                updateParam4.Value = item.globalTransitId?.ToByteArray() ?? (object)DBNull.Value;
+                updateParam5.Value = item.fileState;
+                updateParam6.Value = item.requiredSecurityGroup;
+                updateParam7.Value = item.fileSystemType;
+                updateParam8.Value = item.userDate.milliseconds;
+                updateParam9.Value = item.fileType;
+                updateParam10.Value = item.dataType;
+                updateParam11.Value = item.archivalStatus;
+                updateParam12.Value = item.historyStatus;
+                updateParam13.Value = item.senderId ?? (object)DBNull.Value;
+                updateParam14.Value = item.groupId?.ToByteArray() ?? (object)DBNull.Value;
+                updateParam15.Value = item.uniqueId?.ToByteArray() ?? (object)DBNull.Value;
+                updateParam16.Value = item.byteCount;
+                updateParam17.Value = item.hdrEncryptedKeyHeader;
+                updateParam18.Value = item.hdrVersionTag.ToByteArray();
+                updateParam19.Value = item.hdrAppData;
+                updateParam20.Value = item.hdrLocalVersionTag?.ToByteArray() ?? (object)DBNull.Value;
+                updateParam21.Value = item.hdrLocalAppData ?? (object)DBNull.Value;
+                updateParam22.Value = item.hdrReactionSummary ?? (object)DBNull.Value;
+                updateParam23.Value = item.hdrServerData;
+                updateParam24.Value = item.hdrTransferHistory ?? (object)DBNull.Value;
+                updateParam25.Value = item.hdrFileMetaData;
+                updateParam26.Value = item.hdrTmpDriveAlias.ToByteArray();
+                updateParam27.Value = item.hdrTmpDriveType.ToByteArray();
+                updateParam28.Value = now.milliseconds;
+                updateParam29.Value = now.milliseconds;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.modified = now;
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE driveMainIndex RENAME TO DriveMainIndexOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM DriveMainIndexOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("rowId");
+            sl.Add("identityId");
+            sl.Add("driveId");
+            sl.Add("fileId");
+            sl.Add("globalTransitId");
+            sl.Add("fileState");
+            sl.Add("requiredSecurityGroup");
+            sl.Add("fileSystemType");
+            sl.Add("userDate");
+            sl.Add("fileType");
+            sl.Add("dataType");
+            sl.Add("archivalStatus");
+            sl.Add("historyStatus");
+            sl.Add("senderId");
+            sl.Add("groupId");
+            sl.Add("uniqueId");
+            sl.Add("byteCount");
+            sl.Add("hdrEncryptedKeyHeader");
+            sl.Add("hdrVersionTag");
+            sl.Add("hdrAppData");
+            sl.Add("hdrLocalVersionTag");
+            sl.Add("hdrLocalAppData");
+            sl.Add("hdrReactionSummary");
+            sl.Add("hdrServerData");
+            sl.Add("hdrTransferHistory");
+            sl.Add("hdrFileMetaData");
+            sl.Add("hdrTmpDriveAlias");
+            sl.Add("hdrTmpDriveType");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        public virtual async Task<int> GetDriveCountAsync(Guid driveId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountDriveCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountDriveCommand.CommandText = "SELECT COUNT(*) FROM DriveMainIndexOld WHERE driveId = $driveId;";
+                var getCountDriveParam1 = getCountDriveCommand.CreateParameter();
+                getCountDriveParam1.ParameterName = "$driveId";
+                getCountDriveCommand.Parameters.Add(getCountDriveParam1);
+                getCountDriveParam1.Value = driveId.ToByteArray();
+                var count = await getCountDriveCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            } // using
+        }
+
+        // SELECT rowId,identityId,driveId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified
+        public DriveMainIndexOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<DriveMainIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveMainIndexOldRecord();
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.fileId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.globalTransitId = (rdr[4] == DBNull.Value) ? null : new Guid((byte[])rdr[4]);
+            item.fileState = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.requiredSecurityGroup = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.fileSystemType = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[7];
+            item.userDate = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[8]);
+            item.fileType = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[9];
+            item.dataType = (rdr[10] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[10];
+            item.archivalStatus = (rdr[11] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[11];
+            item.historyStatus = (rdr[12] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[12];
+            item.senderIdNoLengthCheck = (rdr[13] == DBNull.Value) ? null : (string)rdr[13];
+            item.groupId = (rdr[14] == DBNull.Value) ? null : new Guid((byte[])rdr[14]);
+            item.uniqueId = (rdr[15] == DBNull.Value) ? null : new Guid((byte[])rdr[15]);
+            item.byteCount = (rdr[16] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[16];
+            item.hdrEncryptedKeyHeaderNoLengthCheck = (rdr[17] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[17];
+            item.hdrVersionTag = (rdr[18] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[18]);
+            item.hdrAppDataNoLengthCheck = (rdr[19] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[19];
+            item.hdrLocalVersionTag = (rdr[20] == DBNull.Value) ? null : new Guid((byte[])rdr[20]);
+            item.hdrLocalAppDataNoLengthCheck = (rdr[21] == DBNull.Value) ? null : (string)rdr[21];
+            item.hdrReactionSummaryNoLengthCheck = (rdr[22] == DBNull.Value) ? null : (string)rdr[22];
+            item.hdrServerDataNoLengthCheck = (rdr[23] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[23];
+            item.hdrTransferHistoryNoLengthCheck = (rdr[24] == DBNull.Value) ? null : (string)rdr[24];
+            item.hdrFileMetaDataNoLengthCheck = (rdr[25] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[25];
+            item.hdrTmpDriveAlias = (rdr[26] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[26]);
+            item.hdrTmpDriveType = (rdr[27] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[27]);
+            item.created = (rdr[28] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[28]);
+            item.modified = (rdr[29] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[29]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM DriveMainIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@fileId";
+                delete0Command.Parameters.Add(delete0Param3);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = driveId.ToByteArray();
+                delete0Param3.Value = fileId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public DriveMainIndexOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid? uniqueId)
+        {
+            var result = new List<DriveMainIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveMainIndexOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.uniqueId = uniqueId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.fileId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.globalTransitId = (rdr[2] == DBNull.Value) ? null : new Guid((byte[])rdr[2]);
+            item.fileState = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.requiredSecurityGroup = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.fileSystemType = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.userDate = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[6]);
+            item.fileType = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[7];
+            item.dataType = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[8];
+            item.archivalStatus = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[9];
+            item.historyStatus = (rdr[10] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[10];
+            item.senderIdNoLengthCheck = (rdr[11] == DBNull.Value) ? null : (string)rdr[11];
+            item.groupId = (rdr[12] == DBNull.Value) ? null : new Guid((byte[])rdr[12]);
+            item.byteCount = (rdr[13] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[13];
+            item.hdrEncryptedKeyHeaderNoLengthCheck = (rdr[14] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[14];
+            item.hdrVersionTag = (rdr[15] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[15]);
+            item.hdrAppDataNoLengthCheck = (rdr[16] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[16];
+            item.hdrLocalVersionTag = (rdr[17] == DBNull.Value) ? null : new Guid((byte[])rdr[17]);
+            item.hdrLocalAppDataNoLengthCheck = (rdr[18] == DBNull.Value) ? null : (string)rdr[18];
+            item.hdrReactionSummaryNoLengthCheck = (rdr[19] == DBNull.Value) ? null : (string)rdr[19];
+            item.hdrServerDataNoLengthCheck = (rdr[20] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[20];
+            item.hdrTransferHistoryNoLengthCheck = (rdr[21] == DBNull.Value) ? null : (string)rdr[21];
+            item.hdrFileMetaDataNoLengthCheck = (rdr[22] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[22];
+            item.hdrTmpDriveAlias = (rdr[23] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[23]);
+            item.hdrTmpDriveType = (rdr[24] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[24]);
+            item.created = (rdr[25] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[25]);
+            item.modified = (rdr[26] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[26]);
+            return item;
+       }
+
+        public virtual async Task<DriveMainIndexOldRecord> GetByUniqueIdAsync(Guid identityId,Guid driveId,Guid? uniqueId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT rowId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM DriveMainIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND uniqueId = @uniqueId LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@driveId";
+                get0Command.Parameters.Add(get0Param2);
+                var get0Param3 = get0Command.CreateParameter();
+                get0Param3.ParameterName = "@uniqueId";
+                get0Command.Parameters.Add(get0Param3);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = driveId.ToByteArray();
+                get0Param3.Value = uniqueId?.ToByteArray() ?? (object)DBNull.Value;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,identityId,driveId,uniqueId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveMainIndexOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid driveId,Guid? globalTransitId)
+        {
+            var result = new List<DriveMainIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveMainIndexOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.globalTransitId = globalTransitId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.fileId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileState = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
+            item.requiredSecurityGroup = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.fileSystemType = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.userDate = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
+            item.fileType = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.dataType = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[7];
+            item.archivalStatus = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[8];
+            item.historyStatus = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[9];
+            item.senderIdNoLengthCheck = (rdr[10] == DBNull.Value) ? null : (string)rdr[10];
+            item.groupId = (rdr[11] == DBNull.Value) ? null : new Guid((byte[])rdr[11]);
+            item.uniqueId = (rdr[12] == DBNull.Value) ? null : new Guid((byte[])rdr[12]);
+            item.byteCount = (rdr[13] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[13];
+            item.hdrEncryptedKeyHeaderNoLengthCheck = (rdr[14] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[14];
+            item.hdrVersionTag = (rdr[15] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[15]);
+            item.hdrAppDataNoLengthCheck = (rdr[16] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[16];
+            item.hdrLocalVersionTag = (rdr[17] == DBNull.Value) ? null : new Guid((byte[])rdr[17]);
+            item.hdrLocalAppDataNoLengthCheck = (rdr[18] == DBNull.Value) ? null : (string)rdr[18];
+            item.hdrReactionSummaryNoLengthCheck = (rdr[19] == DBNull.Value) ? null : (string)rdr[19];
+            item.hdrServerDataNoLengthCheck = (rdr[20] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[20];
+            item.hdrTransferHistoryNoLengthCheck = (rdr[21] == DBNull.Value) ? null : (string)rdr[21];
+            item.hdrFileMetaDataNoLengthCheck = (rdr[22] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[22];
+            item.hdrTmpDriveAlias = (rdr[23] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[23]);
+            item.hdrTmpDriveType = (rdr[24] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[24]);
+            item.created = (rdr[25] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[25]);
+            item.modified = (rdr[26] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[26]);
+            return item;
+       }
+
+        public virtual async Task<DriveMainIndexOldRecord> GetByGlobalTransitIdAsync(Guid identityId,Guid driveId,Guid? globalTransitId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT rowId,fileId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM DriveMainIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND globalTransitId = @globalTransitId LIMIT 1;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@globalTransitId";
+                get1Command.Parameters.Add(get1Param3);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = driveId.ToByteArray();
+                get1Param3.Value = globalTransitId?.ToByteArray() ?? (object)DBNull.Value;
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr,identityId,driveId,globalTransitId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveMainIndexOldRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,Guid driveId)
+        {
+            var result = new List<DriveMainIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveMainIndexOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.fileId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.globalTransitId = (rdr[2] == DBNull.Value) ? null : new Guid((byte[])rdr[2]);
+            item.fileState = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.requiredSecurityGroup = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.fileSystemType = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.userDate = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[6]);
+            item.fileType = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[7];
+            item.dataType = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[8];
+            item.archivalStatus = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[9];
+            item.historyStatus = (rdr[10] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[10];
+            item.senderIdNoLengthCheck = (rdr[11] == DBNull.Value) ? null : (string)rdr[11];
+            item.groupId = (rdr[12] == DBNull.Value) ? null : new Guid((byte[])rdr[12]);
+            item.uniqueId = (rdr[13] == DBNull.Value) ? null : new Guid((byte[])rdr[13]);
+            item.byteCount = (rdr[14] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[14];
+            item.hdrEncryptedKeyHeaderNoLengthCheck = (rdr[15] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[15];
+            item.hdrVersionTag = (rdr[16] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[16]);
+            item.hdrAppDataNoLengthCheck = (rdr[17] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[17];
+            item.hdrLocalVersionTag = (rdr[18] == DBNull.Value) ? null : new Guid((byte[])rdr[18]);
+            item.hdrLocalAppDataNoLengthCheck = (rdr[19] == DBNull.Value) ? null : (string)rdr[19];
+            item.hdrReactionSummaryNoLengthCheck = (rdr[20] == DBNull.Value) ? null : (string)rdr[20];
+            item.hdrServerDataNoLengthCheck = (rdr[21] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[21];
+            item.hdrTransferHistoryNoLengthCheck = (rdr[22] == DBNull.Value) ? null : (string)rdr[22];
+            item.hdrFileMetaDataNoLengthCheck = (rdr[23] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[23];
+            item.hdrTmpDriveAlias = (rdr[24] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[24]);
+            item.hdrTmpDriveType = (rdr[25] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[25]);
+            item.created = (rdr[26] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[26]);
+            item.modified = (rdr[27] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[27]);
+            return item;
+       }
+
+        public virtual async Task<DriveMainIndexOldRecord> GetFullRecordAsync(Guid identityId,Guid driveId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT rowId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM DriveMainIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId LIMIT 1;"+
+                                             ";";
+                var get2Param1 = get2Command.CreateParameter();
+                get2Param1.ParameterName = "@identityId";
+                get2Command.Parameters.Add(get2Param1);
+                var get2Param2 = get2Command.CreateParameter();
+                get2Param2.ParameterName = "@driveId";
+                get2Command.Parameters.Add(get2Param2);
+
+                get2Param1.Value = identityId.ToByteArray();
+                get2Param2.Value = driveId.ToByteArray();
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader2(rdr,identityId,driveId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveMainIndexOldRecord ReadRecordFromReader3(DbDataReader rdr)
+        {
+            var result = new List<DriveMainIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveMainIndexOldRecord();
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.fileId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.globalTransitId = (rdr[4] == DBNull.Value) ? null : new Guid((byte[])rdr[4]);
+            item.fileState = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.requiredSecurityGroup = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.fileSystemType = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[7];
+            item.userDate = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[8]);
+            item.fileType = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[9];
+            item.dataType = (rdr[10] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[10];
+            item.archivalStatus = (rdr[11] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[11];
+            item.historyStatus = (rdr[12] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[12];
+            item.senderIdNoLengthCheck = (rdr[13] == DBNull.Value) ? null : (string)rdr[13];
+            item.groupId = (rdr[14] == DBNull.Value) ? null : new Guid((byte[])rdr[14]);
+            item.uniqueId = (rdr[15] == DBNull.Value) ? null : new Guid((byte[])rdr[15]);
+            item.byteCount = (rdr[16] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[16];
+            item.hdrEncryptedKeyHeaderNoLengthCheck = (rdr[17] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[17];
+            item.hdrVersionTag = (rdr[18] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[18]);
+            item.hdrAppDataNoLengthCheck = (rdr[19] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[19];
+            item.hdrLocalVersionTag = (rdr[20] == DBNull.Value) ? null : new Guid((byte[])rdr[20]);
+            item.hdrLocalAppDataNoLengthCheck = (rdr[21] == DBNull.Value) ? null : (string)rdr[21];
+            item.hdrReactionSummaryNoLengthCheck = (rdr[22] == DBNull.Value) ? null : (string)rdr[22];
+            item.hdrServerDataNoLengthCheck = (rdr[23] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[23];
+            item.hdrTransferHistoryNoLengthCheck = (rdr[24] == DBNull.Value) ? null : (string)rdr[24];
+            item.hdrFileMetaDataNoLengthCheck = (rdr[25] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[25];
+            item.hdrTmpDriveAlias = (rdr[26] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[26]);
+            item.hdrTmpDriveType = (rdr[27] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[27]);
+            item.created = (rdr[28] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[28]);
+            item.modified = (rdr[29] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[29]);
+            return item;
+       }
+
+        public virtual async Task<List<DriveMainIndexOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get3Command = cn.CreateCommand();
+            {
+                get3Command.CommandText = "SELECT rowId,identityId,driveId,fileId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM DriveMainIndexOld " +
+                                             "ORDER BY rowId ASC "+
+                                             ";";
+
+                {
+                    using (var rdr = await get3Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<DriveMainIndexOldRecord>();
+                        }
+                        var result = new List<DriveMainIndexOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader3(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveMainIndexOldRecord ReadRecordFromReader4(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId)
+        {
+            var result = new List<DriveMainIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveMainIndexOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.globalTransitId = (rdr[1] == DBNull.Value) ? null : new Guid((byte[])rdr[1]);
+            item.fileState = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
+            item.requiredSecurityGroup = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.fileSystemType = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.userDate = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
+            item.fileType = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.dataType = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[7];
+            item.archivalStatus = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[8];
+            item.historyStatus = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[9];
+            item.senderIdNoLengthCheck = (rdr[10] == DBNull.Value) ? null : (string)rdr[10];
+            item.groupId = (rdr[11] == DBNull.Value) ? null : new Guid((byte[])rdr[11]);
+            item.uniqueId = (rdr[12] == DBNull.Value) ? null : new Guid((byte[])rdr[12]);
+            item.byteCount = (rdr[13] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[13];
+            item.hdrEncryptedKeyHeaderNoLengthCheck = (rdr[14] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[14];
+            item.hdrVersionTag = (rdr[15] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[15]);
+            item.hdrAppDataNoLengthCheck = (rdr[16] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[16];
+            item.hdrLocalVersionTag = (rdr[17] == DBNull.Value) ? null : new Guid((byte[])rdr[17]);
+            item.hdrLocalAppDataNoLengthCheck = (rdr[18] == DBNull.Value) ? null : (string)rdr[18];
+            item.hdrReactionSummaryNoLengthCheck = (rdr[19] == DBNull.Value) ? null : (string)rdr[19];
+            item.hdrServerDataNoLengthCheck = (rdr[20] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[20];
+            item.hdrTransferHistoryNoLengthCheck = (rdr[21] == DBNull.Value) ? null : (string)rdr[21];
+            item.hdrFileMetaDataNoLengthCheck = (rdr[22] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[22];
+            item.hdrTmpDriveAlias = (rdr[23] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[23]);
+            item.hdrTmpDriveType = (rdr[24] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[24]);
+            item.created = (rdr[25] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[25]);
+            item.modified = (rdr[26] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[26]);
+            return item;
+       }
+
+        public virtual async Task<DriveMainIndexOldRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get4Command = cn.CreateCommand();
+            {
+                get4Command.CommandText = "SELECT rowId,globalTransitId,fileState,requiredSecurityGroup,fileSystemType,userDate,fileType,dataType,archivalStatus,historyStatus,senderId,groupId,uniqueId,byteCount,hdrEncryptedKeyHeader,hdrVersionTag,hdrAppData,hdrLocalVersionTag,hdrLocalAppData,hdrReactionSummary,hdrServerData,hdrTransferHistory,hdrFileMetaData,hdrTmpDriveAlias,hdrTmpDriveType,created,modified FROM DriveMainIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId LIMIT 1;"+
+                                             ";";
+                var get4Param1 = get4Command.CreateParameter();
+                get4Param1.ParameterName = "@identityId";
+                get4Command.Parameters.Add(get4Param1);
+                var get4Param2 = get4Command.CreateParameter();
+                get4Param2.ParameterName = "@driveId";
+                get4Command.Parameters.Add(get4Param2);
+                var get4Param3 = get4Command.CreateParameter();
+                get4Param3.ParameterName = "@fileId";
+                get4Command.Parameters.Add(get4Param3);
+
+                get4Param1.Value = identityId.ToByteArray();
+                get4Param2.Value = driveId.ToByteArray();
+                get4Param3.Value = fileId.ToByteArray();
+                {
+                    using (var rdr = await get4Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader4(rdr,identityId,driveId,fileId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactions.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactions.cs
@@ -18,7 +18,7 @@ public class TableDriveReactions(
 
     public async Task<int> DeleteAsync(Guid driveId, OdinId identity, Guid postId, string singleReaction)
     {
-        return await base.DeleteAsync(identityKey, driveId, identity, postId, singleReaction);
+        return await base.DeleteAsync(identityKey, driveId, postId, identity, singleReaction);
     }
 
     public async Task<int> DeleteAllReactionsAsync(Guid driveId, OdinId identity, Guid postId)

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
@@ -114,10 +114,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
             else
-                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
-            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveReactions("

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
@@ -414,7 +414,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected DriveReactionsRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid postId,OdinId identity,string singleReaction)
+        protected DriveReactionsRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid postId,OdinId identity,string singleReaction)
         {
             if (singleReaction == null) throw new Exception("Cannot be null");
             if (singleReaction?.Length < 3) throw new Exception("Too short");
@@ -443,7 +443,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId FROM driveReactions " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND postId = @postId AND identity = @identity AND singleReaction = @singleReaction LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND postId = @postId AND identity = @identity AND singleReaction = @singleReaction LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -472,7 +473,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,driveId,postId,identity,singleReaction);
+                        var r = ReadRecordFromReader0(rdr,identityId,driveId,postId,identity,singleReaction);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class DriveReactionsRecord
     {
-        private long _rowId;
-        public long rowId
+        private Int64 _rowId;
+        public Int64 rowId
         {
            get {
                    return _rowId;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
@@ -118,6 +118,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             else
                    rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveReactions("
                    +rowid
@@ -127,7 +128,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"postId BYTEA NOT NULL, "
                    +"singleReaction TEXT NOT NULL "
                    +", UNIQUE(identityId,driveId,identity,postId,singleReaction)"
-                   +") ;"
+                   +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsCRUD.cs
@@ -47,16 +47,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                   _driveId = value;
                }
         }
-        private OdinId _identity;
-        public OdinId identity
-        {
-           get {
-                   return _identity;
-               }
-           set {
-                  _identity = value;
-               }
-        }
         private Guid _postId;
         public Guid postId
         {
@@ -65,6 +55,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
                }
            set {
                   _postId = value;
+               }
+        }
+        private OdinId _identity;
+        public OdinId identity
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                  _identity = value;
                }
         }
         private string _singleReaction;
@@ -123,10 +123,10 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
-                   +"identity TEXT NOT NULL, "
                    +"postId BYTEA NOT NULL, "
+                   +"identity TEXT NOT NULL, "
                    +"singleReaction TEXT NOT NULL "
-                   +", UNIQUE(identityId,driveId,identity,postId,singleReaction)"
+                   +", UNIQUE(identityId,driveId,postId,identity,singleReaction)"
                    +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
@@ -140,8 +140,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                insertCommand.CommandText = "INSERT INTO driveReactions (identityId,driveId,identity,postId,singleReaction) " +
-                                             "VALUES (@identityId,@driveId,@identity,@postId,@singleReaction)";
+                insertCommand.CommandText = "INSERT INTO driveReactions (identityId,driveId,postId,identity,singleReaction) " +
+                                             "VALUES (@identityId,@driveId,@postId,@identity,@singleReaction)";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
                 insertCommand.Parameters.Add(insertParam1);
@@ -149,18 +149,18 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 insertParam2.ParameterName = "@driveId";
                 insertCommand.Parameters.Add(insertParam2);
                 var insertParam3 = insertCommand.CreateParameter();
-                insertParam3.ParameterName = "@identity";
+                insertParam3.ParameterName = "@postId";
                 insertCommand.Parameters.Add(insertParam3);
                 var insertParam4 = insertCommand.CreateParameter();
-                insertParam4.ParameterName = "@postId";
+                insertParam4.ParameterName = "@identity";
                 insertCommand.Parameters.Add(insertParam4);
                 var insertParam5 = insertCommand.CreateParameter();
                 insertParam5.ParameterName = "@singleReaction";
                 insertCommand.Parameters.Add(insertParam5);
                 insertParam1.Value = item.identityId.ToByteArray();
                 insertParam2.Value = item.driveId.ToByteArray();
-                insertParam3.Value = item.identity.DomainName;
-                insertParam4.Value = item.postId.ToByteArray();
+                insertParam3.Value = item.postId.ToByteArray();
+                insertParam4.Value = item.identity.DomainName;
                 insertParam5.Value = item.singleReaction;
                 var count = await insertCommand.ExecuteNonQueryAsync();
                 if (count > 0)
@@ -178,8 +178,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                insertCommand.CommandText = "INSERT INTO driveReactions (identityId,driveId,identity,postId,singleReaction) " +
-                                             "VALUES (@identityId,@driveId,@identity,@postId,@singleReaction) " +
+                insertCommand.CommandText = "INSERT INTO driveReactions (identityId,driveId,postId,identity,singleReaction) " +
+                                             "VALUES (@identityId,@driveId,@postId,@identity,@singleReaction) " +
                                              "ON CONFLICT DO NOTHING";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
@@ -188,18 +188,18 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 insertParam2.ParameterName = "@driveId";
                 insertCommand.Parameters.Add(insertParam2);
                 var insertParam3 = insertCommand.CreateParameter();
-                insertParam3.ParameterName = "@identity";
+                insertParam3.ParameterName = "@postId";
                 insertCommand.Parameters.Add(insertParam3);
                 var insertParam4 = insertCommand.CreateParameter();
-                insertParam4.ParameterName = "@postId";
+                insertParam4.ParameterName = "@identity";
                 insertCommand.Parameters.Add(insertParam4);
                 var insertParam5 = insertCommand.CreateParameter();
                 insertParam5.ParameterName = "@singleReaction";
                 insertCommand.Parameters.Add(insertParam5);
                 insertParam1.Value = item.identityId.ToByteArray();
                 insertParam2.Value = item.driveId.ToByteArray();
-                insertParam3.Value = item.identity.DomainName;
-                insertParam4.Value = item.postId.ToByteArray();
+                insertParam3.Value = item.postId.ToByteArray();
+                insertParam4.Value = item.identity.DomainName;
                 insertParam5.Value = item.singleReaction;
                 var count = await insertCommand.ExecuteNonQueryAsync();
                 if (count > 0)
@@ -217,9 +217,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var upsertCommand = cn.CreateCommand();
             {
-                upsertCommand.CommandText = "INSERT INTO driveReactions (identityId,driveId,identity,postId,singleReaction) " +
-                                             "VALUES (@identityId,@driveId,@identity,@postId,@singleReaction)"+
-                                             "ON CONFLICT (identityId,driveId,identity,postId,singleReaction) DO UPDATE "+
+                upsertCommand.CommandText = "INSERT INTO driveReactions (identityId,driveId,postId,identity,singleReaction) " +
+                                             "VALUES (@identityId,@driveId,@postId,@identity,@singleReaction)"+
+                                             "ON CONFLICT (identityId,driveId,postId,identity,singleReaction) DO UPDATE "+
                                              "SET  "+
                                              ";";
                 var upsertParam1 = upsertCommand.CreateParameter();
@@ -229,18 +229,18 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 upsertParam2.ParameterName = "@driveId";
                 upsertCommand.Parameters.Add(upsertParam2);
                 var upsertParam3 = upsertCommand.CreateParameter();
-                upsertParam3.ParameterName = "@identity";
+                upsertParam3.ParameterName = "@postId";
                 upsertCommand.Parameters.Add(upsertParam3);
                 var upsertParam4 = upsertCommand.CreateParameter();
-                upsertParam4.ParameterName = "@postId";
+                upsertParam4.ParameterName = "@identity";
                 upsertCommand.Parameters.Add(upsertParam4);
                 var upsertParam5 = upsertCommand.CreateParameter();
                 upsertParam5.ParameterName = "@singleReaction";
                 upsertCommand.Parameters.Add(upsertParam5);
                 upsertParam1.Value = item.identityId.ToByteArray();
                 upsertParam2.Value = item.driveId.ToByteArray();
-                upsertParam3.Value = item.identity.DomainName;
-                upsertParam4.Value = item.postId.ToByteArray();
+                upsertParam3.Value = item.postId.ToByteArray();
+                upsertParam4.Value = item.identity.DomainName;
                 upsertParam5.Value = item.singleReaction;
                 var count = await upsertCommand.ExecuteNonQueryAsync();
                 return count;
@@ -256,7 +256,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             {
                 updateCommand.CommandText = "UPDATE driveReactions " +
                                              "SET  "+
-                                             "WHERE (identityId = @identityId AND driveId = @driveId AND identity = @identity AND postId = @postId AND singleReaction = @singleReaction)";
+                                             "WHERE (identityId = @identityId AND driveId = @driveId AND postId = @postId AND identity = @identity AND singleReaction = @singleReaction)";
                 var updateParam1 = updateCommand.CreateParameter();
                 updateParam1.ParameterName = "@identityId";
                 updateCommand.Parameters.Add(updateParam1);
@@ -264,18 +264,18 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 updateParam2.ParameterName = "@driveId";
                 updateCommand.Parameters.Add(updateParam2);
                 var updateParam3 = updateCommand.CreateParameter();
-                updateParam3.ParameterName = "@identity";
+                updateParam3.ParameterName = "@postId";
                 updateCommand.Parameters.Add(updateParam3);
                 var updateParam4 = updateCommand.CreateParameter();
-                updateParam4.ParameterName = "@postId";
+                updateParam4.ParameterName = "@identity";
                 updateCommand.Parameters.Add(updateParam4);
                 var updateParam5 = updateCommand.CreateParameter();
                 updateParam5.ParameterName = "@singleReaction";
                 updateCommand.Parameters.Add(updateParam5);
                 updateParam1.Value = item.identityId.ToByteArray();
                 updateParam2.Value = item.driveId.ToByteArray();
-                updateParam3.Value = item.identity.DomainName;
-                updateParam4.Value = item.postId.ToByteArray();
+                updateParam3.Value = item.postId.ToByteArray();
+                updateParam4.Value = item.identity.DomainName;
                 updateParam5.Value = item.singleReaction;
                 var count = await updateCommand.ExecuteNonQueryAsync();
                 if (count > 0)
@@ -306,8 +306,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             sl.Add("rowId");
             sl.Add("identityId");
             sl.Add("driveId");
-            sl.Add("identity");
             sl.Add("postId");
+            sl.Add("identity");
             sl.Add("singleReaction");
             return sl;
         }
@@ -331,7 +331,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        // SELECT rowId,identityId,driveId,identity,postId,singleReaction
+        // SELECT rowId,identityId,driveId,postId,identity,singleReaction
         protected DriveReactionsRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<DriveReactionsRecord>();
@@ -343,13 +343,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
             item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
             item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
-            item.identity = (rdr[3] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[3]);
-            item.postId = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[4]);
+            item.postId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.identity = (rdr[4] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[4]);
             item.singleReactionNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
             return item;
        }
 
-        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,OdinId identity,Guid postId,string singleReaction)
+        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid postId,OdinId identity,string singleReaction)
         {
             if (singleReaction == null) throw new Exception("Cannot be null");
             if (singleReaction?.Length < 3) throw new Exception("Too short");
@@ -358,7 +358,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var delete0Command = cn.CreateCommand();
             {
                 delete0Command.CommandText = "DELETE FROM driveReactions " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND identity = @identity AND postId = @postId AND singleReaction = @singleReaction";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND postId = @postId AND identity = @identity AND singleReaction = @singleReaction";
                 var delete0Param1 = delete0Command.CreateParameter();
                 delete0Param1.ParameterName = "@identityId";
                 delete0Command.Parameters.Add(delete0Param1);
@@ -366,10 +366,10 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 delete0Param2.ParameterName = "@driveId";
                 delete0Command.Parameters.Add(delete0Param2);
                 var delete0Param3 = delete0Command.CreateParameter();
-                delete0Param3.ParameterName = "@identity";
+                delete0Param3.ParameterName = "@postId";
                 delete0Command.Parameters.Add(delete0Param3);
                 var delete0Param4 = delete0Command.CreateParameter();
-                delete0Param4.ParameterName = "@postId";
+                delete0Param4.ParameterName = "@identity";
                 delete0Command.Parameters.Add(delete0Param4);
                 var delete0Param5 = delete0Command.CreateParameter();
                 delete0Param5.ParameterName = "@singleReaction";
@@ -377,8 +377,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 
                 delete0Param1.Value = identityId.ToByteArray();
                 delete0Param2.Value = driveId.ToByteArray();
-                delete0Param3.Value = identity.DomainName;
-                delete0Param4.Value = postId.ToByteArray();
+                delete0Param3.Value = postId.ToByteArray();
+                delete0Param4.Value = identity.DomainName;
                 delete0Param5.Value = singleReaction;
                 var count = await delete0Command.ExecuteNonQueryAsync();
                 return count;
@@ -414,7 +414,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected DriveReactionsRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,OdinId identity,Guid postId,string singleReaction)
+        protected DriveReactionsRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid postId,OdinId identity,string singleReaction)
         {
             if (singleReaction == null) throw new Exception("Cannot be null");
             if (singleReaction?.Length < 3) throw new Exception("Too short");
@@ -427,14 +427,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new DriveReactionsRecord();
             item.identityId = identityId;
             item.driveId = driveId;
-            item.identity = identity;
             item.postId = postId;
+            item.identity = identity;
             item.singleReaction = singleReaction;
             item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
             return item;
        }
 
-        protected virtual async Task<DriveReactionsRecord> GetAsync(Guid identityId,Guid driveId,OdinId identity,Guid postId,string singleReaction)
+        protected virtual async Task<DriveReactionsRecord> GetAsync(Guid identityId,Guid driveId,Guid postId,OdinId identity,string singleReaction)
         {
             if (singleReaction == null) throw new Exception("Cannot be null");
             if (singleReaction?.Length < 3) throw new Exception("Too short");
@@ -443,7 +443,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId FROM driveReactions " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND identity = @identity AND postId = @postId AND singleReaction = @singleReaction LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND postId = @postId AND identity = @identity AND singleReaction = @singleReaction LIMIT 1;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -451,10 +451,10 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 get0Param2.ParameterName = "@driveId";
                 get0Command.Parameters.Add(get0Param2);
                 var get0Param3 = get0Command.CreateParameter();
-                get0Param3.ParameterName = "@identity";
+                get0Param3.ParameterName = "@postId";
                 get0Command.Parameters.Add(get0Param3);
                 var get0Param4 = get0Command.CreateParameter();
-                get0Param4.ParameterName = "@postId";
+                get0Param4.ParameterName = "@identity";
                 get0Command.Parameters.Add(get0Param4);
                 var get0Param5 = get0Command.CreateParameter();
                 get0Param5.ParameterName = "@singleReaction";
@@ -462,8 +462,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 
                 get0Param1.Value = identityId.ToByteArray();
                 get0Param2.Value = driveId.ToByteArray();
-                get0Param3.Value = identity.DomainName;
-                get0Param4.Value = postId.ToByteArray();
+                get0Param3.Value = postId.ToByteArray();
+                get0Param4.Value = identity.DomainName;
                 get0Param5.Value = singleReaction;
                 {
                     using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
@@ -472,7 +472,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,driveId,identity,postId,singleReaction);
+                        var r = ReadRecordFromReader0(rdr, identityId,driveId,postId,identity,singleReaction);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveReactionsOldCRUD.cs
@@ -1,0 +1,528 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class DriveReactionsOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private OdinId _identity;
+        public OdinId identity
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                  _identity = value;
+               }
+        }
+        private Guid _postId;
+        public Guid postId
+        {
+           get {
+                   return _postId;
+               }
+           set {
+                  _postId = value;
+               }
+        }
+        private string _singleReaction;
+        public string singleReaction
+        {
+           get {
+                   return _singleReaction;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 3) throw new Exception("Too short");
+                    if (value?.Length > 80) throw new Exception("Too long");
+                  _singleReaction = value;
+               }
+        }
+        internal string singleReactionNoLengthCheck
+        {
+           get {
+                   return _singleReaction;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 3) throw new Exception("Too short");
+                  _singleReaction = value;
+               }
+        }
+    } // End of class DriveReactionsOldRecord
+
+    public abstract class TableDriveReactionsOldCRUD
+    {
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableDriveReactionsOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS DriveReactionsOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS DriveReactionsOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"identity TEXT NOT NULL, "
+                   +"postId BYTEA NOT NULL, "
+                   +"singleReaction TEXT NOT NULL "
+                   + rowid
+                   +", PRIMARY KEY (identityId,driveId,identity,postId,singleReaction)"
+                   +");"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(DriveReactionsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.postId.AssertGuidNotEmpty("Guid parameter postId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveReactionsOld (identityId,driveId,identity,postId,singleReaction) " +
+                                             "VALUES (@identityId,@driveId,@identity,@postId,@singleReaction)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@postId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@singleReaction";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.identity.DomainName;
+                insertParam4.Value = item.postId.ToByteArray();
+                insertParam5.Value = item.singleReaction;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DriveReactionsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.postId.AssertGuidNotEmpty("Guid parameter postId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveReactionsOld (identityId,driveId,identity,postId,singleReaction) " +
+                                             "VALUES (@identityId,@driveId,@identity,@postId,@singleReaction) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@postId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@singleReaction";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.identity.DomainName;
+                insertParam4.Value = item.postId.ToByteArray();
+                insertParam5.Value = item.singleReaction;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DriveReactionsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.postId.AssertGuidNotEmpty("Guid parameter postId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO DriveReactionsOld (identityId,driveId,identity,postId,singleReaction) " +
+                                             "VALUES (@identityId,@driveId,@identity,@postId,@singleReaction)"+
+                                             "ON CONFLICT (identityId,driveId,identity,postId,singleReaction) DO UPDATE "+
+                                             "SET  "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@identity";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@postId";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@singleReaction";
+                upsertCommand.Parameters.Add(upsertParam5);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.driveId.ToByteArray();
+                upsertParam3.Value = item.identity.DomainName;
+                upsertParam4.Value = item.postId.ToByteArray();
+                upsertParam5.Value = item.singleReaction;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(DriveReactionsOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.postId.AssertGuidNotEmpty("Guid parameter postId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE DriveReactionsOld " +
+                                             "SET  "+
+                                             "WHERE (identityId = @identityId AND driveId = @driveId AND identity = @identity AND postId = @postId AND singleReaction = @singleReaction)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@identity";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@postId";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@singleReaction";
+                updateCommand.Parameters.Add(updateParam5);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.driveId.ToByteArray();
+                updateParam3.Value = item.identity.DomainName;
+                updateParam4.Value = item.postId.ToByteArray();
+                updateParam5.Value = item.singleReaction;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE driveReactions RENAME TO DriveReactionsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM DriveReactionsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("driveId");
+            sl.Add("identity");
+            sl.Add("postId");
+            sl.Add("singleReaction");
+            return sl;
+        }
+
+        public virtual async Task<int> GetDriveCountAsync(Guid driveId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountDriveCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountDriveCommand.CommandText = "SELECT COUNT(*) FROM DriveReactionsOld WHERE driveId = $driveId;";
+                var getCountDriveParam1 = getCountDriveCommand.CreateParameter();
+                getCountDriveParam1.ParameterName = "$driveId";
+                getCountDriveCommand.Parameters.Add(getCountDriveParam1);
+                getCountDriveParam1.Value = driveId.ToByteArray();
+                var count = await getCountDriveCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            } // using
+        }
+
+        // SELECT identityId,driveId,identity,postId,singleReaction
+        public DriveReactionsOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<DriveReactionsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveReactionsOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.identity = (rdr[2] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[2]);
+            item.postId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.singleReactionNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,OdinId identity,Guid postId,string singleReaction)
+        {
+            if (singleReaction == null) throw new Exception("Cannot be null");
+            if (singleReaction?.Length < 3) throw new Exception("Too short");
+            if (singleReaction?.Length > 80) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM DriveReactionsOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND identity = @identity AND postId = @postId AND singleReaction = @singleReaction";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@identity";
+                delete0Command.Parameters.Add(delete0Param3);
+                var delete0Param4 = delete0Command.CreateParameter();
+                delete0Param4.ParameterName = "@postId";
+                delete0Command.Parameters.Add(delete0Param4);
+                var delete0Param5 = delete0Command.CreateParameter();
+                delete0Param5.ParameterName = "@singleReaction";
+                delete0Command.Parameters.Add(delete0Param5);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = driveId.ToByteArray();
+                delete0Param3.Value = identity.DomainName;
+                delete0Param4.Value = postId.ToByteArray();
+                delete0Param5.Value = singleReaction;
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public virtual async Task<int> DeleteAllReactionsAsync(Guid identityId,Guid driveId,OdinId identity,Guid postId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete1Command = cn.CreateCommand();
+            {
+                delete1Command.CommandText = "DELETE FROM DriveReactionsOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND identity = @identity AND postId = @postId";
+                var delete1Param1 = delete1Command.CreateParameter();
+                delete1Param1.ParameterName = "@identityId";
+                delete1Command.Parameters.Add(delete1Param1);
+                var delete1Param2 = delete1Command.CreateParameter();
+                delete1Param2.ParameterName = "@driveId";
+                delete1Command.Parameters.Add(delete1Param2);
+                var delete1Param3 = delete1Command.CreateParameter();
+                delete1Param3.ParameterName = "@identity";
+                delete1Command.Parameters.Add(delete1Param3);
+                var delete1Param4 = delete1Command.CreateParameter();
+                delete1Param4.ParameterName = "@postId";
+                delete1Command.Parameters.Add(delete1Param4);
+
+                delete1Param1.Value = identityId.ToByteArray();
+                delete1Param2.Value = driveId.ToByteArray();
+                delete1Param3.Value = identity.DomainName;
+                delete1Param4.Value = postId.ToByteArray();
+                var count = await delete1Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public DriveReactionsOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,OdinId identity,Guid postId,string singleReaction)
+        {
+            if (singleReaction == null) throw new Exception("Cannot be null");
+            if (singleReaction?.Length < 3) throw new Exception("Too short");
+            if (singleReaction?.Length > 80) throw new Exception("Too long");
+            var result = new List<DriveReactionsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveReactionsOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.identity = identity;
+            item.postId = postId;
+            item.singleReaction = singleReaction;
+            return item;
+       }
+
+        public virtual async Task<DriveReactionsOldRecord> GetAsync(Guid identityId,Guid driveId,OdinId identity,Guid postId,string singleReaction)
+        {
+            if (singleReaction == null) throw new Exception("Cannot be null");
+            if (singleReaction?.Length < 3) throw new Exception("Too short");
+            if (singleReaction?.Length > 80) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT identityId,driveId,identity,postId,singleReaction FROM DriveReactionsOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND identity = @identity AND postId = @postId AND singleReaction = @singleReaction LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@driveId";
+                get0Command.Parameters.Add(get0Param2);
+                var get0Param3 = get0Command.CreateParameter();
+                get0Param3.ParameterName = "@identity";
+                get0Command.Parameters.Add(get0Param3);
+                var get0Param4 = get0Command.CreateParameter();
+                get0Param4.ParameterName = "@postId";
+                get0Command.Parameters.Add(get0Param4);
+                var get0Param5 = get0Command.CreateParameter();
+                get0Param5.ParameterName = "@singleReaction";
+                get0Command.Parameters.Add(get0Param5);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = driveId.ToByteArray();
+                get0Param3.Value = identity.DomainName;
+                get0Param4.Value = postId.ToByteArray();
+                get0Param5.Value = singleReaction;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,identityId,driveId,identity,postId,singleReaction);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveReactionsOldRecord ReadRecordFromReader1(DbDataReader rdr)
+        {
+            var result = new List<DriveReactionsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveReactionsOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.identity = (rdr[2] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[2]);
+            item.postId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.singleReactionNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
+            return item;
+       }
+
+        public virtual async Task<List<DriveReactionsOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT identityId,driveId,identity,postId,singleReaction FROM DriveReactionsOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<DriveReactionsOldRecord>();
+                        }
+                        var result = new List<DriveReactionsOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader1(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
@@ -78,6 +78,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveTagIndex;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveTagIndex("
                    +"identityId BYTEA NOT NULL, "
@@ -85,7 +88,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"fileId BYTEA NOT NULL, "
                    +"tagId BYTEA NOT NULL "
                    +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveTagIndexCRUD ON driveTagIndex(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
@@ -89,7 +89,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"tagId BYTEA NOT NULL "
                    +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableDriveTagIndexCRUD ON driveTagIndex(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
@@ -370,7 +370,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT tagId FROM driveTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -416,7 +417,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected DriveTagIndexRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        protected DriveTagIndexRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,Guid tagId)
         {
             var result = new List<DriveTagIndexRecord>();
 #pragma warning disable CS0168
@@ -438,7 +439,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId FROM driveTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -463,7 +465,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,tagId);
+                        var r = ReadRecordFromReader1(rdr,identityId,driveId,fileId,tagId);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
@@ -310,13 +310,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return item;
        }
 
-        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        protected virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var delete0Command = cn.CreateCommand();
             {
                 delete0Command.CommandText = "DELETE FROM driveTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
                 var delete0Param1 = delete0Command.CreateParameter();
                 delete0Param1.ParameterName = "@identityId";
                 delete0Command.Parameters.Add(delete0Param1);
@@ -326,26 +326,22 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var delete0Param3 = delete0Command.CreateParameter();
                 delete0Param3.ParameterName = "@fileId";
                 delete0Command.Parameters.Add(delete0Param3);
-                var delete0Param4 = delete0Command.CreateParameter();
-                delete0Param4.ParameterName = "@tagId";
-                delete0Command.Parameters.Add(delete0Param4);
 
                 delete0Param1.Value = identityId.ToByteArray();
                 delete0Param2.Value = driveId.ToByteArray();
                 delete0Param3.Value = fileId.ToByteArray();
-                delete0Param4.Value = tagId.ToByteArray();
                 var count = await delete0Command.ExecuteNonQueryAsync();
                 return count;
             }
         }
 
-        protected virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
+        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var delete1Command = cn.CreateCommand();
             {
                 delete1Command.CommandText = "DELETE FROM driveTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId";
                 var delete1Param1 = delete1Command.CreateParameter();
                 delete1Param1.ParameterName = "@identityId";
                 delete1Command.Parameters.Add(delete1Param1);
@@ -355,38 +351,26 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var delete1Param3 = delete1Command.CreateParameter();
                 delete1Param3.ParameterName = "@fileId";
                 delete1Command.Parameters.Add(delete1Param3);
+                var delete1Param4 = delete1Command.CreateParameter();
+                delete1Param4.ParameterName = "@tagId";
+                delete1Command.Parameters.Add(delete1Param4);
 
                 delete1Param1.Value = identityId.ToByteArray();
                 delete1Param2.Value = driveId.ToByteArray();
                 delete1Param3.Value = fileId.ToByteArray();
+                delete1Param4.Value = tagId.ToByteArray();
                 var count = await delete1Command.ExecuteNonQueryAsync();
                 return count;
             }
         }
 
-        protected DriveTagIndexRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid tagId)
-        {
-            var result = new List<DriveTagIndexRecord>();
-#pragma warning disable CS0168
-            long bytesRead;
-#pragma warning restore CS0168
-            var guid = new byte[16];
-            var item = new DriveTagIndexRecord();
-            item.identityId = identityId;
-            item.driveId = driveId;
-            item.fileId = fileId;
-            item.tagId = tagId;
-            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
-            return item;
-       }
-
-        protected virtual async Task<DriveTagIndexRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        protected virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT rowId FROM driveTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;";
+                get0Command.CommandText = "SELECT tagId FROM driveTagIndex " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -396,50 +380,12 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var get0Param3 = get0Command.CreateParameter();
                 get0Param3.ParameterName = "@fileId";
                 get0Command.Parameters.Add(get0Param3);
-                var get0Param4 = get0Command.CreateParameter();
-                get0Param4.ParameterName = "@tagId";
-                get0Command.Parameters.Add(get0Param4);
 
                 get0Param1.Value = identityId.ToByteArray();
                 get0Param2.Value = driveId.ToByteArray();
                 get0Param3.Value = fileId.ToByteArray();
-                get0Param4.Value = tagId.ToByteArray();
                 {
-                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
-                    {
-                        if (await rdr.ReadAsync() == false)
-                        {
-                            return null;
-                        }
-                        var r = ReadRecordFromReader0(rdr, identityId,driveId,fileId,tagId);
-                        return r;
-                    } // using
-                } //
-            } // using
-        }
-
-        protected virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
-        {
-            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var get1Command = cn.CreateCommand();
-            {
-                get1Command.CommandText = "SELECT tagId FROM driveTagIndex " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
-                var get1Param1 = get1Command.CreateParameter();
-                get1Param1.ParameterName = "@identityId";
-                get1Command.Parameters.Add(get1Param1);
-                var get1Param2 = get1Command.CreateParameter();
-                get1Param2.ParameterName = "@driveId";
-                get1Command.Parameters.Add(get1Param2);
-                var get1Param3 = get1Command.CreateParameter();
-                get1Param3.ParameterName = "@fileId";
-                get1Command.Parameters.Add(get1Param3);
-
-                get1Param1.Value = identityId.ToByteArray();
-                get1Param2.Value = driveId.ToByteArray();
-                get1Param3.Value = fileId.ToByteArray();
-                {
-                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
                     {
                         Guid result0tmp;
                         var thelistresult = new List<Guid>();
@@ -469,6 +415,109 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 } //
             } // using
         }
+
+        protected DriveTagIndexRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            var result = new List<DriveTagIndexRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTagIndexRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.tagId = tagId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            return item;
+       }
+
+        protected virtual async Task<DriveTagIndexRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT rowId FROM driveTagIndex " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@fileId";
+                get1Command.Parameters.Add(get1Param3);
+                var get1Param4 = get1Command.CreateParameter();
+                get1Param4.ParameterName = "@tagId";
+                get1Command.Parameters.Add(get1Param4);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = driveId.ToByteArray();
+                get1Param3.Value = fileId.ToByteArray();
+                get1Param4.Value = tagId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,tagId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        protected virtual async Task<(List<DriveTagIndexRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,driveId,fileId,tagId FROM driveTagIndex " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<DriveTagIndexRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
 
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
@@ -78,20 +78,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveTagIndex;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveTagIndex("
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
                    +"fileId BYTEA NOT NULL, "
                    +"tagId BYTEA NOT NULL "
-                   + rowid
                    +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveTagIndexCRUD ON driveTagIndex(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexCRUD.cs
@@ -17,6 +17,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class DriveTagIndexRecord
     {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private Guid _identityId;
         public Guid identityId
         {
@@ -78,16 +88,20 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveTagIndex;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
-            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
-                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveTagIndex("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
                    +"fileId BYTEA NOT NULL, "
                    +"tagId BYTEA NOT NULL "
-                   +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
+                   +", UNIQUE(identityId,driveId,fileId,tagId)"
                    +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
@@ -252,6 +266,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("identityId");
             sl.Add("driveId");
             sl.Add("fileId");
@@ -278,7 +293,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        // SELECT identityId,driveId,fileId,tagId
+        // SELECT rowId,identityId,driveId,fileId,tagId
         protected DriveTagIndexRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<DriveTagIndexRecord>();
@@ -287,10 +302,11 @@ namespace Odin.Core.Storage.Database.Identity.Table
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new DriveTagIndexRecord();
-            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
-            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
-            item.tagId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.fileId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.tagId = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[4]);
             return item;
        }
 
@@ -360,6 +376,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.driveId = driveId;
             item.fileId = fileId;
             item.tagId = tagId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
             return item;
        }
 
@@ -368,7 +385,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT identityId,driveId,fileId,tagId FROM driveTagIndex " +
+                get0Command.CommandText = "SELECT rowId FROM driveTagIndex " +
                                              "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTagIndexOldCRUD.cs
@@ -1,0 +1,520 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class DriveTagIndexOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private Guid _fileId;
+        public Guid fileId
+        {
+           get {
+                   return _fileId;
+               }
+           set {
+                  _fileId = value;
+               }
+        }
+        private Guid _tagId;
+        public Guid tagId
+        {
+           get {
+                   return _tagId;
+               }
+           set {
+                  _tagId = value;
+               }
+        }
+    } // End of class DriveTagIndexOldRecord
+
+    public abstract class TableDriveTagIndexOldCRUD
+    {
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableDriveTagIndexOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS DriveTagIndexOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS DriveTagIndexOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL, "
+                   +"tagId BYTEA NOT NULL "
+                   + rowid
+                   +", PRIMARY KEY (identityId,driveId,fileId,tagId)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0DriveTagIndexOld ON DriveTagIndexOld(identityId,driveId,fileId);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(DriveTagIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.tagId.AssertGuidNotEmpty("Guid parameter tagId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveTagIndexOld (identityId,driveId,fileId,tagId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@tagId)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@tagId";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.tagId.ToByteArray();
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DriveTagIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.tagId.AssertGuidNotEmpty("Guid parameter tagId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveTagIndexOld (identityId,driveId,fileId,tagId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@tagId) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@tagId";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.tagId.ToByteArray();
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DriveTagIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.tagId.AssertGuidNotEmpty("Guid parameter tagId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO DriveTagIndexOld (identityId,driveId,fileId,tagId) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@tagId)"+
+                                             "ON CONFLICT (identityId,driveId,fileId,tagId) DO UPDATE "+
+                                             "SET  "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@fileId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@tagId";
+                upsertCommand.Parameters.Add(upsertParam4);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.driveId.ToByteArray();
+                upsertParam3.Value = item.fileId.ToByteArray();
+                upsertParam4.Value = item.tagId.ToByteArray();
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(DriveTagIndexOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.tagId.AssertGuidNotEmpty("Guid parameter tagId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE DriveTagIndexOld " +
+                                             "SET  "+
+                                             "WHERE (identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@fileId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@tagId";
+                updateCommand.Parameters.Add(updateParam4);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.driveId.ToByteArray();
+                updateParam3.Value = item.fileId.ToByteArray();
+                updateParam4.Value = item.tagId.ToByteArray();
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE driveTagIndex RENAME TO DriveTagIndexOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM DriveTagIndexOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("driveId");
+            sl.Add("fileId");
+            sl.Add("tagId");
+            return sl;
+        }
+
+        public virtual async Task<int> GetDriveCountAsync(Guid driveId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountDriveCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountDriveCommand.CommandText = "SELECT COUNT(*) FROM DriveTagIndexOld WHERE driveId = $driveId;";
+                var getCountDriveParam1 = getCountDriveCommand.CreateParameter();
+                getCountDriveParam1.ParameterName = "$driveId";
+                getCountDriveCommand.Parameters.Add(getCountDriveParam1);
+                getCountDriveParam1.Value = driveId.ToByteArray();
+                var count = await getCountDriveCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            } // using
+        }
+
+        // SELECT identityId,driveId,fileId,tagId
+        public DriveTagIndexOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<DriveTagIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTagIndexOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.tagId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM DriveTagIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@fileId";
+                delete0Command.Parameters.Add(delete0Param3);
+                var delete0Param4 = delete0Command.CreateParameter();
+                delete0Param4.ParameterName = "@tagId";
+                delete0Command.Parameters.Add(delete0Param4);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = driveId.ToByteArray();
+                delete0Param3.Value = fileId.ToByteArray();
+                delete0Param4.Value = tagId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete1Command = cn.CreateCommand();
+            {
+                delete1Command.CommandText = "DELETE FROM DriveTagIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                var delete1Param1 = delete1Command.CreateParameter();
+                delete1Param1.ParameterName = "@identityId";
+                delete1Command.Parameters.Add(delete1Param1);
+                var delete1Param2 = delete1Command.CreateParameter();
+                delete1Param2.ParameterName = "@driveId";
+                delete1Command.Parameters.Add(delete1Param2);
+                var delete1Param3 = delete1Command.CreateParameter();
+                delete1Param3.ParameterName = "@fileId";
+                delete1Command.Parameters.Add(delete1Param3);
+
+                delete1Param1.Value = identityId.ToByteArray();
+                delete1Param2.Value = driveId.ToByteArray();
+                delete1Param3.Value = fileId.ToByteArray();
+                var count = await delete1Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public DriveTagIndexOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            var result = new List<DriveTagIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTagIndexOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.tagId = tagId;
+            return item;
+       }
+
+        public virtual async Task<DriveTagIndexOldRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,Guid tagId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT identityId,driveId,fileId,tagId FROM DriveTagIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND tagId = @tagId LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@driveId";
+                get0Command.Parameters.Add(get0Param2);
+                var get0Param3 = get0Command.CreateParameter();
+                get0Param3.ParameterName = "@fileId";
+                get0Command.Parameters.Add(get0Param3);
+                var get0Param4 = get0Command.CreateParameter();
+                get0Param4.ParameterName = "@tagId";
+                get0Command.Parameters.Add(get0Param4);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = driveId.ToByteArray();
+                get0Param3.Value = fileId.ToByteArray();
+                get0Param4.Value = tagId.ToByteArray();
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,identityId,driveId,fileId,tagId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<List<Guid>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT tagId FROM DriveTagIndexOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@fileId";
+                get1Command.Parameters.Add(get1Param3);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = driveId.ToByteArray();
+                get1Param3.Value = fileId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        Guid result0tmp;
+                        var thelistresult = new List<Guid>();
+                        if (!await rdr.ReadAsync()) {
+                            return thelistresult;
+                        }
+                    byte[] tmpbuf = new byte[65535+1];
+                    var guid = new byte[16];
+                    while (true)
+                    {
+
+                        if (rdr[0] == DBNull.Value)
+                            throw new Exception("Impossible, item is null in DB, but set as NOT NULL");
+                        else
+                        {
+                            guid = (byte[]) rdr[0];
+                            if (guid.Length != 16)
+                                throw new Exception("Not a GUID in tagId...");
+                            result0tmp = new Guid(guid);
+                        }
+                        thelistresult.Add(result0tmp);
+                        if (!await rdr.ReadAsync())
+                           break;
+                    } // while
+                    return thelistresult;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveTagIndexOldRecord ReadRecordFromReader2(DbDataReader rdr)
+        {
+            var result = new List<DriveTagIndexOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTagIndexOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.tagId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            return item;
+       }
+
+        public virtual async Task<List<DriveTagIndexOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT identityId,driveId,fileId,tagId FROM DriveTagIndexOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<DriveTagIndexOldRecord>();
+                        }
+                        var result = new List<DriveTagIndexOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader2(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
@@ -118,11 +118,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveTransferHistory;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveTransferHistory("
                    +"identityId BYTEA NOT NULL, "
@@ -133,9 +128,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"isInOutbox BOOLEAN NOT NULL, "
                    +"latestSuccessfullyDeliveredVersionTag BYTEA , "
                    +"isReadByRecipient BOOLEAN NOT NULL "
-                   + rowid
                    +", PRIMARY KEY (identityId,driveId,fileId,remoteIdentityId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveTransferHistoryCRUD ON driveTransferHistory(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
@@ -147,7 +147,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"isReadByRecipient BOOLEAN NOT NULL "
                    +", UNIQUE(identityId,driveId,fileId,remoteIdentityId)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableDriveTransferHistoryCRUD ON driveTransferHistory(identityId,driveId,fileId);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0driveTransferHistory ON driveTransferHistory(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -481,7 +481,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected DriveTransferHistoryRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId)
+        protected DriveTransferHistoryRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId)
         {
             var result = new List<DriveTransferHistoryRecord>();
 #pragma warning disable CS0168
@@ -507,7 +507,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM driveTransferHistory " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -531,7 +532,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<DriveTransferHistoryRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader0(rdr, identityId,driveId,fileId));
+                            result.Add(ReadRecordFromReader0(rdr,identityId,driveId,fileId));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -541,7 +542,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected DriveTransferHistoryRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
+        protected DriveTransferHistoryRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
         {
             var result = new List<DriveTransferHistoryRecord>();
 #pragma warning disable CS0168
@@ -567,7 +568,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM driveTransferHistory " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -592,7 +594,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,remoteIdentityId);
+                        var r = ReadRecordFromReader1(rdr,identityId,driveId,fileId,remoteIdentityId);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
@@ -118,6 +118,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS driveTransferHistory;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS driveTransferHistory("
                    +"identityId BYTEA NOT NULL, "
@@ -129,7 +132,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"latestSuccessfullyDeliveredVersionTag BYTEA , "
                    +"isReadByRecipient BOOLEAN NOT NULL "
                    +", PRIMARY KEY (identityId,driveId,fileId,remoteIdentityId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableDriveTransferHistoryCRUD ON driveTransferHistory(identityId,driveId,fileId);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
@@ -427,13 +427,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return item;
        }
 
-        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
+        protected virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var delete0Command = cn.CreateCommand();
             {
                 delete0Command.CommandText = "DELETE FROM driveTransferHistory " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
                 var delete0Param1 = delete0Command.CreateParameter();
                 delete0Param1.ParameterName = "@identityId";
                 delete0Command.Parameters.Add(delete0Param1);
@@ -443,26 +443,22 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var delete0Param3 = delete0Command.CreateParameter();
                 delete0Param3.ParameterName = "@fileId";
                 delete0Command.Parameters.Add(delete0Param3);
-                var delete0Param4 = delete0Command.CreateParameter();
-                delete0Param4.ParameterName = "@remoteIdentityId";
-                delete0Command.Parameters.Add(delete0Param4);
 
                 delete0Param1.Value = identityId.ToByteArray();
                 delete0Param2.Value = driveId.ToByteArray();
                 delete0Param3.Value = fileId.ToByteArray();
-                delete0Param4.Value = remoteIdentityId.DomainName;
                 var count = await delete0Command.ExecuteNonQueryAsync();
                 return count;
             }
         }
 
-        protected virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
+        protected virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var delete1Command = cn.CreateCommand();
             {
                 delete1Command.CommandText = "DELETE FROM driveTransferHistory " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId";
                 var delete1Param1 = delete1Command.CreateParameter();
                 delete1Param1.ParameterName = "@identityId";
                 delete1Command.Parameters.Add(delete1Param1);
@@ -472,74 +468,20 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var delete1Param3 = delete1Command.CreateParameter();
                 delete1Param3.ParameterName = "@fileId";
                 delete1Command.Parameters.Add(delete1Param3);
+                var delete1Param4 = delete1Command.CreateParameter();
+                delete1Param4.ParameterName = "@remoteIdentityId";
+                delete1Command.Parameters.Add(delete1Param4);
 
                 delete1Param1.Value = identityId.ToByteArray();
                 delete1Param2.Value = driveId.ToByteArray();
                 delete1Param3.Value = fileId.ToByteArray();
+                delete1Param4.Value = remoteIdentityId.DomainName;
                 var count = await delete1Command.ExecuteNonQueryAsync();
                 return count;
             }
         }
 
-        protected DriveTransferHistoryRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
-        {
-            var result = new List<DriveTransferHistoryRecord>();
-#pragma warning disable CS0168
-            long bytesRead;
-#pragma warning restore CS0168
-            var guid = new byte[16];
-            var item = new DriveTransferHistoryRecord();
-            item.identityId = identityId;
-            item.driveId = driveId;
-            item.fileId = fileId;
-            item.remoteIdentityId = remoteIdentityId;
-            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
-            item.latestTransferStatus = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
-            item.isInOutbox = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[2]);
-            item.latestSuccessfullyDeliveredVersionTag = (rdr[3] == DBNull.Value) ? null : new Guid((byte[])rdr[3]);
-            item.isReadByRecipient = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[4]);
-            return item;
-       }
-
-        protected virtual async Task<DriveTransferHistoryRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
-        {
-            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var get0Command = cn.CreateCommand();
-            {
-                get0Command.CommandText = "SELECT rowId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM driveTransferHistory " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId LIMIT 1;";
-                var get0Param1 = get0Command.CreateParameter();
-                get0Param1.ParameterName = "@identityId";
-                get0Command.Parameters.Add(get0Param1);
-                var get0Param2 = get0Command.CreateParameter();
-                get0Param2.ParameterName = "@driveId";
-                get0Command.Parameters.Add(get0Param2);
-                var get0Param3 = get0Command.CreateParameter();
-                get0Param3.ParameterName = "@fileId";
-                get0Command.Parameters.Add(get0Param3);
-                var get0Param4 = get0Command.CreateParameter();
-                get0Param4.ParameterName = "@remoteIdentityId";
-                get0Command.Parameters.Add(get0Param4);
-
-                get0Param1.Value = identityId.ToByteArray();
-                get0Param2.Value = driveId.ToByteArray();
-                get0Param3.Value = fileId.ToByteArray();
-                get0Param4.Value = remoteIdentityId.DomainName;
-                {
-                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
-                    {
-                        if (await rdr.ReadAsync() == false)
-                        {
-                            return null;
-                        }
-                        var r = ReadRecordFromReader0(rdr, identityId,driveId,fileId,remoteIdentityId);
-                        return r;
-                    } // using
-                } //
-            } // using
-        }
-
-        protected DriveTransferHistoryRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId)
+        protected DriveTransferHistoryRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId)
         {
             var result = new List<DriveTransferHistoryRecord>();
 #pragma warning disable CS0168
@@ -562,10 +504,70 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<List<DriveTransferHistoryRecord>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
         {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT rowId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM driveTransferHistory " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@driveId";
+                get0Command.Parameters.Add(get0Param2);
+                var get0Param3 = get0Command.CreateParameter();
+                get0Param3.ParameterName = "@fileId";
+                get0Command.Parameters.Add(get0Param3);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = driveId.ToByteArray();
+                get0Param3.Value = fileId.ToByteArray();
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<DriveTransferHistoryRecord>();
+                        }
+                        var result = new List<DriveTransferHistoryRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr, identityId,driveId,fileId));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        protected DriveTransferHistoryRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
+        {
+            var result = new List<DriveTransferHistoryRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTransferHistoryRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.remoteIdentityId = remoteIdentityId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.latestTransferStatus = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
+            item.isInOutbox = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[2]);
+            item.latestSuccessfullyDeliveredVersionTag = (rdr[3] == DBNull.Value) ? null : new Guid((byte[])rdr[3]);
+            item.isReadByRecipient = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[4]);
+            return item;
+       }
+
+        protected virtual async Task<DriveTransferHistoryRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get1Command = cn.CreateCommand();
             {
-                get1Command.CommandText = "SELECT rowId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM driveTransferHistory " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
+                get1Command.CommandText = "SELECT rowId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM driveTransferHistory " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId LIMIT 1;";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -575,29 +577,76 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 var get1Param3 = get1Command.CreateParameter();
                 get1Param3.ParameterName = "@fileId";
                 get1Command.Parameters.Add(get1Param3);
+                var get1Param4 = get1Command.CreateParameter();
+                get1Param4.ParameterName = "@remoteIdentityId";
+                get1Command.Parameters.Add(get1Param4);
 
                 get1Param1.Value = identityId.ToByteArray();
                 get1Param2.Value = driveId.ToByteArray();
                 get1Param3.Value = fileId.ToByteArray();
+                get1Param4.Value = remoteIdentityId.DomainName;
                 {
-                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
                     {
                         if (await rdr.ReadAsync() == false)
                         {
-                            return new List<DriveTransferHistoryRecord>();
+                            return null;
                         }
-                        var result = new List<DriveTransferHistoryRecord>();
-                        while (true)
-                        {
-                            result.Add(ReadRecordFromReader1(rdr, identityId,driveId,fileId));
-                            if (!await rdr.ReadAsync())
-                                break;
-                        }
-                        return result;
+                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,remoteIdentityId);
+                        return r;
                     } // using
                 } //
             } // using
         }
+
+        protected virtual async Task<(List<DriveTransferHistoryRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM driveTransferHistory " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<DriveTransferHistoryRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
 
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryOldCRUD.cs
@@ -1,0 +1,651 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class DriveTransferHistoryOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private Guid _fileId;
+        public Guid fileId
+        {
+           get {
+                   return _fileId;
+               }
+           set {
+                  _fileId = value;
+               }
+        }
+        private OdinId _remoteIdentityId;
+        public OdinId remoteIdentityId
+        {
+           get {
+                   return _remoteIdentityId;
+               }
+           set {
+                  _remoteIdentityId = value;
+               }
+        }
+        private Int32 _latestTransferStatus;
+        public Int32 latestTransferStatus
+        {
+           get {
+                   return _latestTransferStatus;
+               }
+           set {
+                  _latestTransferStatus = value;
+               }
+        }
+        private Boolean _isInOutbox;
+        public Boolean isInOutbox
+        {
+           get {
+                   return _isInOutbox;
+               }
+           set {
+                  _isInOutbox = value;
+               }
+        }
+        private Guid? _latestSuccessfullyDeliveredVersionTag;
+        public Guid? latestSuccessfullyDeliveredVersionTag
+        {
+           get {
+                   return _latestSuccessfullyDeliveredVersionTag;
+               }
+           set {
+                  _latestSuccessfullyDeliveredVersionTag = value;
+               }
+        }
+        private Boolean _isReadByRecipient;
+        public Boolean isReadByRecipient
+        {
+           get {
+                   return _isReadByRecipient;
+               }
+           set {
+                  _isReadByRecipient = value;
+               }
+        }
+    } // End of class DriveTransferHistoryOldRecord
+
+    public abstract class TableDriveTransferHistoryOldCRUD
+    {
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableDriveTransferHistoryOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS DriveTransferHistoryOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS DriveTransferHistoryOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL, "
+                   +"remoteIdentityId TEXT NOT NULL, "
+                   +"latestTransferStatus BIGINT NOT NULL, "
+                   +"isInOutbox BOOLEAN NOT NULL, "
+                   +"latestSuccessfullyDeliveredVersionTag BYTEA , "
+                   +"isReadByRecipient BOOLEAN NOT NULL "
+                   + rowid
+                   +", PRIMARY KEY (identityId,driveId,fileId,remoteIdentityId)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0DriveTransferHistoryOld ON DriveTransferHistoryOld(identityId,driveId,fileId);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(DriveTransferHistoryOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.latestSuccessfullyDeliveredVersionTag.AssertGuidNotEmpty("Guid parameter latestSuccessfullyDeliveredVersionTag cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveTransferHistoryOld (identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@remoteIdentityId,@latestTransferStatus,@isInOutbox,@latestSuccessfullyDeliveredVersionTag,@isReadByRecipient)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@remoteIdentityId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@latestTransferStatus";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@isInOutbox";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@latestSuccessfullyDeliveredVersionTag";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@isReadByRecipient";
+                insertCommand.Parameters.Add(insertParam8);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.remoteIdentityId.DomainName;
+                insertParam5.Value = item.latestTransferStatus;
+                insertParam6.Value = item.isInOutbox;
+                insertParam7.Value = item.latestSuccessfullyDeliveredVersionTag?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam8.Value = item.isReadByRecipient;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DriveTransferHistoryOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.latestSuccessfullyDeliveredVersionTag.AssertGuidNotEmpty("Guid parameter latestSuccessfullyDeliveredVersionTag cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO DriveTransferHistoryOld (identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@remoteIdentityId,@latestTransferStatus,@isInOutbox,@latestSuccessfullyDeliveredVersionTag,@isReadByRecipient) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@remoteIdentityId";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@latestTransferStatus";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@isInOutbox";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@latestSuccessfullyDeliveredVersionTag";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@isReadByRecipient";
+                insertCommand.Parameters.Add(insertParam8);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.remoteIdentityId.DomainName;
+                insertParam5.Value = item.latestTransferStatus;
+                insertParam6.Value = item.isInOutbox;
+                insertParam7.Value = item.latestSuccessfullyDeliveredVersionTag?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam8.Value = item.isReadByRecipient;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DriveTransferHistoryOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.latestSuccessfullyDeliveredVersionTag.AssertGuidNotEmpty("Guid parameter latestSuccessfullyDeliveredVersionTag cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO DriveTransferHistoryOld (identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@remoteIdentityId,@latestTransferStatus,@isInOutbox,@latestSuccessfullyDeliveredVersionTag,@isReadByRecipient)"+
+                                             "ON CONFLICT (identityId,driveId,fileId,remoteIdentityId) DO UPDATE "+
+                                             "SET latestTransferStatus = @latestTransferStatus,isInOutbox = @isInOutbox,latestSuccessfullyDeliveredVersionTag = @latestSuccessfullyDeliveredVersionTag,isReadByRecipient = @isReadByRecipient "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@fileId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@remoteIdentityId";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@latestTransferStatus";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@isInOutbox";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@latestSuccessfullyDeliveredVersionTag";
+                upsertCommand.Parameters.Add(upsertParam7);
+                var upsertParam8 = upsertCommand.CreateParameter();
+                upsertParam8.ParameterName = "@isReadByRecipient";
+                upsertCommand.Parameters.Add(upsertParam8);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.driveId.ToByteArray();
+                upsertParam3.Value = item.fileId.ToByteArray();
+                upsertParam4.Value = item.remoteIdentityId.DomainName;
+                upsertParam5.Value = item.latestTransferStatus;
+                upsertParam6.Value = item.isInOutbox;
+                upsertParam7.Value = item.latestSuccessfullyDeliveredVersionTag?.ToByteArray() ?? (object)DBNull.Value;
+                upsertParam8.Value = item.isReadByRecipient;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(DriveTransferHistoryOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.latestSuccessfullyDeliveredVersionTag.AssertGuidNotEmpty("Guid parameter latestSuccessfullyDeliveredVersionTag cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE DriveTransferHistoryOld " +
+                                             "SET latestTransferStatus = @latestTransferStatus,isInOutbox = @isInOutbox,latestSuccessfullyDeliveredVersionTag = @latestSuccessfullyDeliveredVersionTag,isReadByRecipient = @isReadByRecipient "+
+                                             "WHERE (identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@fileId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@remoteIdentityId";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@latestTransferStatus";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@isInOutbox";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@latestSuccessfullyDeliveredVersionTag";
+                updateCommand.Parameters.Add(updateParam7);
+                var updateParam8 = updateCommand.CreateParameter();
+                updateParam8.ParameterName = "@isReadByRecipient";
+                updateCommand.Parameters.Add(updateParam8);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.driveId.ToByteArray();
+                updateParam3.Value = item.fileId.ToByteArray();
+                updateParam4.Value = item.remoteIdentityId.DomainName;
+                updateParam5.Value = item.latestTransferStatus;
+                updateParam6.Value = item.isInOutbox;
+                updateParam7.Value = item.latestSuccessfullyDeliveredVersionTag?.ToByteArray() ?? (object)DBNull.Value;
+                updateParam8.Value = item.isReadByRecipient;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE driveTransferHistory RENAME TO DriveTransferHistoryOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM DriveTransferHistoryOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("driveId");
+            sl.Add("fileId");
+            sl.Add("remoteIdentityId");
+            sl.Add("latestTransferStatus");
+            sl.Add("isInOutbox");
+            sl.Add("latestSuccessfullyDeliveredVersionTag");
+            sl.Add("isReadByRecipient");
+            return sl;
+        }
+
+        public virtual async Task<int> GetDriveCountAsync(Guid driveId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountDriveCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountDriveCommand.CommandText = "SELECT COUNT(*) FROM DriveTransferHistoryOld WHERE driveId = $driveId;";
+                var getCountDriveParam1 = getCountDriveCommand.CreateParameter();
+                getCountDriveParam1.ParameterName = "$driveId";
+                getCountDriveCommand.Parameters.Add(getCountDriveParam1);
+                getCountDriveParam1.Value = driveId.ToByteArray();
+                var count = await getCountDriveCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            } // using
+        }
+
+        // SELECT identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient
+        public DriveTransferHistoryOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<DriveTransferHistoryOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTransferHistoryOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.remoteIdentityId = (rdr[3] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[3]);
+            item.latestTransferStatus = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.isInOutbox = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[5]);
+            item.latestSuccessfullyDeliveredVersionTag = (rdr[6] == DBNull.Value) ? null : new Guid((byte[])rdr[6]);
+            item.isReadByRecipient = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[7]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM DriveTransferHistoryOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@fileId";
+                delete0Command.Parameters.Add(delete0Param3);
+                var delete0Param4 = delete0Command.CreateParameter();
+                delete0Param4.ParameterName = "@remoteIdentityId";
+                delete0Command.Parameters.Add(delete0Param4);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = driveId.ToByteArray();
+                delete0Param3.Value = fileId.ToByteArray();
+                delete0Param4.Value = remoteIdentityId.DomainName;
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public virtual async Task<int> DeleteAllRowsAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete1Command = cn.CreateCommand();
+            {
+                delete1Command.CommandText = "DELETE FROM DriveTransferHistoryOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId";
+                var delete1Param1 = delete1Command.CreateParameter();
+                delete1Param1.ParameterName = "@identityId";
+                delete1Command.Parameters.Add(delete1Param1);
+                var delete1Param2 = delete1Command.CreateParameter();
+                delete1Param2.ParameterName = "@driveId";
+                delete1Command.Parameters.Add(delete1Param2);
+                var delete1Param3 = delete1Command.CreateParameter();
+                delete1Param3.ParameterName = "@fileId";
+                delete1Command.Parameters.Add(delete1Param3);
+
+                delete1Param1.Value = identityId.ToByteArray();
+                delete1Param2.Value = driveId.ToByteArray();
+                delete1Param3.Value = fileId.ToByteArray();
+                var count = await delete1Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public DriveTransferHistoryOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
+        {
+            var result = new List<DriveTransferHistoryOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTransferHistoryOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.remoteIdentityId = remoteIdentityId;
+            item.latestTransferStatus = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[0];
+            item.isInOutbox = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[1]);
+            item.latestSuccessfullyDeliveredVersionTag = (rdr[2] == DBNull.Value) ? null : new Guid((byte[])rdr[2]);
+            item.isReadByRecipient = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[3]);
+            return item;
+       }
+
+        public virtual async Task<DriveTransferHistoryOldRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,OdinId remoteIdentityId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM DriveTransferHistoryOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND remoteIdentityId = @remoteIdentityId LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@driveId";
+                get0Command.Parameters.Add(get0Param2);
+                var get0Param3 = get0Command.CreateParameter();
+                get0Param3.ParameterName = "@fileId";
+                get0Command.Parameters.Add(get0Param3);
+                var get0Param4 = get0Command.CreateParameter();
+                get0Param4.ParameterName = "@remoteIdentityId";
+                get0Command.Parameters.Add(get0Param4);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = driveId.ToByteArray();
+                get0Param3.Value = fileId.ToByteArray();
+                get0Param4.Value = remoteIdentityId.DomainName;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,identityId,driveId,fileId,remoteIdentityId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveTransferHistoryOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId)
+        {
+            var result = new List<DriveTransferHistoryOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTransferHistoryOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.remoteIdentityId = (rdr[0] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[0]);
+            item.latestTransferStatus = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
+            item.isInOutbox = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[2]);
+            item.latestSuccessfullyDeliveredVersionTag = (rdr[3] == DBNull.Value) ? null : new Guid((byte[])rdr[3]);
+            item.isReadByRecipient = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[4]);
+            return item;
+       }
+
+        public virtual async Task<List<DriveTransferHistoryOldRecord>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM DriveTransferHistoryOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@fileId";
+                get1Command.Parameters.Add(get1Param3);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = driveId.ToByteArray();
+                get1Param3.Value = fileId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<DriveTransferHistoryOldRecord>();
+                        }
+                        var result = new List<DriveTransferHistoryOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader1(rdr,identityId,driveId,fileId));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public DriveTransferHistoryOldRecord ReadRecordFromReader2(DbDataReader rdr)
+        {
+            var result = new List<DriveTransferHistoryOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new DriveTransferHistoryOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.remoteIdentityId = (rdr[3] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[3]);
+            item.latestTransferStatus = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.isInOutbox = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[5]);
+            item.latestSuccessfullyDeliveredVersionTag = (rdr[6] == DBNull.Value) ? null : new Guid((byte[])rdr[6]);
+            item.isReadByRecipient = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[7]);
+            return item;
+       }
+
+        public virtual async Task<List<DriveTransferHistoryOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient FROM DriveTransferHistoryOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<DriveTransferHistoryOldRecord>();
+                        }
+                        var result = new List<DriveTransferHistoryOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader2(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
@@ -19,6 +19,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class FollowsMeRecord
     {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private Guid _identityId;
         public Guid identityId
         {
@@ -106,17 +116,21 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS followsMe;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
-            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
-                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS followsMe("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"identity TEXT NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   +", PRIMARY KEY (identityId,identity,driveId)"
+                   +", UNIQUE(identityId,identity,driveId)"
                    +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableFollowsMeCRUD ON followsMe(identityId,identity);"
                    ;
@@ -311,6 +325,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("identityId");
             sl.Add("identity");
             sl.Add("driveId");
@@ -319,7 +334,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return sl;
         }
 
-        // SELECT identityId,identity,driveId,created,modified
+        // SELECT rowId,identityId,identity,driveId,created,modified
         protected FollowsMeRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<FollowsMeRecord>();
@@ -328,11 +343,12 @@ namespace Odin.Core.Storage.Database.Identity.Table
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new FollowsMeRecord();
-            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
-            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
-            item.created = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
-            item.modified = (rdr[4] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[4]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.identityNoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[2];
+            item.driveId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.created = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[4]);
+            item.modified = (rdr[5] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[5]);
             return item;
        }
 
@@ -380,8 +396,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.identityId = identityId;
             item.identity = identity;
             item.driveId = driveId;
-            item.created = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[0]);
-            item.modified = (rdr[1] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[1]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.created = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[1]);
+            item.modified = (rdr[2] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[2]);
             return item;
        }
 
@@ -396,7 +413,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT created,modified FROM followsMe " +
+                get0Command.CommandText = "SELECT rowId,created,modified FROM followsMe " +
                                              "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
@@ -440,9 +457,10 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new FollowsMeRecord();
             item.identityId = identityId;
             item.identity = identity;
-            item.driveId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.created = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[1]);
-            item.modified = (rdr[2] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[2]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.created = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.modified = (rdr[3] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[3]);
             return item;
        }
 
@@ -454,7 +472,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get1Command = cn.CreateCommand();
             {
-                get1Command.CommandText = "SELECT driveId,created,modified FROM followsMe " +
+                get1Command.CommandText = "SELECT rowId,driveId,created,modified FROM followsMe " +
                                              "WHERE identityId = @identityId AND identity = @identity;";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
@@ -106,11 +106,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS followsMe;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS followsMe("
                    +"identityId BYTEA NOT NULL, "
@@ -118,9 +113,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"driveId BYTEA NOT NULL, "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   + rowid
                    +", PRIMARY KEY (identityId,identity,driveId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableFollowsMeCRUD ON followsMe(identityId,identity);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
@@ -382,7 +382,67 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected FollowsMeRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,string identity,Guid driveId)
+        protected FollowsMeRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,string identity)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 255) throw new Exception("Too long");
+            var result = new List<FollowsMeRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new FollowsMeRecord();
+            item.identityId = identityId;
+            item.identity = identity;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.created = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.modified = (rdr[3] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[3]);
+            return item;
+       }
+
+        protected virtual async Task<List<FollowsMeRecord>> GetAsync(Guid identityId,string identity)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 255) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT rowId,driveId,created,modified FROM followsMe " +
+                                             "WHERE identityId = @identityId AND identity = @identity;";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@identity";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = identity;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableFollowsMeCRUD", identityId.ToString()+identity, null);
+                            return new List<FollowsMeRecord>();
+                        }
+                        var result = new List<FollowsMeRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr, identityId,identity));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        protected FollowsMeRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,string identity,Guid driveId)
         {
             if (identity == null) throw new Exception("Cannot be null");
             if (identity?.Length < 3) throw new Exception("Too short");
@@ -411,32 +471,32 @@ namespace Odin.Core.Storage.Database.Identity.Table
             if (hit)
                 return (FollowsMeRecord)cacheObject;
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var get0Command = cn.CreateCommand();
+            await using var get1Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT rowId,created,modified FROM followsMe " +
+                get1Command.CommandText = "SELECT rowId,created,modified FROM followsMe " +
                                              "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;";
-                var get0Param1 = get0Command.CreateParameter();
-                get0Param1.ParameterName = "@identityId";
-                get0Command.Parameters.Add(get0Param1);
-                var get0Param2 = get0Command.CreateParameter();
-                get0Param2.ParameterName = "@identity";
-                get0Command.Parameters.Add(get0Param2);
-                var get0Param3 = get0Command.CreateParameter();
-                get0Param3.ParameterName = "@driveId";
-                get0Command.Parameters.Add(get0Param3);
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@identity";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param3);
 
-                get0Param1.Value = identityId.ToByteArray();
-                get0Param2.Value = identity;
-                get0Param3.Value = driveId.ToByteArray();
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = identity;
+                get1Param3.Value = driveId.ToByteArray();
                 {
-                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
                     {
                         if (await rdr.ReadAsync() == false)
                         {
                             _cache.AddOrUpdate("TableFollowsMeCRUD", identityId.ToString()+identity+driveId.ToString(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,identity,driveId);
+                        var r = ReadRecordFromReader1(rdr, identityId,identity,driveId);
                         _cache.AddOrUpdate("TableFollowsMeCRUD", identityId.ToString()+identity+driveId.ToString(), r);
                         return r;
                     } // using
@@ -444,65 +504,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected FollowsMeRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,string identity)
+        protected virtual async Task<(List<FollowsMeRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
         {
-            if (identity == null) throw new Exception("Cannot be null");
-            if (identity?.Length < 3) throw new Exception("Too short");
-            if (identity?.Length > 255) throw new Exception("Too long");
-            var result = new List<FollowsMeRecord>();
-#pragma warning disable CS0168
-            long bytesRead;
-#pragma warning restore CS0168
-            var guid = new byte[16];
-            var item = new FollowsMeRecord();
-            item.identityId = identityId;
-            item.identity = identity;
-            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
-            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
-            item.created = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
-            item.modified = (rdr[3] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[3]);
-            return item;
-       }
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
 
-        protected virtual async Task<List<FollowsMeRecord>> GetAsync(Guid identityId,string identity)
-        {
-            if (identity == null) throw new Exception("Cannot be null");
-            if (identity?.Length < 3) throw new Exception("Too short");
-            if (identity?.Length > 255) throw new Exception("Too long");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var get1Command = cn.CreateCommand();
+            await using var getPaging0Command = cn.CreateCommand();
             {
-                get1Command.CommandText = "SELECT rowId,driveId,created,modified FROM followsMe " +
-                                             "WHERE identityId = @identityId AND identity = @identity;";
-                var get1Param1 = get1Command.CreateParameter();
-                get1Param1.ParameterName = "@identityId";
-                get1Command.Parameters.Add(get1Param1);
-                var get1Param2 = get1Command.CreateParameter();
-                get1Param2.ParameterName = "@identity";
-                get1Command.Parameters.Add(get1Param2);
+                getPaging0Command.CommandText = "SELECT rowId,identityId,identity,driveId,created,modified FROM followsMe " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
 
-                get1Param1.Value = identityId.ToByteArray();
-                get1Param2.Value = identity;
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
                 {
-                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
                     {
-                        if (await rdr.ReadAsync() == false)
-                        {
-                            _cache.AddOrUpdate("TableFollowsMeCRUD", identityId.ToString()+identity, null);
-                            return new List<FollowsMeRecord>();
-                        }
                         var result = new List<FollowsMeRecord>();
-                        while (true)
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
                         {
-                            result.Add(ReadRecordFromReader1(rdr, identityId,identity));
-                            if (!await rdr.ReadAsync())
-                                break;
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
                         }
-                        return result;
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
                     } // using
                 } //
-            } // using
-        }
+            } // using 
+        } // PagingGet
 
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
@@ -106,6 +106,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS followsMe;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS followsMe("
                    +"identityId BYTEA NOT NULL, "
@@ -114,7 +117,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
                    +", PRIMARY KEY (identityId,identity,driveId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableFollowsMeCRUD ON followsMe(identityId,identity);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCRUD.cs
@@ -132,7 +132,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,identity,driveId)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableFollowsMeCRUD ON followsMe(identityId,identity);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0followsMe ON followsMe(identityId,identity);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -382,7 +382,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected FollowsMeRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,string identity)
+        protected FollowsMeRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,string identity)
         {
             if (identity == null) throw new Exception("Cannot be null");
             if (identity?.Length < 3) throw new Exception("Too short");
@@ -411,7 +411,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,driveId,created,modified FROM followsMe " +
-                                             "WHERE identityId = @identityId AND identity = @identity;";
+                                             "WHERE identityId = @identityId AND identity = @identity;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -432,7 +433,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<FollowsMeRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader0(rdr, identityId,identity));
+                            result.Add(ReadRecordFromReader0(rdr,identityId,identity));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -442,7 +443,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected FollowsMeRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,string identity,Guid driveId)
+        protected FollowsMeRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,string identity,Guid driveId)
         {
             if (identity == null) throw new Exception("Cannot be null");
             if (identity?.Length < 3) throw new Exception("Too short");
@@ -474,7 +475,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId,created,modified FROM followsMe " +
-                                             "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -496,7 +498,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableFollowsMeCRUD", identityId.ToString()+identity+driveId.ToString(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,identity,driveId);
+                        var r = ReadRecordFromReader1(rdr,identityId,identity,driveId);
                         _cache.AddOrUpdate("TableFollowsMeCRUD", identityId.ToString()+identity+driveId.ToString(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeOldCRUD.cs
@@ -1,0 +1,553 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+[assembly: InternalsVisibleTo("DatabaseCommitTest")]
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class FollowsMeOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private string _identity;
+        public string identity
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 3) throw new Exception("Too short");
+                    if (value?.Length > 255) throw new Exception("Too long");
+                  _identity = value;
+               }
+        }
+        internal string identityNoLengthCheck
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 3) throw new Exception("Too short");
+                  _identity = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class FollowsMeOldRecord
+
+    public abstract class TableFollowsMeOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableFollowsMeOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS FollowsMeOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS FollowsMeOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"identity TEXT NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,identity,driveId)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0FollowsMeOld ON FollowsMeOld(identityId,identity);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(FollowsMeOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO FollowsMeOld (identityId,identity,driveId,created,modified) " +
+                                             "VALUES (@identityId,@identity,@driveId,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.identity;
+                insertParam3.Value = item.driveId.ToByteArray();
+                var now = UnixTimeUtc.Now();
+                insertParam4.Value = now.milliseconds;
+                item.modified = null;
+                insertParam5.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.created = now;
+                    _cache.AddOrUpdate("TableFollowsMeOldCRUD", item.identityId.ToString()+item.identity+item.driveId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(FollowsMeOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO FollowsMeOld (identityId,identity,driveId,created,modified) " +
+                                             "VALUES (@identityId,@identity,@driveId,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.identity;
+                insertParam3.Value = item.driveId.ToByteArray();
+                var now = UnixTimeUtc.Now();
+                insertParam4.Value = now.milliseconds;
+                item.modified = null;
+                insertParam5.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    item.created = now;
+                   _cache.AddOrUpdate("TableFollowsMeOldCRUD", item.identityId.ToString()+item.identity+item.driveId.ToString(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(FollowsMeOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO FollowsMeOld (identityId,identity,driveId,created) " +
+                                             "VALUES (@identityId,@identity,@driveId,@created)"+
+                                             "ON CONFLICT (identityId,identity,driveId) DO UPDATE "+
+                                             "SET modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@identity";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.identity;
+                upsertParam3.Value = item.driveId.ToByteArray();
+                upsertParam4.Value = now.milliseconds;
+                upsertParam5.Value = now.milliseconds;
+                await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   _cache.AddOrUpdate("TableFollowsMeOldCRUD", item.identityId.ToString()+item.identity+item.driveId.ToString(), item);
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(FollowsMeOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE FollowsMeOld " +
+                                             "SET modified = @modified "+
+                                             "WHERE (identityId = @identityId AND identity = @identity AND driveId = @driveId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@identity";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam5);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.identity;
+                updateParam3.Value = item.driveId.ToByteArray();
+                updateParam4.Value = now.milliseconds;
+                updateParam5.Value = now.milliseconds;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.modified = now;
+                    _cache.AddOrUpdate("TableFollowsMeOldCRUD", item.identityId.ToString()+item.identity+item.driveId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE followsMe RENAME TO FollowsMeOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM FollowsMeOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("identity");
+            sl.Add("driveId");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        // SELECT identityId,identity,driveId,created,modified
+        public FollowsMeOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<FollowsMeOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new FollowsMeOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.created = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.modified = (rdr[4] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[4]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,string identity,Guid driveId)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 255) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM FollowsMeOld " +
+                                             "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@identity";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param3);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = identity;
+                delete0Param3.Value = driveId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableFollowsMeOldCRUD", identityId.ToString()+identity+driveId.ToString());
+                return count;
+            }
+        }
+
+        public FollowsMeOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,string identity)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 255) throw new Exception("Too long");
+            var result = new List<FollowsMeOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new FollowsMeOldRecord();
+            item.identityId = identityId;
+            item.identity = identity;
+            item.driveId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.created = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[1]);
+            item.modified = (rdr[2] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[2]);
+            return item;
+       }
+
+        public virtual async Task<List<FollowsMeOldRecord>> GetAsync(Guid identityId,string identity)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 255) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT driveId,created,modified FROM FollowsMeOld " +
+                                             "WHERE identityId = @identityId AND identity = @identity;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@identity";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = identity;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableFollowsMeOldCRUD", identityId.ToString()+identity, null);
+                            return new List<FollowsMeOldRecord>();
+                        }
+                        var result = new List<FollowsMeOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr,identityId,identity));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public FollowsMeOldRecord ReadRecordFromReader1(DbDataReader rdr)
+        {
+            var result = new List<FollowsMeOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new FollowsMeOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.created = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.modified = (rdr[4] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[4]);
+            return item;
+       }
+
+        public virtual async Task<List<FollowsMeOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT identityId,identity,driveId,created,modified FROM FollowsMeOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<FollowsMeOldRecord>();
+                        }
+                        var result = new List<FollowsMeOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader1(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public FollowsMeOldRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,string identity,Guid driveId)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 255) throw new Exception("Too long");
+            var result = new List<FollowsMeOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new FollowsMeOldRecord();
+            item.identityId = identityId;
+            item.identity = identity;
+            item.driveId = driveId;
+            item.created = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[0]);
+            item.modified = (rdr[1] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[1]);
+            return item;
+       }
+
+        public virtual async Task<FollowsMeOldRecord> GetAsync(Guid identityId,string identity,Guid driveId)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 255) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableFollowsMeOldCRUD", identityId.ToString()+identity+driveId.ToString());
+            if (hit)
+                return (FollowsMeOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT created,modified FROM FollowsMeOld " +
+                                             "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;"+
+                                             ";";
+                var get2Param1 = get2Command.CreateParameter();
+                get2Param1.ParameterName = "@identityId";
+                get2Command.Parameters.Add(get2Param1);
+                var get2Param2 = get2Command.CreateParameter();
+                get2Param2.ParameterName = "@identity";
+                get2Command.Parameters.Add(get2Param2);
+                var get2Param3 = get2Command.CreateParameter();
+                get2Param3.ParameterName = "@driveId";
+                get2Command.Parameters.Add(get2Param3);
+
+                get2Param1.Value = identityId.ToByteArray();
+                get2Param2.Value = identity;
+                get2Param3.Value = driveId.ToByteArray();
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableFollowsMeOldCRUD", identityId.ToString()+identity+driveId.ToString(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader2(rdr,identityId,identity,driveId);
+                        _cache.AddOrUpdate("TableFollowsMeOldCRUD", identityId.ToString()+identity+driveId.ToString(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCRUD.cs
@@ -363,7 +363,61 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected ImFollowingRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,OdinId identity,Guid driveId)
+        protected ImFollowingRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,OdinId identity)
+        {
+            var result = new List<ImFollowingRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new ImFollowingRecord();
+            item.identityId = identityId;
+            item.identity = identity;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.created = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.modified = (rdr[3] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[3]);
+            return item;
+       }
+
+        protected virtual async Task<List<ImFollowingRecord>> GetAsync(Guid identityId,OdinId identity)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT rowId,driveId,created,modified FROM imFollowing " +
+                                             "WHERE identityId = @identityId AND identity = @identity;";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@identity";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = identity.DomainName;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableImFollowingCRUD", identityId.ToString()+identity.DomainName, null);
+                            return new List<ImFollowingRecord>();
+                        }
+                        var result = new List<ImFollowingRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr, identityId,identity));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        protected ImFollowingRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,OdinId identity,Guid driveId)
         {
             var result = new List<ImFollowingRecord>();
 #pragma warning disable CS0168
@@ -386,32 +440,32 @@ namespace Odin.Core.Storage.Database.Identity.Table
             if (hit)
                 return (ImFollowingRecord)cacheObject;
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var get0Command = cn.CreateCommand();
+            await using var get1Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT rowId,created,modified FROM imFollowing " +
+                get1Command.CommandText = "SELECT rowId,created,modified FROM imFollowing " +
                                              "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;";
-                var get0Param1 = get0Command.CreateParameter();
-                get0Param1.ParameterName = "@identityId";
-                get0Command.Parameters.Add(get0Param1);
-                var get0Param2 = get0Command.CreateParameter();
-                get0Param2.ParameterName = "@identity";
-                get0Command.Parameters.Add(get0Param2);
-                var get0Param3 = get0Command.CreateParameter();
-                get0Param3.ParameterName = "@driveId";
-                get0Command.Parameters.Add(get0Param3);
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@identity";
+                get1Command.Parameters.Add(get1Param2);
+                var get1Param3 = get1Command.CreateParameter();
+                get1Param3.ParameterName = "@driveId";
+                get1Command.Parameters.Add(get1Param3);
 
-                get0Param1.Value = identityId.ToByteArray();
-                get0Param2.Value = identity.DomainName;
-                get0Param3.Value = driveId.ToByteArray();
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = identity.DomainName;
+                get1Param3.Value = driveId.ToByteArray();
                 {
-                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
                     {
                         if (await rdr.ReadAsync() == false)
                         {
                             _cache.AddOrUpdate("TableImFollowingCRUD", identityId.ToString()+identity.DomainName+driveId.ToString(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,identity,driveId);
+                        var r = ReadRecordFromReader1(rdr, identityId,identity,driveId);
                         _cache.AddOrUpdate("TableImFollowingCRUD", identityId.ToString()+identity.DomainName+driveId.ToString(), r);
                         return r;
                     } // using
@@ -419,59 +473,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected ImFollowingRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,OdinId identity)
+        protected virtual async Task<(List<ImFollowingRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
         {
-            var result = new List<ImFollowingRecord>();
-#pragma warning disable CS0168
-            long bytesRead;
-#pragma warning restore CS0168
-            var guid = new byte[16];
-            var item = new ImFollowingRecord();
-            item.identityId = identityId;
-            item.identity = identity;
-            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
-            item.driveId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
-            item.created = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
-            item.modified = (rdr[3] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[3]);
-            return item;
-       }
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
 
-        protected virtual async Task<List<ImFollowingRecord>> GetAsync(Guid identityId,OdinId identity)
-        {
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
-            await using var get1Command = cn.CreateCommand();
+            await using var getPaging0Command = cn.CreateCommand();
             {
-                get1Command.CommandText = "SELECT rowId,driveId,created,modified FROM imFollowing " +
-                                             "WHERE identityId = @identityId AND identity = @identity;";
-                var get1Param1 = get1Command.CreateParameter();
-                get1Param1.ParameterName = "@identityId";
-                get1Command.Parameters.Add(get1Param1);
-                var get1Param2 = get1Command.CreateParameter();
-                get1Param2.ParameterName = "@identity";
-                get1Command.Parameters.Add(get1Param2);
+                getPaging0Command.CommandText = "SELECT rowId,identityId,identity,driveId,created,modified FROM imFollowing " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
 
-                get1Param1.Value = identityId.ToByteArray();
-                get1Param2.Value = identity.DomainName;
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
                 {
-                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
                     {
-                        if (await rdr.ReadAsync() == false)
-                        {
-                            _cache.AddOrUpdate("TableImFollowingCRUD", identityId.ToString()+identity.DomainName, null);
-                            return new List<ImFollowingRecord>();
-                        }
                         var result = new List<ImFollowingRecord>();
-                        while (true)
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
                         {
-                            result.Add(ReadRecordFromReader1(rdr, identityId,identity));
-                            if (!await rdr.ReadAsync())
-                                break;
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
                         }
-                        return result;
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
                     } // using
                 } //
-            } // using
-        }
+            } // using 
+        } // PagingGet
 
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCRUD.cs
@@ -90,6 +90,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS imFollowing;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS imFollowing("
                    +"identityId BYTEA NOT NULL, "
@@ -98,7 +101,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
                    +", PRIMARY KEY (identityId,identity,driveId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableImFollowingCRUD ON imFollowing(identityId,identity);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCRUD.cs
@@ -116,7 +116,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,identity,driveId)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableImFollowingCRUD ON imFollowing(identityId,identity);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0imFollowing ON imFollowing(identityId,identity);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -363,7 +363,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected ImFollowingRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,OdinId identity)
+        protected ImFollowingRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,OdinId identity)
         {
             var result = new List<ImFollowingRecord>();
 #pragma warning disable CS0168
@@ -386,7 +386,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,driveId,created,modified FROM imFollowing " +
-                                             "WHERE identityId = @identityId AND identity = @identity;";
+                                             "WHERE identityId = @identityId AND identity = @identity;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -407,7 +408,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<ImFollowingRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader0(rdr, identityId,identity));
+                            result.Add(ReadRecordFromReader0(rdr,identityId,identity));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -417,7 +418,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected ImFollowingRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,OdinId identity,Guid driveId)
+        protected ImFollowingRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,OdinId identity,Guid driveId)
         {
             var result = new List<ImFollowingRecord>();
 #pragma warning disable CS0168
@@ -443,7 +444,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId,created,modified FROM imFollowing " +
-                                             "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -465,7 +467,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableImFollowingCRUD", identityId.ToString()+identity.DomainName+driveId.ToString(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,identity,driveId);
+                        var r = ReadRecordFromReader1(rdr,identityId,identity,driveId);
                         _cache.AddOrUpdate("TableImFollowingCRUD", identityId.ToString()+identity.DomainName+driveId.ToString(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCRUD.cs
@@ -90,11 +90,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS imFollowing;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS imFollowing("
                    +"identityId BYTEA NOT NULL, "
@@ -102,9 +97,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"driveId BYTEA NOT NULL, "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   + rowid
                    +", PRIMARY KEY (identityId,identity,driveId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableImFollowingCRUD ON imFollowing(identityId,identity);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingOldCRUD.cs
@@ -1,0 +1,522 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class ImFollowingOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private OdinId _identity;
+        public OdinId identity
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                  _identity = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class ImFollowingOldRecord
+
+    public abstract class TableImFollowingOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableImFollowingOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS ImFollowingOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS ImFollowingOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"identity TEXT NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,identity,driveId)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0ImFollowingOld ON ImFollowingOld(identityId,identity);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(ImFollowingOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO ImFollowingOld (identityId,identity,driveId,created,modified) " +
+                                             "VALUES (@identityId,@identity,@driveId,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.identity.DomainName;
+                insertParam3.Value = item.driveId.ToByteArray();
+                var now = UnixTimeUtc.Now();
+                insertParam4.Value = now.milliseconds;
+                item.modified = null;
+                insertParam5.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.created = now;
+                    _cache.AddOrUpdate("TableImFollowingOldCRUD", item.identityId.ToString()+item.identity.DomainName+item.driveId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(ImFollowingOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO ImFollowingOld (identityId,identity,driveId,created,modified) " +
+                                             "VALUES (@identityId,@identity,@driveId,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.identity.DomainName;
+                insertParam3.Value = item.driveId.ToByteArray();
+                var now = UnixTimeUtc.Now();
+                insertParam4.Value = now.milliseconds;
+                item.modified = null;
+                insertParam5.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    item.created = now;
+                   _cache.AddOrUpdate("TableImFollowingOldCRUD", item.identityId.ToString()+item.identity.DomainName+item.driveId.ToString(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(ImFollowingOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO ImFollowingOld (identityId,identity,driveId,created) " +
+                                             "VALUES (@identityId,@identity,@driveId,@created)"+
+                                             "ON CONFLICT (identityId,identity,driveId) DO UPDATE "+
+                                             "SET modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@identity";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.identity.DomainName;
+                upsertParam3.Value = item.driveId.ToByteArray();
+                upsertParam4.Value = now.milliseconds;
+                upsertParam5.Value = now.milliseconds;
+                await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   _cache.AddOrUpdate("TableImFollowingOldCRUD", item.identityId.ToString()+item.identity.DomainName+item.driveId.ToString(), item);
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(ImFollowingOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE ImFollowingOld " +
+                                             "SET modified = @modified "+
+                                             "WHERE (identityId = @identityId AND identity = @identity AND driveId = @driveId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@identity";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam5);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.identity.DomainName;
+                updateParam3.Value = item.driveId.ToByteArray();
+                updateParam4.Value = now.milliseconds;
+                updateParam5.Value = now.milliseconds;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.modified = now;
+                    _cache.AddOrUpdate("TableImFollowingOldCRUD", item.identityId.ToString()+item.identity.DomainName+item.driveId.ToString(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE imFollowing RENAME TO ImFollowingOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM ImFollowingOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("identity");
+            sl.Add("driveId");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        // SELECT identityId,identity,driveId,created,modified
+        public ImFollowingOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<ImFollowingOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new ImFollowingOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.identity = (rdr[1] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[1]);
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.created = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.modified = (rdr[4] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[4]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,OdinId identity,Guid driveId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM ImFollowingOld " +
+                                             "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@identity";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param3);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = identity.DomainName;
+                delete0Param3.Value = driveId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableImFollowingOldCRUD", identityId.ToString()+identity.DomainName+driveId.ToString());
+                return count;
+            }
+        }
+
+        public ImFollowingOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,OdinId identity)
+        {
+            var result = new List<ImFollowingOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new ImFollowingOldRecord();
+            item.identityId = identityId;
+            item.identity = identity;
+            item.driveId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.created = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[1]);
+            item.modified = (rdr[2] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[2]);
+            return item;
+       }
+
+        public virtual async Task<List<ImFollowingOldRecord>> GetAsync(Guid identityId,OdinId identity)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT driveId,created,modified FROM ImFollowingOld " +
+                                             "WHERE identityId = @identityId AND identity = @identity;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@identity";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = identity.DomainName;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableImFollowingOldCRUD", identityId.ToString()+identity.DomainName, null);
+                            return new List<ImFollowingOldRecord>();
+                        }
+                        var result = new List<ImFollowingOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr,identityId,identity));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public ImFollowingOldRecord ReadRecordFromReader1(DbDataReader rdr)
+        {
+            var result = new List<ImFollowingOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new ImFollowingOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.identity = (rdr[1] == DBNull.Value) ?                 throw new Exception("item is NULL, but set as NOT NULL") : new OdinId((string)rdr[1]);
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.created = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.modified = (rdr[4] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[4]);
+            return item;
+       }
+
+        public virtual async Task<List<ImFollowingOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT identityId,identity,driveId,created,modified FROM ImFollowingOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<ImFollowingOldRecord>();
+                        }
+                        var result = new List<ImFollowingOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader1(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public ImFollowingOldRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,OdinId identity,Guid driveId)
+        {
+            var result = new List<ImFollowingOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new ImFollowingOldRecord();
+            item.identityId = identityId;
+            item.identity = identity;
+            item.driveId = driveId;
+            item.created = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[0]);
+            item.modified = (rdr[1] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[1]);
+            return item;
+       }
+
+        public virtual async Task<ImFollowingOldRecord> GetAsync(Guid identityId,OdinId identity,Guid driveId)
+        {
+            var (hit, cacheObject) = _cache.Get("TableImFollowingOldCRUD", identityId.ToString()+identity.DomainName+driveId.ToString());
+            if (hit)
+                return (ImFollowingOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT created,modified FROM ImFollowingOld " +
+                                             "WHERE identityId = @identityId AND identity = @identity AND driveId = @driveId LIMIT 1;"+
+                                             ";";
+                var get2Param1 = get2Command.CreateParameter();
+                get2Param1.ParameterName = "@identityId";
+                get2Command.Parameters.Add(get2Param1);
+                var get2Param2 = get2Command.CreateParameter();
+                get2Param2.ParameterName = "@identity";
+                get2Command.Parameters.Add(get2Param2);
+                var get2Param3 = get2Command.CreateParameter();
+                get2Param3.ParameterName = "@driveId";
+                get2Command.Parameters.Add(get2Param3);
+
+                get2Param1.Value = identityId.ToByteArray();
+                get2Param2.Value = identity.DomainName;
+                get2Param3.Value = driveId.ToByteArray();
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableImFollowingOldCRUD", identityId.ToString()+identity.DomainName+driveId.ToString(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader2(rdr,identityId,identity,driveId);
+                        _cache.AddOrUpdate("TableImFollowingOldCRUD", identityId.ToString()+identity.DomainName+driveId.ToString(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInbox.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInbox.cs
@@ -63,7 +63,7 @@ public class TableInbox(
 
         cmd.CommandText =
             "UPDATE inbox SET popstamp=@popstamp WHERE rowid IN (SELECT rowid FROM inbox WHERE identityId=@identityId AND boxId=@boxId AND popstamp IS NULL ORDER BY rowId ASC LIMIT @count); " +
-            "SELECT identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified FROM inbox WHERE identityId = @identityId AND popstamp=@popstamp ORDER BY rowId ASC";
+            "SELECT rowid,identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified FROM inbox WHERE identityId = @identityId AND popstamp=@popstamp ORDER BY rowId ASC";
 
         var param1 = cmd.CreateParameter();
         var param2 = cmd.CreateParameter();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
@@ -174,10 +174,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
             else
-                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
-            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS inbox("

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
@@ -193,9 +193,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,fileId)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableInboxCRUD ON inbox(identityId,timeStamp);"
-                   +"CREATE INDEX IF NOT EXISTS Idx1TableInboxCRUD ON inbox(identityId,boxId);"
-                   +"CREATE INDEX IF NOT EXISTS Idx2TableInboxCRUD ON inbox(identityId,popStamp);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0inbox ON inbox(identityId,timeStamp);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1inbox ON inbox(identityId,boxId);"
+                   +"CREATE INDEX IF NOT EXISTS Idx2inbox ON inbox(identityId,popStamp);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -536,7 +536,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected InboxRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid fileId)
+        protected InboxRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid fileId)
         {
             var result = new List<InboxRecord>();
 #pragma warning disable CS0168
@@ -566,7 +566,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified FROM inbox " +
-                                             "WHERE identityId = @identityId AND fileId = @fileId LIMIT 1;";
+                                             "WHERE identityId = @identityId AND fileId = @fileId LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -583,7 +584,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,fileId);
+                        var r = ReadRecordFromReader0(rdr,identityId,fileId);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
@@ -37,16 +37,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                   _identityId = value;
                }
         }
-        private Guid _fileId;
-        public Guid fileId
-        {
-           get {
-                   return _fileId;
-               }
-           set {
-                  _fileId = value;
-               }
-        }
         private Guid _boxId;
         public Guid boxId
         {
@@ -55,6 +45,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
                }
            set {
                   _boxId = value;
+               }
+        }
+        private Guid _fileId;
+        public Guid fileId
+        {
+           get {
+                   return _fileId;
+               }
+           set {
+                  _fileId = value;
                }
         }
         private Int32 _priority;
@@ -182,8 +182,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 "CREATE TABLE IF NOT EXISTS inbox("
                    +rowid
                    +"identityId BYTEA NOT NULL, "
-                   +"fileId BYTEA NOT NULL UNIQUE, "
                    +"boxId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL UNIQUE, "
                    +"priority BIGINT NOT NULL, "
                    +"timeStamp BIGINT NOT NULL, "
                    +"value BYTEA , "
@@ -203,22 +203,22 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<int> InsertAsync(InboxRecord item)
         {
             item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
-            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
             item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
             item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                insertCommand.CommandText = "INSERT INTO inbox (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
-                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified)";
+                insertCommand.CommandText = "INSERT INTO inbox (identityId,boxId,fileId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
+                                             "VALUES (@identityId,@boxId,@fileId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified)";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
                 insertCommand.Parameters.Add(insertParam1);
                 var insertParam2 = insertCommand.CreateParameter();
-                insertParam2.ParameterName = "@fileId";
+                insertParam2.ParameterName = "@boxId";
                 insertCommand.Parameters.Add(insertParam2);
                 var insertParam3 = insertCommand.CreateParameter();
-                insertParam3.ParameterName = "@boxId";
+                insertParam3.ParameterName = "@fileId";
                 insertCommand.Parameters.Add(insertParam3);
                 var insertParam4 = insertCommand.CreateParameter();
                 insertParam4.ParameterName = "@priority";
@@ -242,8 +242,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 insertParam10.ParameterName = "@modified";
                 insertCommand.Parameters.Add(insertParam10);
                 insertParam1.Value = item.identityId.ToByteArray();
-                insertParam2.Value = item.fileId.ToByteArray();
-                insertParam3.Value = item.boxId.ToByteArray();
+                insertParam2.Value = item.boxId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
                 insertParam4.Value = item.priority;
                 insertParam5.Value = item.timeStamp.milliseconds;
                 insertParam6.Value = item.value ?? (object)DBNull.Value;
@@ -265,23 +265,23 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<bool> TryInsertAsync(InboxRecord item)
         {
             item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
-            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
             item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
             item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                insertCommand.CommandText = "INSERT INTO inbox (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
-                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified) " +
+                insertCommand.CommandText = "INSERT INTO inbox (identityId,boxId,fileId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
+                                             "VALUES (@identityId,@boxId,@fileId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified) " +
                                              "ON CONFLICT DO NOTHING";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
                 insertCommand.Parameters.Add(insertParam1);
                 var insertParam2 = insertCommand.CreateParameter();
-                insertParam2.ParameterName = "@fileId";
+                insertParam2.ParameterName = "@boxId";
                 insertCommand.Parameters.Add(insertParam2);
                 var insertParam3 = insertCommand.CreateParameter();
-                insertParam3.ParameterName = "@boxId";
+                insertParam3.ParameterName = "@fileId";
                 insertCommand.Parameters.Add(insertParam3);
                 var insertParam4 = insertCommand.CreateParameter();
                 insertParam4.ParameterName = "@priority";
@@ -305,8 +305,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 insertParam10.ParameterName = "@modified";
                 insertCommand.Parameters.Add(insertParam10);
                 insertParam1.Value = item.identityId.ToByteArray();
-                insertParam2.Value = item.fileId.ToByteArray();
-                insertParam3.Value = item.boxId.ToByteArray();
+                insertParam2.Value = item.boxId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
                 insertParam4.Value = item.priority;
                 insertParam5.Value = item.timeStamp.milliseconds;
                 insertParam6.Value = item.value ?? (object)DBNull.Value;
@@ -328,14 +328,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<int> UpsertAsync(InboxRecord item)
         {
             item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
-            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
             item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
             item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var upsertCommand = cn.CreateCommand();
             {
-                upsertCommand.CommandText = "INSERT INTO inbox (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created) " +
-                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created)"+
+                upsertCommand.CommandText = "INSERT INTO inbox (identityId,boxId,fileId,priority,timeStamp,value,popStamp,correlationId,created) " +
+                                             "VALUES (@identityId,@boxId,@fileId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created)"+
                                              "ON CONFLICT (identityId,fileId) DO UPDATE "+
                                              "SET boxId = @boxId,priority = @priority,timeStamp = @timeStamp,value = @value,popStamp = @popStamp,correlationId = @correlationId,modified = @modified "+
                                              "RETURNING created, modified;";
@@ -343,10 +343,10 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 upsertParam1.ParameterName = "@identityId";
                 upsertCommand.Parameters.Add(upsertParam1);
                 var upsertParam2 = upsertCommand.CreateParameter();
-                upsertParam2.ParameterName = "@fileId";
+                upsertParam2.ParameterName = "@boxId";
                 upsertCommand.Parameters.Add(upsertParam2);
                 var upsertParam3 = upsertCommand.CreateParameter();
-                upsertParam3.ParameterName = "@boxId";
+                upsertParam3.ParameterName = "@fileId";
                 upsertCommand.Parameters.Add(upsertParam3);
                 var upsertParam4 = upsertCommand.CreateParameter();
                 upsertParam4.ParameterName = "@priority";
@@ -371,8 +371,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 upsertCommand.Parameters.Add(upsertParam10);
                 var now = UnixTimeUtc.Now();
                 upsertParam1.Value = item.identityId.ToByteArray();
-                upsertParam2.Value = item.fileId.ToByteArray();
-                upsertParam3.Value = item.boxId.ToByteArray();
+                upsertParam2.Value = item.boxId.ToByteArray();
+                upsertParam3.Value = item.fileId.ToByteArray();
                 upsertParam4.Value = item.priority;
                 upsertParam5.Value = item.timeStamp.milliseconds;
                 upsertParam6.Value = item.value ?? (object)DBNull.Value;
@@ -399,8 +399,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<int> UpdateAsync(InboxRecord item)
         {
             item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
-            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
             item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
             item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var updateCommand = cn.CreateCommand();
@@ -412,10 +412,10 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 updateParam1.ParameterName = "@identityId";
                 updateCommand.Parameters.Add(updateParam1);
                 var updateParam2 = updateCommand.CreateParameter();
-                updateParam2.ParameterName = "@fileId";
+                updateParam2.ParameterName = "@boxId";
                 updateCommand.Parameters.Add(updateParam2);
                 var updateParam3 = updateCommand.CreateParameter();
-                updateParam3.ParameterName = "@boxId";
+                updateParam3.ParameterName = "@fileId";
                 updateCommand.Parameters.Add(updateParam3);
                 var updateParam4 = updateCommand.CreateParameter();
                 updateParam4.ParameterName = "@priority";
@@ -440,8 +440,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 updateCommand.Parameters.Add(updateParam10);
                 var now = UnixTimeUtc.Now();
                 updateParam1.Value = item.identityId.ToByteArray();
-                updateParam2.Value = item.fileId.ToByteArray();
-                updateParam3.Value = item.boxId.ToByteArray();
+                updateParam2.Value = item.boxId.ToByteArray();
+                updateParam3.Value = item.fileId.ToByteArray();
                 updateParam4.Value = item.priority;
                 updateParam5.Value = item.timeStamp.milliseconds;
                 updateParam6.Value = item.value ?? (object)DBNull.Value;
@@ -478,8 +478,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var sl = new List<string>();
             sl.Add("rowId");
             sl.Add("identityId");
-            sl.Add("fileId");
             sl.Add("boxId");
+            sl.Add("fileId");
             sl.Add("priority");
             sl.Add("timeStamp");
             sl.Add("value");
@@ -490,7 +490,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return sl;
         }
 
-        // SELECT rowId,identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified
+        // SELECT rowId,identityId,boxId,fileId,priority,timeStamp,value,popStamp,correlationId,created,modified
         protected InboxRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<InboxRecord>();
@@ -501,8 +501,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new InboxRecord();
             item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
             item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
-            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
-            item.boxId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.boxId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.fileId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
             item.priority = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
             item.timeStamp = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
             item.valueNoLengthCheck = (rdr[6] == DBNull.Value) ? null : (byte[])(rdr[6]);

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
@@ -1,4 +1,4 @@
-  using System;
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Collections.Generic;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class InboxRecord
     {
-        private long _rowId;
-        public long rowId
+        private Int64 _rowId;
+        public Int64 rowId
         {
            get {
                    return _rowId;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
@@ -1,4 +1,4 @@
-using System;
+  using System;
 using System.Data;
 using System.Data.Common;
 using System.Collections.Generic;
@@ -37,16 +37,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                   _identityId = value;
                }
         }
-        private Guid _boxId;
-        public Guid boxId
-        {
-           get {
-                   return _boxId;
-               }
-           set {
-                  _boxId = value;
-               }
-        }
         private Guid _fileId;
         public Guid fileId
         {
@@ -55,6 +45,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
                }
            set {
                   _fileId = value;
+               }
+        }
+        private Guid _boxId;
+        public Guid boxId
+        {
+           get {
+                   return _boxId;
+               }
+           set {
+                  _boxId = value;
                }
         }
         private Int32 _priority;
@@ -182,8 +182,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 "CREATE TABLE IF NOT EXISTS inbox("
                    +rowid
                    +"identityId BYTEA NOT NULL, "
-                   +"boxId BYTEA NOT NULL, "
                    +"fileId BYTEA NOT NULL UNIQUE, "
+                   +"boxId BYTEA NOT NULL, "
                    +"priority BIGINT NOT NULL, "
                    +"timeStamp BIGINT NOT NULL, "
                    +"value BYTEA , "
@@ -203,22 +203,22 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<int> InsertAsync(InboxRecord item)
         {
             item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
-            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
             item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
             item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                insertCommand.CommandText = "INSERT INTO inbox (identityId,boxId,fileId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
-                                             "VALUES (@identityId,@boxId,@fileId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified)";
+                insertCommand.CommandText = "INSERT INTO inbox (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
+                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified)";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
                 insertCommand.Parameters.Add(insertParam1);
                 var insertParam2 = insertCommand.CreateParameter();
-                insertParam2.ParameterName = "@boxId";
+                insertParam2.ParameterName = "@fileId";
                 insertCommand.Parameters.Add(insertParam2);
                 var insertParam3 = insertCommand.CreateParameter();
-                insertParam3.ParameterName = "@fileId";
+                insertParam3.ParameterName = "@boxId";
                 insertCommand.Parameters.Add(insertParam3);
                 var insertParam4 = insertCommand.CreateParameter();
                 insertParam4.ParameterName = "@priority";
@@ -242,8 +242,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 insertParam10.ParameterName = "@modified";
                 insertCommand.Parameters.Add(insertParam10);
                 insertParam1.Value = item.identityId.ToByteArray();
-                insertParam2.Value = item.boxId.ToByteArray();
-                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam2.Value = item.fileId.ToByteArray();
+                insertParam3.Value = item.boxId.ToByteArray();
                 insertParam4.Value = item.priority;
                 insertParam5.Value = item.timeStamp.milliseconds;
                 insertParam6.Value = item.value ?? (object)DBNull.Value;
@@ -265,23 +265,23 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<bool> TryInsertAsync(InboxRecord item)
         {
             item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
-            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
             item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
             item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                insertCommand.CommandText = "INSERT INTO inbox (identityId,boxId,fileId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
-                                             "VALUES (@identityId,@boxId,@fileId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified) " +
+                insertCommand.CommandText = "INSERT INTO inbox (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
+                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified) " +
                                              "ON CONFLICT DO NOTHING";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
                 insertCommand.Parameters.Add(insertParam1);
                 var insertParam2 = insertCommand.CreateParameter();
-                insertParam2.ParameterName = "@boxId";
+                insertParam2.ParameterName = "@fileId";
                 insertCommand.Parameters.Add(insertParam2);
                 var insertParam3 = insertCommand.CreateParameter();
-                insertParam3.ParameterName = "@fileId";
+                insertParam3.ParameterName = "@boxId";
                 insertCommand.Parameters.Add(insertParam3);
                 var insertParam4 = insertCommand.CreateParameter();
                 insertParam4.ParameterName = "@priority";
@@ -305,8 +305,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 insertParam10.ParameterName = "@modified";
                 insertCommand.Parameters.Add(insertParam10);
                 insertParam1.Value = item.identityId.ToByteArray();
-                insertParam2.Value = item.boxId.ToByteArray();
-                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam2.Value = item.fileId.ToByteArray();
+                insertParam3.Value = item.boxId.ToByteArray();
                 insertParam4.Value = item.priority;
                 insertParam5.Value = item.timeStamp.milliseconds;
                 insertParam6.Value = item.value ?? (object)DBNull.Value;
@@ -328,14 +328,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<int> UpsertAsync(InboxRecord item)
         {
             item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
-            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
             item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
             item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var upsertCommand = cn.CreateCommand();
             {
-                upsertCommand.CommandText = "INSERT INTO inbox (identityId,boxId,fileId,priority,timeStamp,value,popStamp,correlationId,created) " +
-                                             "VALUES (@identityId,@boxId,@fileId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created)"+
+                upsertCommand.CommandText = "INSERT INTO inbox (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created) " +
+                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created)"+
                                              "ON CONFLICT (identityId,fileId) DO UPDATE "+
                                              "SET boxId = @boxId,priority = @priority,timeStamp = @timeStamp,value = @value,popStamp = @popStamp,correlationId = @correlationId,modified = @modified "+
                                              "RETURNING created, modified;";
@@ -343,10 +343,10 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 upsertParam1.ParameterName = "@identityId";
                 upsertCommand.Parameters.Add(upsertParam1);
                 var upsertParam2 = upsertCommand.CreateParameter();
-                upsertParam2.ParameterName = "@boxId";
+                upsertParam2.ParameterName = "@fileId";
                 upsertCommand.Parameters.Add(upsertParam2);
                 var upsertParam3 = upsertCommand.CreateParameter();
-                upsertParam3.ParameterName = "@fileId";
+                upsertParam3.ParameterName = "@boxId";
                 upsertCommand.Parameters.Add(upsertParam3);
                 var upsertParam4 = upsertCommand.CreateParameter();
                 upsertParam4.ParameterName = "@priority";
@@ -371,8 +371,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 upsertCommand.Parameters.Add(upsertParam10);
                 var now = UnixTimeUtc.Now();
                 upsertParam1.Value = item.identityId.ToByteArray();
-                upsertParam2.Value = item.boxId.ToByteArray();
-                upsertParam3.Value = item.fileId.ToByteArray();
+                upsertParam2.Value = item.fileId.ToByteArray();
+                upsertParam3.Value = item.boxId.ToByteArray();
                 upsertParam4.Value = item.priority;
                 upsertParam5.Value = item.timeStamp.milliseconds;
                 upsertParam6.Value = item.value ?? (object)DBNull.Value;
@@ -399,8 +399,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
         protected virtual async Task<int> UpdateAsync(InboxRecord item)
         {
             item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
-            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
             item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
             item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var updateCommand = cn.CreateCommand();
@@ -412,10 +412,10 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 updateParam1.ParameterName = "@identityId";
                 updateCommand.Parameters.Add(updateParam1);
                 var updateParam2 = updateCommand.CreateParameter();
-                updateParam2.ParameterName = "@boxId";
+                updateParam2.ParameterName = "@fileId";
                 updateCommand.Parameters.Add(updateParam2);
                 var updateParam3 = updateCommand.CreateParameter();
-                updateParam3.ParameterName = "@fileId";
+                updateParam3.ParameterName = "@boxId";
                 updateCommand.Parameters.Add(updateParam3);
                 var updateParam4 = updateCommand.CreateParameter();
                 updateParam4.ParameterName = "@priority";
@@ -440,8 +440,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 updateCommand.Parameters.Add(updateParam10);
                 var now = UnixTimeUtc.Now();
                 updateParam1.Value = item.identityId.ToByteArray();
-                updateParam2.Value = item.boxId.ToByteArray();
-                updateParam3.Value = item.fileId.ToByteArray();
+                updateParam2.Value = item.fileId.ToByteArray();
+                updateParam3.Value = item.boxId.ToByteArray();
                 updateParam4.Value = item.priority;
                 updateParam5.Value = item.timeStamp.milliseconds;
                 updateParam6.Value = item.value ?? (object)DBNull.Value;
@@ -478,8 +478,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var sl = new List<string>();
             sl.Add("rowId");
             sl.Add("identityId");
-            sl.Add("boxId");
             sl.Add("fileId");
+            sl.Add("boxId");
             sl.Add("priority");
             sl.Add("timeStamp");
             sl.Add("value");
@@ -490,7 +490,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return sl;
         }
 
-        // SELECT rowId,identityId,boxId,fileId,priority,timeStamp,value,popStamp,correlationId,created,modified
+        // SELECT rowId,identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified
         protected InboxRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<InboxRecord>();
@@ -501,8 +501,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new InboxRecord();
             item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
             item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
-            item.boxId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
-            item.fileId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.fileId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.boxId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
             item.priority = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
             item.timeStamp = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
             item.valueNoLengthCheck = (rdr[6] == DBNull.Value) ? null : (byte[])(rdr[6]);

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
@@ -178,6 +178,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             else
                    rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS inbox("
                    +rowid
@@ -192,7 +193,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,fileId)"
-                   +") ;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableInboxCRUD ON inbox(identityId,timeStamp);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableInboxCRUD ON inbox(identityId,boxId);"
                    +"CREATE INDEX IF NOT EXISTS Idx2TableInboxCRUD ON inbox(identityId,popStamp);"

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCRUD.cs
@@ -590,5 +590,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
+        protected virtual async Task<(List<InboxRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified FROM inbox " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<InboxRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxOldCRUD.cs
@@ -1,0 +1,646 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class InboxOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _fileId;
+        public Guid fileId
+        {
+           get {
+                   return _fileId;
+               }
+           set {
+                  _fileId = value;
+               }
+        }
+        private Guid _boxId;
+        public Guid boxId
+        {
+           get {
+                   return _boxId;
+               }
+           set {
+                  _boxId = value;
+               }
+        }
+        private Int32 _priority;
+        public Int32 priority
+        {
+           get {
+                   return _priority;
+               }
+           set {
+                  _priority = value;
+               }
+        }
+        private UnixTimeUtc _timeStamp;
+        public UnixTimeUtc timeStamp
+        {
+           get {
+                   return _timeStamp;
+               }
+           set {
+                  _timeStamp = value;
+               }
+        }
+        private byte[] _value;
+        public byte[] value
+        {
+           get {
+                   return _value;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _value = value;
+               }
+        }
+        internal byte[] valueNoLengthCheck
+        {
+           get {
+                   return _value;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _value = value;
+               }
+        }
+        private Guid? _popStamp;
+        public Guid? popStamp
+        {
+           get {
+                   return _popStamp;
+               }
+           set {
+                  _popStamp = value;
+               }
+        }
+        private string _correlationId;
+        public string correlationId
+        {
+           get {
+                   return _correlationId;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _correlationId = value;
+               }
+        }
+        internal string correlationIdNoLengthCheck
+        {
+           get {
+                   return _correlationId;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _correlationId = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class InboxOldRecord
+
+    public abstract class TableInboxOldCRUD
+    {
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableInboxOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS InboxOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS InboxOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL UNIQUE, "
+                   +"boxId BYTEA NOT NULL, "
+                   +"priority BIGINT NOT NULL, "
+                   +"timeStamp BIGINT NOT NULL, "
+                   +"value BYTEA , "
+                   +"popStamp BYTEA , "
+                   +"correlationId TEXT , "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,fileId)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0InboxOld ON InboxOld(identityId,timeStamp);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1InboxOld ON InboxOld(identityId,boxId);"
+                   +"CREATE INDEX IF NOT EXISTS Idx2InboxOld ON InboxOld(identityId,popStamp);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(InboxOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
+            item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO InboxOld (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
+                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@boxId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@priority";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@timeStamp";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@value";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@popStamp";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@correlationId";
+                insertCommand.Parameters.Add(insertParam8);
+                var insertParam9 = insertCommand.CreateParameter();
+                insertParam9.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam9);
+                var insertParam10 = insertCommand.CreateParameter();
+                insertParam10.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam10);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.fileId.ToByteArray();
+                insertParam3.Value = item.boxId.ToByteArray();
+                insertParam4.Value = item.priority;
+                insertParam5.Value = item.timeStamp.milliseconds;
+                insertParam6.Value = item.value ?? (object)DBNull.Value;
+                insertParam7.Value = item.popStamp?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam8.Value = item.correlationId ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam9.Value = now.milliseconds;
+                item.modified = null;
+                insertParam10.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.created = now;
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(InboxOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
+            item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO InboxOld (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified) " +
+                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@boxId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@priority";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@timeStamp";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@value";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@popStamp";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@correlationId";
+                insertCommand.Parameters.Add(insertParam8);
+                var insertParam9 = insertCommand.CreateParameter();
+                insertParam9.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam9);
+                var insertParam10 = insertCommand.CreateParameter();
+                insertParam10.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam10);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.fileId.ToByteArray();
+                insertParam3.Value = item.boxId.ToByteArray();
+                insertParam4.Value = item.priority;
+                insertParam5.Value = item.timeStamp.milliseconds;
+                insertParam6.Value = item.value ?? (object)DBNull.Value;
+                insertParam7.Value = item.popStamp?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam8.Value = item.correlationId ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam9.Value = now.milliseconds;
+                item.modified = null;
+                insertParam10.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    item.created = now;
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(InboxOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
+            item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO InboxOld (identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created) " +
+                                             "VALUES (@identityId,@fileId,@boxId,@priority,@timeStamp,@value,@popStamp,@correlationId,@created)"+
+                                             "ON CONFLICT (identityId,fileId) DO UPDATE "+
+                                             "SET boxId = @boxId,priority = @priority,timeStamp = @timeStamp,value = @value,popStamp = @popStamp,correlationId = @correlationId,modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@fileId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@boxId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@priority";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@timeStamp";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@value";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@popStamp";
+                upsertCommand.Parameters.Add(upsertParam7);
+                var upsertParam8 = upsertCommand.CreateParameter();
+                upsertParam8.ParameterName = "@correlationId";
+                upsertCommand.Parameters.Add(upsertParam8);
+                var upsertParam9 = upsertCommand.CreateParameter();
+                upsertParam9.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam9);
+                var upsertParam10 = upsertCommand.CreateParameter();
+                upsertParam10.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam10);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.fileId.ToByteArray();
+                upsertParam3.Value = item.boxId.ToByteArray();
+                upsertParam4.Value = item.priority;
+                upsertParam5.Value = item.timeStamp.milliseconds;
+                upsertParam6.Value = item.value ?? (object)DBNull.Value;
+                upsertParam7.Value = item.popStamp?.ToByteArray() ?? (object)DBNull.Value;
+                upsertParam8.Value = item.correlationId ?? (object)DBNull.Value;
+                upsertParam9.Value = now.milliseconds;
+                upsertParam10.Value = now.milliseconds;
+                await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(InboxOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.boxId.AssertGuidNotEmpty("Guid parameter boxId cannot be set to Empty GUID.");
+            item.popStamp.AssertGuidNotEmpty("Guid parameter popStamp cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE InboxOld " +
+                                             "SET boxId = @boxId,priority = @priority,timeStamp = @timeStamp,value = @value,popStamp = @popStamp,correlationId = @correlationId,modified = @modified "+
+                                             "WHERE (identityId = @identityId AND fileId = @fileId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@fileId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@boxId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@priority";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@timeStamp";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@value";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@popStamp";
+                updateCommand.Parameters.Add(updateParam7);
+                var updateParam8 = updateCommand.CreateParameter();
+                updateParam8.ParameterName = "@correlationId";
+                updateCommand.Parameters.Add(updateParam8);
+                var updateParam9 = updateCommand.CreateParameter();
+                updateParam9.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam9);
+                var updateParam10 = updateCommand.CreateParameter();
+                updateParam10.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam10);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.fileId.ToByteArray();
+                updateParam3.Value = item.boxId.ToByteArray();
+                updateParam4.Value = item.priority;
+                updateParam5.Value = item.timeStamp.milliseconds;
+                updateParam6.Value = item.value ?? (object)DBNull.Value;
+                updateParam7.Value = item.popStamp?.ToByteArray() ?? (object)DBNull.Value;
+                updateParam8.Value = item.correlationId ?? (object)DBNull.Value;
+                updateParam9.Value = now.milliseconds;
+                updateParam10.Value = now.milliseconds;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.modified = now;
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE inbox RENAME TO InboxOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM InboxOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("fileId");
+            sl.Add("boxId");
+            sl.Add("priority");
+            sl.Add("timeStamp");
+            sl.Add("value");
+            sl.Add("popStamp");
+            sl.Add("correlationId");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        // SELECT identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified
+        public InboxOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<InboxOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new InboxOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.fileId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.boxId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.priority = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.timeStamp = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[4]);
+            item.valueNoLengthCheck = (rdr[5] == DBNull.Value) ? null : (byte[])(rdr[5]);
+            if (item.value?.Length < 0)
+                throw new Exception("Too little data in value...");
+            item.popStamp = (rdr[6] == DBNull.Value) ? null : new Guid((byte[])rdr[6]);
+            item.correlationIdNoLengthCheck = (rdr[7] == DBNull.Value) ? null : (string)rdr[7];
+            item.created = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[8]);
+            item.modified = (rdr[9] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[9]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM InboxOld " +
+                                             "WHERE identityId = @identityId AND fileId = @fileId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@fileId";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = fileId.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public InboxOldRecord ReadRecordFromReader0(DbDataReader rdr)
+        {
+            var result = new List<InboxOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new InboxOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.fileId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.boxId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.priority = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.timeStamp = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[4]);
+            item.valueNoLengthCheck = (rdr[5] == DBNull.Value) ? null : (byte[])(rdr[5]);
+            if (item.value?.Length < 0)
+                throw new Exception("Too little data in value...");
+            item.popStamp = (rdr[6] == DBNull.Value) ? null : new Guid((byte[])rdr[6]);
+            item.correlationIdNoLengthCheck = (rdr[7] == DBNull.Value) ? null : (string)rdr[7];
+            item.created = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[8]);
+            item.modified = (rdr[9] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[9]);
+            return item;
+       }
+
+        public virtual async Task<List<InboxOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT identityId,fileId,boxId,priority,timeStamp,value,popStamp,correlationId,created,modified FROM InboxOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<InboxOldRecord>();
+                        }
+                        var result = new List<InboxOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public InboxOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid fileId)
+        {
+            var result = new List<InboxOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new InboxOldRecord();
+            item.identityId = identityId;
+            item.fileId = fileId;
+            item.boxId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.priority = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
+            item.timeStamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.valueNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.value?.Length < 0)
+                throw new Exception("Too little data in value...");
+            item.popStamp = (rdr[4] == DBNull.Value) ? null : new Guid((byte[])rdr[4]);
+            item.correlationIdNoLengthCheck = (rdr[5] == DBNull.Value) ? null : (string)rdr[5];
+            item.created = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[6]);
+            item.modified = (rdr[7] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[7]);
+            return item;
+       }
+
+        public virtual async Task<InboxOldRecord> GetAsync(Guid identityId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT boxId,priority,timeStamp,value,popStamp,correlationId,created,modified FROM InboxOld " +
+                                             "WHERE identityId = @identityId AND fileId = @fileId LIMIT 1;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@fileId";
+                get1Command.Parameters.Add(get1Param2);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = fileId.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr,identityId,fileId);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
@@ -140,6 +140,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyThreeValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyThreeValue("
                    +"identityId BYTEA NOT NULL, "
@@ -148,7 +151,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"key3 BYTEA , "
                    +"data BYTEA  "
                    +", PRIMARY KEY (identityId,key1)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableKeyThreeValueCRUD ON keyThreeValue(identityId,key2);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableKeyThreeValueCRUD ON keyThreeValue(key3);"
                    ;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
@@ -140,11 +140,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyThreeValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyThreeValue("
                    +"identityId BYTEA NOT NULL, "
@@ -152,9 +147,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"key2 BYTEA , "
                    +"key3 BYTEA , "
                    +"data BYTEA  "
-                   + rowid
                    +", PRIMARY KEY (identityId,key1)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableKeyThreeValueCRUD ON keyThreeValue(identityId,key2);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableKeyThreeValueCRUD ON keyThreeValue(key3);"
                    ;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
@@ -637,5 +637,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
+        protected virtual async Task<(List<KeyThreeValueRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,key1,key2,key3,data FROM keyThreeValue " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<KeyThreeValueRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
@@ -17,6 +17,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class KeyThreeValueRecord
     {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private Guid _identityId;
         public Guid identityId
         {
@@ -140,17 +150,21 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyThreeValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
-            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
-                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyThreeValue("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"key1 BYTEA NOT NULL, "
                    +"key2 BYTEA , "
                    +"key3 BYTEA , "
                    +"data BYTEA  "
-                   +", PRIMARY KEY (identityId,key1)"
+                   +", UNIQUE(identityId,key1)"
                    +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableKeyThreeValueCRUD ON keyThreeValue(identityId,key2);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableKeyThreeValueCRUD ON keyThreeValue(key3);"
@@ -326,6 +340,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("identityId");
             sl.Add("key1");
             sl.Add("key2");
@@ -334,7 +349,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return sl;
         }
 
-        // SELECT identityId,key1,key2,key3,data
+        // SELECT rowId,identityId,key1,key2,key3,data
         protected KeyThreeValueRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<KeyThreeValueRecord>();
@@ -343,17 +358,18 @@ namespace Odin.Core.Storage.Database.Identity.Table
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new KeyThreeValueRecord();
-            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.key1NoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[2]);
             if (item.key1?.Length < 16)
                 throw new Exception("Too little data in key1...");
-            item.key2NoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            item.key2NoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
             if (item.key2?.Length < 0)
                 throw new Exception("Too little data in key2...");
-            item.key3NoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            item.key3NoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
             if (item.key3?.Length < 0)
                 throw new Exception("Too little data in key3...");
-            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            item.dataNoLengthCheck = (rdr[5] == DBNull.Value) ? null : (byte[])(rdr[5]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -502,10 +518,11 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.identityId = identityId;
             item.key2 = key2;
             item.key3 = key3;
-            item.key1NoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
             if (item.key1?.Length < 16)
                 throw new Exception("Too little data in key1...");
-            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -520,7 +537,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get2Command = cn.CreateCommand();
             {
-                get2Command.CommandText = "SELECT key1,data FROM keyThreeValue " +
+                get2Command.CommandText = "SELECT rowId,key1,data FROM keyThreeValue " +
                                              "WHERE identityId = @identityId AND key2 = @key2 AND key3 = @key3;";
                 var get2Param1 = get2Command.CreateParameter();
                 get2Param1.ParameterName = "@identityId";
@@ -569,13 +586,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new KeyThreeValueRecord();
             item.identityId = identityId;
             item.key1 = key1;
-            item.key2NoLengthCheck = (rdr[0] == DBNull.Value) ? null : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.key2NoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
             if (item.key2?.Length < 0)
                 throw new Exception("Too little data in key2...");
-            item.key3NoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            item.key3NoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
             if (item.key3?.Length < 0)
                 throw new Exception("Too little data in key3...");
-            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -592,7 +610,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get3Command = cn.CreateCommand();
             {
-                get3Command.CommandText = "SELECT key2,key3,data FROM keyThreeValue " +
+                get3Command.CommandText = "SELECT rowId,key2,key3,data FROM keyThreeValue " +
                                              "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;";
                 var get3Param1 = get3Command.CreateParameter();
                 get3Param1.ParameterName = "@identityId";

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCRUD.cs
@@ -166,8 +166,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"data BYTEA  "
                    +", UNIQUE(identityId,key1)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableKeyThreeValueCRUD ON keyThreeValue(identityId,key2);"
-                   +"CREATE INDEX IF NOT EXISTS Idx1TableKeyThreeValueCRUD ON keyThreeValue(key3);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0keyThreeValue ON keyThreeValue(identityId,key2);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1keyThreeValue ON keyThreeValue(key3);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -409,7 +409,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT data FROM keyThreeValue " +
-                                             "WHERE identityId = @identityId AND key2 = @key2;";
+                                             "WHERE identityId = @identityId AND key2 = @key2;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -460,7 +461,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT data FROM keyThreeValue " +
-                                             "WHERE identityId = @identityId AND key3 = @key3;";
+                                             "WHERE identityId = @identityId AND key3 = @key3;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -503,7 +505,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected KeyThreeValueRecord ReadRecordFromReader2(DbDataReader rdr, Guid identityId,byte[] key2,byte[] key3)
+        protected KeyThreeValueRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,byte[] key2,byte[] key3)
         {
             if (key2?.Length < 0) throw new Exception("Too short");
             if (key2?.Length > 256) throw new Exception("Too long");
@@ -538,7 +540,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get2Command = cn.CreateCommand();
             {
                 get2Command.CommandText = "SELECT rowId,key1,data FROM keyThreeValue " +
-                                             "WHERE identityId = @identityId AND key2 = @key2 AND key3 = @key3;";
+                                             "WHERE identityId = @identityId AND key2 = @key2 AND key3 = @key3;"+
+                                             ";";
                 var get2Param1 = get2Command.CreateParameter();
                 get2Param1.ParameterName = "@identityId";
                 get2Command.Parameters.Add(get2Param1);
@@ -563,7 +566,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<KeyThreeValueRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader2(rdr, identityId,key2,key3));
+                            result.Add(ReadRecordFromReader2(rdr,identityId,key2,key3));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -573,7 +576,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected KeyThreeValueRecord ReadRecordFromReader3(DbDataReader rdr, Guid identityId,byte[] key1)
+        protected KeyThreeValueRecord ReadRecordFromReader3(DbDataReader rdr,Guid identityId,byte[] key1)
         {
             if (key1 == null) throw new Exception("Cannot be null");
             if (key1?.Length < 16) throw new Exception("Too short");
@@ -611,7 +614,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get3Command = cn.CreateCommand();
             {
                 get3Command.CommandText = "SELECT rowId,key2,key3,data FROM keyThreeValue " +
-                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;";
+                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;"+
+                                             ";";
                 var get3Param1 = get3Command.CreateParameter();
                 get3Param1.ParameterName = "@identityId";
                 get3Command.Parameters.Add(get3Param1);
@@ -629,7 +633,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableKeyThreeValueCRUD", identityId.ToString()+key1.ToBase64(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader3(rdr, identityId,key1);
+                        var r = ReadRecordFromReader3(rdr,identityId,key1);
                         _cache.AddOrUpdate("TableKeyThreeValueCRUD", identityId.ToString()+key1.ToBase64(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueOldCRUD.cs
@@ -1,0 +1,696 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class KeyThreeValueOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private byte[] _key1;
+        public byte[] key1
+        {
+           get {
+                   return _key1;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 48) throw new Exception("Too long");
+                  _key1 = value;
+               }
+        }
+        internal byte[] key1NoLengthCheck
+        {
+           get {
+                   return _key1;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _key1 = value;
+               }
+        }
+        private byte[] _key2;
+        public byte[] key2
+        {
+           get {
+                   return _key2;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 256) throw new Exception("Too long");
+                  _key2 = value;
+               }
+        }
+        internal byte[] key2NoLengthCheck
+        {
+           get {
+                   return _key2;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _key2 = value;
+               }
+        }
+        private byte[] _key3;
+        public byte[] key3
+        {
+           get {
+                   return _key3;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 256) throw new Exception("Too long");
+                  _key3 = value;
+               }
+        }
+        internal byte[] key3NoLengthCheck
+        {
+           get {
+                   return _key3;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _key3 = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 1048576) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+    } // End of class KeyThreeValueOldRecord
+
+    public abstract class TableKeyThreeValueOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableKeyThreeValueOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS KeyThreeValueOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS KeyThreeValueOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"key1 BYTEA NOT NULL, "
+                   +"key2 BYTEA , "
+                   +"key3 BYTEA , "
+                   +"data BYTEA  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,key1)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0KeyThreeValueOld ON KeyThreeValueOld(identityId,key2);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1KeyThreeValueOld ON KeyThreeValueOld(key3);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(KeyThreeValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO KeyThreeValueOld (identityId,key1,key2,key3,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@key3,@data)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@key1";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@key2";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@key3";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.key1;
+                insertParam3.Value = item.key2 ?? (object)DBNull.Value;
+                insertParam4.Value = item.key3 ?? (object)DBNull.Value;
+                insertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyThreeValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(KeyThreeValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO KeyThreeValueOld (identityId,key1,key2,key3,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@key3,@data) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@key1";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@key2";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@key3";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.key1;
+                insertParam3.Value = item.key2 ?? (object)DBNull.Value;
+                insertParam4.Value = item.key3 ?? (object)DBNull.Value;
+                insertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableKeyThreeValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(KeyThreeValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO KeyThreeValueOld (identityId,key1,key2,key3,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@key3,@data)"+
+                                             "ON CONFLICT (identityId,key1) DO UPDATE "+
+                                             "SET key2 = @key2,key3 = @key3,data = @data "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@key1";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@key2";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@key3";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam5);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.key1;
+                upsertParam3.Value = item.key2 ?? (object)DBNull.Value;
+                upsertParam4.Value = item.key3 ?? (object)DBNull.Value;
+                upsertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.AddOrUpdate("TableKeyThreeValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(KeyThreeValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE KeyThreeValueOld " +
+                                             "SET key2 = @key2,key3 = @key3,data = @data "+
+                                             "WHERE (identityId = @identityId AND key1 = @key1)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@key1";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@key2";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@key3";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam5);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.key1;
+                updateParam3.Value = item.key2 ?? (object)DBNull.Value;
+                updateParam4.Value = item.key3 ?? (object)DBNull.Value;
+                updateParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyThreeValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE keyThreeValue RENAME TO KeyThreeValueOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM KeyThreeValueOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("key1");
+            sl.Add("key2");
+            sl.Add("key3");
+            sl.Add("data");
+            return sl;
+        }
+
+        // SELECT identityId,key1,key2,key3,data
+        public KeyThreeValueOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<KeyThreeValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyThreeValueOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.key2NoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.key3NoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.key3?.Length < 0)
+                throw new Exception("Too little data in key3...");
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM KeyThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key1 = @key1";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@key1";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = key1;
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableKeyThreeValueOldCRUD", identityId.ToString()+key1.ToBase64());
+                return count;
+            }
+        }
+
+        public virtual async Task<List<byte[]>> GetByKeyTwoAsync(Guid identityId,byte[] key2)
+        {
+            if (key2?.Length < 0) throw new Exception("Too short");
+            if (key2?.Length > 256) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT data FROM KeyThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key2 = @key2;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@key2";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = key2 ?? (object)DBNull.Value;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        byte[] result0tmp;
+                        var thelistresult = new List<byte[]>();
+                        if (!await rdr.ReadAsync()) {
+                            return thelistresult;
+                        }
+                    byte[] tmpbuf = new byte[1048576+1];
+                    var guid = new byte[16];
+                    while (true)
+                    {
+
+                        if (rdr[0] == DBNull.Value)
+                            result0tmp = null;
+                        else
+                        {
+                            tmpbuf = (byte[]) rdr[0];
+                            if (tmpbuf.Length < 0)
+                                throw new Exception("Too little data in data...");
+                            result0tmp = new byte[tmpbuf.Length];
+                            Buffer.BlockCopy(tmpbuf, 0, result0tmp, 0, (int) tmpbuf.Length);
+                        }
+                        thelistresult.Add(result0tmp);
+                        if (!await rdr.ReadAsync())
+                           break;
+                    } // while
+                    return thelistresult;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<List<byte[]>> GetByKeyThreeAsync(Guid identityId,byte[] key3)
+        {
+            if (key3?.Length < 0) throw new Exception("Too short");
+            if (key3?.Length > 256) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT data FROM KeyThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key3 = @key3;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@key3";
+                get1Command.Parameters.Add(get1Param2);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = key3 ?? (object)DBNull.Value;
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        byte[] result0tmp;
+                        var thelistresult = new List<byte[]>();
+                        if (!await rdr.ReadAsync()) {
+                            return thelistresult;
+                        }
+                    byte[] tmpbuf = new byte[1048576+1];
+                    var guid = new byte[16];
+                    while (true)
+                    {
+
+                        if (rdr[0] == DBNull.Value)
+                            result0tmp = null;
+                        else
+                        {
+                            tmpbuf = (byte[]) rdr[0];
+                            if (tmpbuf.Length < 0)
+                                throw new Exception("Too little data in data...");
+                            result0tmp = new byte[tmpbuf.Length];
+                            Buffer.BlockCopy(tmpbuf, 0, result0tmp, 0, (int) tmpbuf.Length);
+                        }
+                        thelistresult.Add(result0tmp);
+                        if (!await rdr.ReadAsync())
+                           break;
+                    } // while
+                    return thelistresult;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyThreeValueOldRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,byte[] key2,byte[] key3)
+        {
+            if (key2?.Length < 0) throw new Exception("Too short");
+            if (key2?.Length > 256) throw new Exception("Too long");
+            if (key3?.Length < 0) throw new Exception("Too short");
+            if (key3?.Length > 256) throw new Exception("Too long");
+            var result = new List<KeyThreeValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyThreeValueOldRecord();
+            item.identityId = identityId;
+            item.key2 = key2;
+            item.key3 = key3;
+            item.key1NoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<KeyThreeValueOldRecord>> GetByKeyTwoThreeAsync(Guid identityId,byte[] key2,byte[] key3)
+        {
+            if (key2?.Length < 0) throw new Exception("Too short");
+            if (key2?.Length > 256) throw new Exception("Too long");
+            if (key3?.Length < 0) throw new Exception("Too short");
+            if (key3?.Length > 256) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT key1,data FROM KeyThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key2 = @key2 AND key3 = @key3;"+
+                                             ";";
+                var get2Param1 = get2Command.CreateParameter();
+                get2Param1.ParameterName = "@identityId";
+                get2Command.Parameters.Add(get2Param1);
+                var get2Param2 = get2Command.CreateParameter();
+                get2Param2.ParameterName = "@key2";
+                get2Command.Parameters.Add(get2Param2);
+                var get2Param3 = get2Command.CreateParameter();
+                get2Param3.ParameterName = "@key3";
+                get2Command.Parameters.Add(get2Param3);
+
+                get2Param1.Value = identityId.ToByteArray();
+                get2Param2.Value = key2 ?? (object)DBNull.Value;
+                get2Param3.Value = key3 ?? (object)DBNull.Value;
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableKeyThreeValueOldCRUD", identityId.ToString()+key2.ToBase64()+key3.ToBase64(), null);
+                            return new List<KeyThreeValueOldRecord>();
+                        }
+                        var result = new List<KeyThreeValueOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader2(rdr,identityId,key2,key3));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyThreeValueOldRecord ReadRecordFromReader3(DbDataReader rdr)
+        {
+            var result = new List<KeyThreeValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyThreeValueOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.key2NoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.key3NoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.key3?.Length < 0)
+                throw new Exception("Too little data in key3...");
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<KeyThreeValueOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get3Command = cn.CreateCommand();
+            {
+                get3Command.CommandText = "SELECT identityId,key1,key2,key3,data FROM KeyThreeValueOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get3Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<KeyThreeValueOldRecord>();
+                        }
+                        var result = new List<KeyThreeValueOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader3(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyThreeValueOldRecord ReadRecordFromReader4(DbDataReader rdr,Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            var result = new List<KeyThreeValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyThreeValueOldRecord();
+            item.identityId = identityId;
+            item.key1 = key1;
+            item.key2NoLengthCheck = (rdr[0] == DBNull.Value) ? null : (byte[])(rdr[0]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.key3NoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            if (item.key3?.Length < 0)
+                throw new Exception("Too little data in key3...");
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<KeyThreeValueOldRecord> GetAsync(Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableKeyThreeValueOldCRUD", identityId.ToString()+key1.ToBase64());
+            if (hit)
+                return (KeyThreeValueOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get4Command = cn.CreateCommand();
+            {
+                get4Command.CommandText = "SELECT key2,key3,data FROM KeyThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;"+
+                                             ";";
+                var get4Param1 = get4Command.CreateParameter();
+                get4Param1.ParameterName = "@identityId";
+                get4Command.Parameters.Add(get4Param1);
+                var get4Param2 = get4Command.CreateParameter();
+                get4Param2.ParameterName = "@key1";
+                get4Command.Parameters.Add(get4Param2);
+
+                get4Param1.Value = identityId.ToByteArray();
+                get4Param2.Value = key1;
+                {
+                    using (var rdr = await get4Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableKeyThreeValueOldCRUD", identityId.ToString()+key1.ToBase64(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader4(rdr,identityId,key1);
+                        _cache.AddOrUpdate("TableKeyThreeValueOldCRUD", identityId.ToString()+key1.ToBase64(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
@@ -118,20 +118,14 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyTwoValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyTwoValue("
                    +"identityId BYTEA NOT NULL, "
                    +"key1 BYTEA NOT NULL, "
                    +"key2 BYTEA , "
                    +"data BYTEA  "
-                   + rowid
                    +", PRIMARY KEY (identityId,key1)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableKeyTwoValueCRUD ON keyTwoValue(identityId,key2);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
@@ -479,5 +479,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
+        protected virtual async Task<(List<KeyTwoValueRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,key1,key2,data FROM keyTwoValue " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<KeyTwoValueRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
@@ -118,6 +118,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyTwoValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyTwoValue("
                    +"identityId BYTEA NOT NULL, "
@@ -125,7 +128,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"key2 BYTEA , "
                    +"data BYTEA  "
                    +", PRIMARY KEY (identityId,key1)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableKeyTwoValueCRUD ON keyTwoValue(identityId,key2);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
@@ -17,6 +17,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class KeyTwoValueRecord
     {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private Guid _identityId;
         public Guid identityId
         {
@@ -118,16 +128,20 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyTwoValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
-            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
-                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyTwoValue("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"key1 BYTEA NOT NULL, "
                    +"key2 BYTEA , "
                    +"data BYTEA  "
-                   +", PRIMARY KEY (identityId,key1)"
+                   +", UNIQUE(identityId,key1)"
                    +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableKeyTwoValueCRUD ON keyTwoValue(identityId,key2);"
                    ;
@@ -286,6 +300,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("identityId");
             sl.Add("key1");
             sl.Add("key2");
@@ -293,7 +308,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             return sl;
         }
 
-        // SELECT identityId,key1,key2,data
+        // SELECT rowId,identityId,key1,key2,data
         protected KeyTwoValueRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<KeyTwoValueRecord>();
@@ -302,14 +317,15 @@ namespace Odin.Core.Storage.Database.Identity.Table
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new KeyTwoValueRecord();
-            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
-            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.key1NoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[2]);
             if (item.key1?.Length < 16)
                 throw new Exception("Too little data in key1...");
-            item.key2NoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            item.key2NoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
             if (item.key2?.Length < 0)
                 throw new Exception("Too little data in key2...");
-            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -353,10 +369,11 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new KeyTwoValueRecord();
             item.identityId = identityId;
             item.key2 = key2;
-            item.key1NoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
             if (item.key1?.Length < 16)
                 throw new Exception("Too little data in key1...");
-            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -369,7 +386,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get0Command = cn.CreateCommand();
             {
-                get0Command.CommandText = "SELECT key1,data FROM keyTwoValue " +
+                get0Command.CommandText = "SELECT rowId,key1,data FROM keyTwoValue " +
                                              "WHERE identityId = @identityId AND key2 = @key2;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
@@ -414,10 +431,11 @@ namespace Odin.Core.Storage.Database.Identity.Table
             var item = new KeyTwoValueRecord();
             item.identityId = identityId;
             item.key1 = key1;
-            item.key2NoLengthCheck = (rdr[0] == DBNull.Value) ? null : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.key2NoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
             if (item.key2?.Length < 0)
                 throw new Exception("Too little data in key2...");
-            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             return item;
@@ -434,7 +452,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var get1Command = cn.CreateCommand();
             {
-                get1Command.CommandText = "SELECT key2,data FROM keyTwoValue " +
+                get1Command.CommandText = "SELECT rowId,key2,data FROM keyTwoValue " +
                                              "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCRUD.cs
@@ -143,7 +143,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"data BYTEA  "
                    +", UNIQUE(identityId,key1)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableKeyTwoValueCRUD ON keyTwoValue(identityId,key2);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0keyTwoValue ON keyTwoValue(identityId,key2);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -357,7 +357,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected KeyTwoValueRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,byte[] key2)
+        protected KeyTwoValueRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,byte[] key2)
         {
             if (key2?.Length < 0) throw new Exception("Too short");
             if (key2?.Length > 128) throw new Exception("Too long");
@@ -387,7 +387,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,key1,data FROM keyTwoValue " +
-                                             "WHERE identityId = @identityId AND key2 = @key2;";
+                                             "WHERE identityId = @identityId AND key2 = @key2;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -408,7 +409,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<KeyTwoValueRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader0(rdr, identityId,key2));
+                            result.Add(ReadRecordFromReader0(rdr,identityId,key2));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -418,7 +419,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected KeyTwoValueRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,byte[] key1)
+        protected KeyTwoValueRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,byte[] key1)
         {
             if (key1 == null) throw new Exception("Cannot be null");
             if (key1?.Length < 16) throw new Exception("Too short");
@@ -453,7 +454,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId,key2,data FROM keyTwoValue " +
-                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;";
+                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -471,7 +473,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableKeyTwoValueCRUD", identityId.ToString()+key1.ToBase64(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,key1);
+                        var r = ReadRecordFromReader1(rdr,identityId,key1);
                         _cache.AddOrUpdate("TableKeyTwoValueCRUD", identityId.ToString()+key1.ToBase64(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueOldCRUD.cs
@@ -1,0 +1,533 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class KeyTwoValueOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private byte[] _key1;
+        public byte[] key1
+        {
+           get {
+                   return _key1;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 48) throw new Exception("Too long");
+                  _key1 = value;
+               }
+        }
+        internal byte[] key1NoLengthCheck
+        {
+           get {
+                   return _key1;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _key1 = value;
+               }
+        }
+        private byte[] _key2;
+        public byte[] key2
+        {
+           get {
+                   return _key2;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 128) throw new Exception("Too long");
+                  _key2 = value;
+               }
+        }
+        internal byte[] key2NoLengthCheck
+        {
+           get {
+                   return _key2;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _key2 = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 1048576) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+    } // End of class KeyTwoValueOldRecord
+
+    public abstract class TableKeyTwoValueOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableKeyTwoValueOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS KeyTwoValueOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS KeyTwoValueOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"key1 BYTEA NOT NULL, "
+                   +"key2 BYTEA , "
+                   +"data BYTEA  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,key1)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0KeyTwoValueOld ON KeyTwoValueOld(identityId,key2);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(KeyTwoValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO KeyTwoValueOld (identityId,key1,key2,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@data)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@key1";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@key2";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.key1;
+                insertParam3.Value = item.key2 ?? (object)DBNull.Value;
+                insertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyTwoValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(KeyTwoValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO KeyTwoValueOld (identityId,key1,key2,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@data) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@key1";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@key2";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.key1;
+                insertParam3.Value = item.key2 ?? (object)DBNull.Value;
+                insertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableKeyTwoValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(KeyTwoValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO KeyTwoValueOld (identityId,key1,key2,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@data)"+
+                                             "ON CONFLICT (identityId,key1) DO UPDATE "+
+                                             "SET key2 = @key2,data = @data "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@key1";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@key2";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam4);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.key1;
+                upsertParam3.Value = item.key2 ?? (object)DBNull.Value;
+                upsertParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.AddOrUpdate("TableKeyTwoValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(KeyTwoValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE KeyTwoValueOld " +
+                                             "SET key2 = @key2,data = @data "+
+                                             "WHERE (identityId = @identityId AND key1 = @key1)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@key1";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@key2";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam4);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.key1;
+                updateParam3.Value = item.key2 ?? (object)DBNull.Value;
+                updateParam4.Value = item.data ?? (object)DBNull.Value;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyTwoValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE keyTwoValue RENAME TO KeyTwoValueOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM KeyTwoValueOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("key1");
+            sl.Add("key2");
+            sl.Add("data");
+            return sl;
+        }
+
+        // SELECT identityId,key1,key2,data
+        public KeyTwoValueOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<KeyTwoValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyTwoValueOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.key2NoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM KeyTwoValueOld " +
+                                             "WHERE identityId = @identityId AND key1 = @key1";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@key1";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = key1;
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableKeyTwoValueOldCRUD", identityId.ToString()+key1.ToBase64());
+                return count;
+            }
+        }
+
+        public KeyTwoValueOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,byte[] key2)
+        {
+            if (key2?.Length < 0) throw new Exception("Too short");
+            if (key2?.Length > 128) throw new Exception("Too long");
+            var result = new List<KeyTwoValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyTwoValueOldRecord();
+            item.identityId = identityId;
+            item.key2 = key2;
+            item.key1NoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<KeyTwoValueOldRecord>> GetByKeyTwoAsync(Guid identityId,byte[] key2)
+        {
+            if (key2?.Length < 0) throw new Exception("Too short");
+            if (key2?.Length > 128) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT key1,data FROM KeyTwoValueOld " +
+                                             "WHERE identityId = @identityId AND key2 = @key2;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@key2";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = key2 ?? (object)DBNull.Value;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableKeyTwoValueOldCRUD", identityId.ToString()+key2.ToBase64(), null);
+                            return new List<KeyTwoValueOldRecord>();
+                        }
+                        var result = new List<KeyTwoValueOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr,identityId,key2));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyTwoValueOldRecord ReadRecordFromReader1(DbDataReader rdr)
+        {
+            var result = new List<KeyTwoValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyTwoValueOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.key2NoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.dataNoLengthCheck = (rdr[3] == DBNull.Value) ? null : (byte[])(rdr[3]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<KeyTwoValueOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT identityId,key1,key2,data FROM KeyTwoValueOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<KeyTwoValueOldRecord>();
+                        }
+                        var result = new List<KeyTwoValueOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader1(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyTwoValueOldRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            var result = new List<KeyTwoValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyTwoValueOldRecord();
+            item.identityId = identityId;
+            item.key1 = key1;
+            item.key2NoLengthCheck = (rdr[0] == DBNull.Value) ? null : (byte[])(rdr[0]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<KeyTwoValueOldRecord> GetAsync(Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableKeyTwoValueOldCRUD", identityId.ToString()+key1.ToBase64());
+            if (hit)
+                return (KeyTwoValueOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT key2,data FROM KeyTwoValueOld " +
+                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;"+
+                                             ";";
+                var get2Param1 = get2Command.CreateParameter();
+                get2Param1.ParameterName = "@identityId";
+                get2Command.Parameters.Add(get2Param1);
+                var get2Param2 = get2Command.CreateParameter();
+                get2Param2.ParameterName = "@key1";
+                get2Command.Parameters.Add(get2Param2);
+
+                get2Param1.Value = identityId.ToByteArray();
+                get2Param2.Value = key1;
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableKeyTwoValueOldCRUD", identityId.ToString()+key1.ToBase64(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader2(rdr,identityId,key1);
+                        _cache.AddOrUpdate("TableKeyTwoValueOldCRUD", identityId.ToString()+key1.ToBase64(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueCRUD.cs
@@ -144,11 +144,6 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyUniqueThreeValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyUniqueThreeValue("
                    +"identityId BYTEA NOT NULL, "
@@ -156,10 +151,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"key2 BYTEA NOT NULL, "
                    +"key3 BYTEA NOT NULL, "
                    +"data BYTEA  "
-                   + rowid
                    +", PRIMARY KEY (identityId,key1)"
                    +", UNIQUE(identityId,key2,key3)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableKeyUniqueThreeValueCRUD ON keyUniqueThreeValue(identityId,key2);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableKeyUniqueThreeValueCRUD ON keyUniqueThreeValue(key3);"
                    ;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueCRUD.cs
@@ -144,6 +144,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyUniqueThreeValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyUniqueThreeValue("
                    +"identityId BYTEA NOT NULL, "
@@ -153,7 +156,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"data BYTEA  "
                    +", PRIMARY KEY (identityId,key1)"
                    +", UNIQUE(identityId,key2,key3)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableKeyUniqueThreeValueCRUD ON keyUniqueThreeValue(identityId,key2);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableKeyUniqueThreeValueCRUD ON keyUniqueThreeValue(key3);"
                    ;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueCRUD.cs
@@ -171,8 +171,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +", UNIQUE(identityId,key1)"
                    +", UNIQUE(identityId,key2,key3)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableKeyUniqueThreeValueCRUD ON keyUniqueThreeValue(identityId,key2);"
-                   +"CREATE INDEX IF NOT EXISTS Idx1TableKeyUniqueThreeValueCRUD ON keyUniqueThreeValue(key3);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0keyUniqueThreeValue ON keyUniqueThreeValue(identityId,key2);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1keyUniqueThreeValue ON keyUniqueThreeValue(key3);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -415,7 +415,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT data FROM keyUniqueThreeValue " +
-                                             "WHERE identityId = @identityId AND key2 = @key2;";
+                                             "WHERE identityId = @identityId AND key2 = @key2;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -467,7 +468,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT data FROM keyUniqueThreeValue " +
-                                             "WHERE identityId = @identityId AND key3 = @key3;";
+                                             "WHERE identityId = @identityId AND key3 = @key3;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -510,7 +512,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected KeyUniqueThreeValueRecord ReadRecordFromReader2(DbDataReader rdr, Guid identityId,byte[] key2,byte[] key3)
+        protected KeyUniqueThreeValueRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,byte[] key2,byte[] key3)
         {
             if (key2 == null) throw new Exception("Cannot be null");
             if (key2?.Length < 0) throw new Exception("Too short");
@@ -549,7 +551,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get2Command = cn.CreateCommand();
             {
                 get2Command.CommandText = "SELECT rowId,key1,data FROM keyUniqueThreeValue " +
-                                             "WHERE identityId = @identityId AND key2 = @key2 AND key3 = @key3;";
+                                             "WHERE identityId = @identityId AND key2 = @key2 AND key3 = @key3;"+
+                                             ";";
                 var get2Param1 = get2Command.CreateParameter();
                 get2Param1.ParameterName = "@identityId";
                 get2Command.Parameters.Add(get2Param1);
@@ -574,7 +577,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<KeyUniqueThreeValueRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader2(rdr, identityId,key2,key3));
+                            result.Add(ReadRecordFromReader2(rdr,identityId,key2,key3));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -584,7 +587,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected KeyUniqueThreeValueRecord ReadRecordFromReader3(DbDataReader rdr, Guid identityId,byte[] key1)
+        protected KeyUniqueThreeValueRecord ReadRecordFromReader3(DbDataReader rdr,Guid identityId,byte[] key1)
         {
             if (key1 == null) throw new Exception("Cannot be null");
             if (key1?.Length < 16) throw new Exception("Too short");
@@ -622,7 +625,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get3Command = cn.CreateCommand();
             {
                 get3Command.CommandText = "SELECT rowId,key2,key3,data FROM keyUniqueThreeValue " +
-                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;";
+                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;"+
+                                             ";";
                 var get3Param1 = get3Command.CreateParameter();
                 get3Param1.ParameterName = "@identityId";
                 get3Command.Parameters.Add(get3Param1);
@@ -640,7 +644,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableKeyUniqueThreeValueCRUD", identityId.ToString()+key1.ToBase64(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader3(rdr, identityId,key1);
+                        var r = ReadRecordFromReader3(rdr,identityId,key1);
                         _cache.AddOrUpdate("TableKeyUniqueThreeValueCRUD", identityId.ToString()+key1.ToBase64(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueCRUD.cs
@@ -648,5 +648,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
+        protected virtual async Task<(List<KeyUniqueThreeValueRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,key1,key2,key3,data FROM keyUniqueThreeValue " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<KeyUniqueThreeValueRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyUniqueThreeValueOldCRUD.cs
@@ -1,0 +1,707 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class KeyUniqueThreeValueOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private byte[] _key1;
+        public byte[] key1
+        {
+           get {
+                   return _key1;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 48) throw new Exception("Too long");
+                  _key1 = value;
+               }
+        }
+        internal byte[] key1NoLengthCheck
+        {
+           get {
+                   return _key1;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _key1 = value;
+               }
+        }
+        private byte[] _key2;
+        public byte[] key2
+        {
+           get {
+                   return _key2;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 256) throw new Exception("Too long");
+                  _key2 = value;
+               }
+        }
+        internal byte[] key2NoLengthCheck
+        {
+           get {
+                   return _key2;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _key2 = value;
+               }
+        }
+        private byte[] _key3;
+        public byte[] key3
+        {
+           get {
+                   return _key3;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 256) throw new Exception("Too long");
+                  _key3 = value;
+               }
+        }
+        internal byte[] key3NoLengthCheck
+        {
+           get {
+                   return _key3;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _key3 = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 1048576) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+    } // End of class KeyUniqueThreeValueOldRecord
+
+    public abstract class TableKeyUniqueThreeValueOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableKeyUniqueThreeValueOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS KeyUniqueThreeValueOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS KeyUniqueThreeValueOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"key1 BYTEA NOT NULL, "
+                   +"key2 BYTEA NOT NULL, "
+                   +"key3 BYTEA NOT NULL, "
+                   +"data BYTEA  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,key1)"
+                   +", UNIQUE(identityId,key2,key3)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0KeyUniqueThreeValueOld ON KeyUniqueThreeValueOld(identityId,key2);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1KeyUniqueThreeValueOld ON KeyUniqueThreeValueOld(key3);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(KeyUniqueThreeValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO KeyUniqueThreeValueOld (identityId,key1,key2,key3,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@key3,@data)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@key1";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@key2";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@key3";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.key1;
+                insertParam3.Value = item.key2;
+                insertParam4.Value = item.key3;
+                insertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyUniqueThreeValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(KeyUniqueThreeValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO KeyUniqueThreeValueOld (identityId,key1,key2,key3,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@key3,@data) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@key1";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@key2";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@key3";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam5);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.key1;
+                insertParam3.Value = item.key2;
+                insertParam4.Value = item.key3;
+                insertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableKeyUniqueThreeValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(KeyUniqueThreeValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO KeyUniqueThreeValueOld (identityId,key1,key2,key3,data) " +
+                                             "VALUES (@identityId,@key1,@key2,@key3,@data)"+
+                                             "ON CONFLICT (identityId,key1) DO UPDATE "+
+                                             "SET key2 = @key2,key3 = @key3,data = @data "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@key1";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@key2";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@key3";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam5);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.key1;
+                upsertParam3.Value = item.key2;
+                upsertParam4.Value = item.key3;
+                upsertParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.AddOrUpdate("TableKeyUniqueThreeValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(KeyUniqueThreeValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE KeyUniqueThreeValueOld " +
+                                             "SET key2 = @key2,key3 = @key3,data = @data "+
+                                             "WHERE (identityId = @identityId AND key1 = @key1)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@key1";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@key2";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@key3";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam5);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.key1;
+                updateParam3.Value = item.key2;
+                updateParam4.Value = item.key3;
+                updateParam5.Value = item.data ?? (object)DBNull.Value;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyUniqueThreeValueOldCRUD", item.identityId.ToString()+item.key1.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE keyUniqueThreeValue RENAME TO KeyUniqueThreeValueOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM KeyUniqueThreeValueOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("key1");
+            sl.Add("key2");
+            sl.Add("key3");
+            sl.Add("data");
+            return sl;
+        }
+
+        // SELECT identityId,key1,key2,key3,data
+        public KeyUniqueThreeValueOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<KeyUniqueThreeValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyUniqueThreeValueOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.key2NoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[2]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.key3NoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
+            if (item.key3?.Length < 0)
+                throw new Exception("Too little data in key3...");
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM KeyUniqueThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key1 = @key1";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@key1";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = key1;
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableKeyUniqueThreeValueOldCRUD", identityId.ToString()+key1.ToBase64());
+                return count;
+            }
+        }
+
+        public virtual async Task<List<byte[]>> GetByKeyTwoAsync(Guid identityId,byte[] key2)
+        {
+            if (key2 == null) throw new Exception("Cannot be null");
+            if (key2?.Length < 0) throw new Exception("Too short");
+            if (key2?.Length > 256) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT data FROM KeyUniqueThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key2 = @key2;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@key2";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = key2;
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        byte[] result0tmp;
+                        var thelistresult = new List<byte[]>();
+                        if (!await rdr.ReadAsync()) {
+                            return thelistresult;
+                        }
+                    byte[] tmpbuf = new byte[1048576+1];
+                    var guid = new byte[16];
+                    while (true)
+                    {
+
+                        if (rdr[0] == DBNull.Value)
+                            result0tmp = null;
+                        else
+                        {
+                            tmpbuf = (byte[]) rdr[0];
+                            if (tmpbuf.Length < 0)
+                                throw new Exception("Too little data in data...");
+                            result0tmp = new byte[tmpbuf.Length];
+                            Buffer.BlockCopy(tmpbuf, 0, result0tmp, 0, (int) tmpbuf.Length);
+                        }
+                        thelistresult.Add(result0tmp);
+                        if (!await rdr.ReadAsync())
+                           break;
+                    } // while
+                    return thelistresult;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<List<byte[]>> GetByKeyThreeAsync(Guid identityId,byte[] key3)
+        {
+            if (key3 == null) throw new Exception("Cannot be null");
+            if (key3?.Length < 0) throw new Exception("Too short");
+            if (key3?.Length > 256) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT data FROM KeyUniqueThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key3 = @key3;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@key3";
+                get1Command.Parameters.Add(get1Param2);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = key3;
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        byte[] result0tmp;
+                        var thelistresult = new List<byte[]>();
+                        if (!await rdr.ReadAsync()) {
+                            return thelistresult;
+                        }
+                    byte[] tmpbuf = new byte[1048576+1];
+                    var guid = new byte[16];
+                    while (true)
+                    {
+
+                        if (rdr[0] == DBNull.Value)
+                            result0tmp = null;
+                        else
+                        {
+                            tmpbuf = (byte[]) rdr[0];
+                            if (tmpbuf.Length < 0)
+                                throw new Exception("Too little data in data...");
+                            result0tmp = new byte[tmpbuf.Length];
+                            Buffer.BlockCopy(tmpbuf, 0, result0tmp, 0, (int) tmpbuf.Length);
+                        }
+                        thelistresult.Add(result0tmp);
+                        if (!await rdr.ReadAsync())
+                           break;
+                    } // while
+                    return thelistresult;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyUniqueThreeValueOldRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,byte[] key2,byte[] key3)
+        {
+            if (key2 == null) throw new Exception("Cannot be null");
+            if (key2?.Length < 0) throw new Exception("Too short");
+            if (key2?.Length > 256) throw new Exception("Too long");
+            if (key3 == null) throw new Exception("Cannot be null");
+            if (key3?.Length < 0) throw new Exception("Too short");
+            if (key3?.Length > 256) throw new Exception("Too long");
+            var result = new List<KeyUniqueThreeValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyUniqueThreeValueOldRecord();
+            item.identityId = identityId;
+            item.key2 = key2;
+            item.key3 = key3;
+            item.key1NoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.dataNoLengthCheck = (rdr[1] == DBNull.Value) ? null : (byte[])(rdr[1]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<KeyUniqueThreeValueOldRecord>> GetByKeyTwoThreeAsync(Guid identityId,byte[] key2,byte[] key3)
+        {
+            if (key2 == null) throw new Exception("Cannot be null");
+            if (key2?.Length < 0) throw new Exception("Too short");
+            if (key2?.Length > 256) throw new Exception("Too long");
+            if (key3 == null) throw new Exception("Cannot be null");
+            if (key3?.Length < 0) throw new Exception("Too short");
+            if (key3?.Length > 256) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT key1,data FROM KeyUniqueThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key2 = @key2 AND key3 = @key3;"+
+                                             ";";
+                var get2Param1 = get2Command.CreateParameter();
+                get2Param1.ParameterName = "@identityId";
+                get2Command.Parameters.Add(get2Param1);
+                var get2Param2 = get2Command.CreateParameter();
+                get2Param2.ParameterName = "@key2";
+                get2Command.Parameters.Add(get2Param2);
+                var get2Param3 = get2Command.CreateParameter();
+                get2Param3.ParameterName = "@key3";
+                get2Command.Parameters.Add(get2Param3);
+
+                get2Param1.Value = identityId.ToByteArray();
+                get2Param2.Value = key2;
+                get2Param3.Value = key3;
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableKeyUniqueThreeValueOldCRUD", identityId.ToString()+key2.ToBase64()+key3.ToBase64(), null);
+                            return new List<KeyUniqueThreeValueOldRecord>();
+                        }
+                        var result = new List<KeyUniqueThreeValueOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader2(rdr,identityId,key2,key3));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyUniqueThreeValueOldRecord ReadRecordFromReader3(DbDataReader rdr)
+        {
+            var result = new List<KeyUniqueThreeValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyUniqueThreeValueOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.key1NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key1?.Length < 16)
+                throw new Exception("Too little data in key1...");
+            item.key2NoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[2]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.key3NoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
+            if (item.key3?.Length < 0)
+                throw new Exception("Too little data in key3...");
+            item.dataNoLengthCheck = (rdr[4] == DBNull.Value) ? null : (byte[])(rdr[4]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<KeyUniqueThreeValueOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get3Command = cn.CreateCommand();
+            {
+                get3Command.CommandText = "SELECT identityId,key1,key2,key3,data FROM KeyUniqueThreeValueOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get3Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<KeyUniqueThreeValueOldRecord>();
+                        }
+                        var result = new List<KeyUniqueThreeValueOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader3(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyUniqueThreeValueOldRecord ReadRecordFromReader4(DbDataReader rdr,Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            var result = new List<KeyUniqueThreeValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyUniqueThreeValueOldRecord();
+            item.identityId = identityId;
+            item.key1 = key1;
+            item.key2NoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.key2?.Length < 0)
+                throw new Exception("Too little data in key2...");
+            item.key3NoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key3?.Length < 0)
+                throw new Exception("Too little data in key3...");
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<KeyUniqueThreeValueOldRecord> GetAsync(Guid identityId,byte[] key1)
+        {
+            if (key1 == null) throw new Exception("Cannot be null");
+            if (key1?.Length < 16) throw new Exception("Too short");
+            if (key1?.Length > 48) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableKeyUniqueThreeValueOldCRUD", identityId.ToString()+key1.ToBase64());
+            if (hit)
+                return (KeyUniqueThreeValueOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get4Command = cn.CreateCommand();
+            {
+                get4Command.CommandText = "SELECT key2,key3,data FROM KeyUniqueThreeValueOld " +
+                                             "WHERE identityId = @identityId AND key1 = @key1 LIMIT 1;"+
+                                             ";";
+                var get4Param1 = get4Command.CreateParameter();
+                get4Param1.ParameterName = "@identityId";
+                get4Command.Parameters.Add(get4Param1);
+                var get4Param2 = get4Command.CreateParameter();
+                get4Param2.ParameterName = "@key1";
+                get4Command.Parameters.Add(get4Param2);
+
+                get4Param1.Value = identityId.ToByteArray();
+                get4Param2.Value = key1;
+                {
+                    using (var rdr = await get4Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableKeyUniqueThreeValueOldCRUD", identityId.ToString()+key1.ToBase64(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader4(rdr,identityId,key1);
+                        _cache.AddOrUpdate("TableKeyUniqueThreeValueOldCRUD", identityId.ToString()+key1.ToBase64(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCRUD.cs
@@ -316,7 +316,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected KeyValueRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,byte[] key)
+        protected KeyValueRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,byte[] key)
         {
             if (key == null) throw new Exception("Cannot be null");
             if (key?.Length < 16) throw new Exception("Too short");
@@ -348,7 +348,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,data FROM keyValue " +
-                                             "WHERE identityId = @identityId AND key = @key LIMIT 1;";
+                                             "WHERE identityId = @identityId AND key = @key LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -366,7 +367,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                             _cache.AddOrUpdate("TableKeyValueCRUD", identityId.ToString()+key.ToBase64(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identityId,key);
+                        var r = ReadRecordFromReader0(rdr,identityId,key);
                         _cache.AddOrUpdate("TableKeyValueCRUD", identityId.ToString()+key.ToBase64(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCRUD.cs
@@ -99,13 +99,16 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyValue("
                    +"identityId BYTEA NOT NULL, "
                    +"key BYTEA NOT NULL, "
                    +"data BYTEA  "
                    +", PRIMARY KEY (identityId,key)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCRUD.cs
@@ -374,5 +374,54 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
+        protected virtual async Task<(List<KeyValueRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = 0;
+
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getPaging0Command = cn.CreateCommand();
+            {
+                getPaging0Command.CommandText = "SELECT rowId,identityId,key,data FROM keyValue " +
+                                            "WHERE rowId > @rowId  ORDER BY rowId ASC  LIMIT @count;";
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@rowId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
+
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await getPaging0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        var result = new List<KeyValueRecord>();
+                        Int64? nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].rowId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
     }
 }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCRUD.cs
@@ -99,19 +99,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS keyValue;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyValue("
                    +"identityId BYTEA NOT NULL, "
                    +"key BYTEA NOT NULL, "
                    +"data BYTEA  "
-                   + rowid
                    +", PRIMARY KEY (identityId,key)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueOldCRUD.cs
@@ -1,0 +1,425 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+[assembly: InternalsVisibleTo("DatabaseCommitTest")]
+[assembly: InternalsVisibleTo("DatabaseConnectionTests")]
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class KeyValueOldRecord
+    {
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private byte[] _key;
+        public byte[] key
+        {
+           get {
+                   return _key;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 48) throw new Exception("Too long");
+                  _key = value;
+               }
+        }
+        internal byte[] keyNoLengthCheck
+        {
+           get {
+                   return _key;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _key = value;
+               }
+        }
+        private byte[] _data;
+        public byte[] data
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 1048576) throw new Exception("Too long");
+                  _data = value;
+               }
+        }
+        internal byte[] dataNoLengthCheck
+        {
+           get {
+                   return _data;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _data = value;
+               }
+        }
+    } // End of class KeyValueOldRecord
+
+    public abstract class TableKeyValueOldCRUD
+    {
+        private readonly CacheHelper _cache;
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableKeyValueOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _cache = cache;
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS KeyValueOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS KeyValueOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"key BYTEA NOT NULL, "
+                   +"data BYTEA  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,key)"
+                   +");"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(KeyValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO KeyValueOld (identityId,key,data) " +
+                                             "VALUES (@identityId,@key,@data)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@key";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam3);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.key;
+                insertParam3.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyValueOldCRUD", item.identityId.ToString()+item.key.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(KeyValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO KeyValueOld (identityId,key,data) " +
+                                             "VALUES (@identityId,@key,@data) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@key";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@data";
+                insertCommand.Parameters.Add(insertParam3);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.key;
+                insertParam3.Value = item.data ?? (object)DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableKeyValueOldCRUD", item.identityId.ToString()+item.key.ToBase64(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(KeyValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO KeyValueOld (identityId,key,data) " +
+                                             "VALUES (@identityId,@key,@data)"+
+                                             "ON CONFLICT (identityId,key) DO UPDATE "+
+                                             "SET data = @data "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@key";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@data";
+                upsertCommand.Parameters.Add(upsertParam3);
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.key;
+                upsertParam3.Value = item.data ?? (object)DBNull.Value;
+                var count = await upsertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.AddOrUpdate("TableKeyValueOldCRUD", item.identityId.ToString()+item.key.ToBase64(), item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(KeyValueOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE KeyValueOld " +
+                                             "SET data = @data "+
+                                             "WHERE (identityId = @identityId AND key = @key)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@key";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@data";
+                updateCommand.Parameters.Add(updateParam3);
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.key;
+                updateParam3.Value = item.data ?? (object)DBNull.Value;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyValueOldCRUD", item.identityId.ToString()+item.key.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE keyValue RENAME TO KeyValueOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM KeyValueOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("identityId");
+            sl.Add("key");
+            sl.Add("data");
+            return sl;
+        }
+
+        // SELECT identityId,key,data
+        public KeyValueOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<KeyValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyValueOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.keyNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key?.Length < 16)
+                throw new Exception("Too little data in key...");
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,byte[] key)
+        {
+            if (key == null) throw new Exception("Cannot be null");
+            if (key?.Length < 16) throw new Exception("Too short");
+            if (key?.Length > 48) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM KeyValueOld " +
+                                             "WHERE identityId = @identityId AND key = @key";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@key";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = key;
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                if (count > 0)
+                    _cache.Remove("TableKeyValueOldCRUD", identityId.ToString()+key.ToBase64());
+                return count;
+            }
+        }
+
+        public KeyValueOldRecord ReadRecordFromReader0(DbDataReader rdr)
+        {
+            var result = new List<KeyValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyValueOldRecord();
+            item.identityId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.keyNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
+            if (item.key?.Length < 16)
+                throw new Exception("Too little data in key...");
+            item.dataNoLengthCheck = (rdr[2] == DBNull.Value) ? null : (byte[])(rdr[2]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<List<KeyValueOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT identityId,key,data FROM KeyValueOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<KeyValueOldRecord>();
+                        }
+                        var result = new List<KeyValueOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public KeyValueOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,byte[] key)
+        {
+            if (key == null) throw new Exception("Cannot be null");
+            if (key?.Length < 16) throw new Exception("Too short");
+            if (key?.Length > 48) throw new Exception("Too long");
+            var result = new List<KeyValueOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyValueOldRecord();
+            item.identityId = identityId;
+            item.key = key;
+            item.dataNoLengthCheck = (rdr[0] == DBNull.Value) ? null : (byte[])(rdr[0]);
+            if (item.data?.Length < 0)
+                throw new Exception("Too little data in data...");
+            return item;
+       }
+
+        public virtual async Task<KeyValueOldRecord> GetAsync(Guid identityId,byte[] key)
+        {
+            if (key == null) throw new Exception("Cannot be null");
+            if (key?.Length < 16) throw new Exception("Too short");
+            if (key?.Length > 48) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableKeyValueOldCRUD", identityId.ToString()+key.ToBase64());
+            if (hit)
+                return (KeyValueOldRecord)cacheObject;
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT data FROM KeyValueOld " +
+                                             "WHERE identityId = @identityId AND key = @key LIMIT 1;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@identityId";
+                get1Command.Parameters.Add(get1Param1);
+                var get1Param2 = get1Command.CreateParameter();
+                get1Param2.ParameterName = "@key";
+                get1Command.Parameters.Add(get1Param2);
+
+                get1Param1.Value = identityId.ToByteArray();
+                get1Param2.Value = key;
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableKeyValueOldCRUD", identityId.ToString()+key.ToBase64(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr,identityId,key);
+                        _cache.AddOrUpdate("TableKeyValueOldCRUD", identityId.ToString()+key.ToBase64(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
@@ -232,6 +232,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             else
                    rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS outbox("
                    +rowid
@@ -250,7 +251,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,driveId,fileId,recipient)"
-                   +") ;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableOutboxCRUD ON outbox(identityId,nextRunTime);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class OutboxRecord
     {
-        private Int64 _rowId;
-        public Int64 rowId
+        private long _rowId;
+        public long rowId
         {
            get {
                    return _rowId;
@@ -228,11 +228,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
+                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+            else
+                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS outbox("
+                   +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
                    +"fileId BYTEA NOT NULL, "
@@ -247,9 +249,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"correlationId TEXT , "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   + rowid
-                   +", PRIMARY KEY (identityId,driveId,fileId,recipient)"
-                   +");"
+                   +", UNIQUE(identityId,driveId,fileId,recipient)"
+                   +") ;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableOutboxCRUD ON outbox(identityId,nextRunTime);"
                    ;
             await cmd.ExecuteNonQueryAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
@@ -228,10 +228,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
             var rowid = "";
             if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-                   rowid = "rowid BIGSERIAL PRIMARY KEY,";
+               rowid = "rowid BIGSERIAL PRIMARY KEY,";
             else
-                   rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
-            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS outbox("

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
 {
     public class OutboxRecord
     {
-        private long _rowId;
-        public long rowId
+        private Int64 _rowId;
+        public Int64 rowId
         {
            get {
                    return _rowId;

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxCRUD.cs
@@ -251,7 +251,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"modified BIGINT  "
                    +", UNIQUE(identityId,driveId,fileId,recipient)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableOutboxCRUD ON outbox(identityId,nextRunTime);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0outbox ON outbox(identityId,nextRunTime);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -679,7 +679,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             }
         }
 
-        protected OutboxRecord ReadRecordFromReader0(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId)
+        protected OutboxRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId)
         {
             var result = new List<OutboxRecord>();
 #pragma warning disable CS0168
@@ -713,7 +713,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,recipient,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created,modified FROM outbox " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identityId";
                 get0Command.Parameters.Add(get0Param1);
@@ -737,7 +738,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         var result = new List<OutboxRecord>();
                         while (true)
                         {
-                            result.Add(ReadRecordFromReader0(rdr, identityId,driveId,fileId));
+                            result.Add(ReadRecordFromReader0(rdr,identityId,driveId,fileId));
                             if (!await rdr.ReadAsync())
                                 break;
                         }
@@ -747,7 +748,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             } // using
         }
 
-        protected OutboxRecord ReadRecordFromReader1(DbDataReader rdr, Guid identityId,Guid driveId,Guid fileId,string recipient)
+        protected OutboxRecord ReadRecordFromReader1(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,string recipient)
         {
             if (recipient == null) throw new Exception("Cannot be null");
             if (recipient?.Length < 0) throw new Exception("Too short");
@@ -787,7 +788,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var get1Command = cn.CreateCommand();
             {
                 get1Command.CommandText = "SELECT rowId,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created,modified FROM outbox " +
-                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND recipient = @recipient LIMIT 1;";
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND recipient = @recipient LIMIT 1;"+
+                                             ";";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Param1.ParameterName = "@identityId";
                 get1Command.Parameters.Add(get1Param1);
@@ -812,7 +814,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader1(rdr, identityId,driveId,fileId,recipient);
+                        var r = ReadRecordFromReader1(rdr,identityId,driveId,fileId,recipient);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableOutboxOldCRUD.cs
@@ -1,0 +1,895 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.Identity.Table
+{
+    public class OutboxOldRecord
+    {
+        private Int64 _rowId;
+        public Int64 rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
+        private Guid _identityId;
+        public Guid identityId
+        {
+           get {
+                   return _identityId;
+               }
+           set {
+                  _identityId = value;
+               }
+        }
+        private Guid _driveId;
+        public Guid driveId
+        {
+           get {
+                   return _driveId;
+               }
+           set {
+                  _driveId = value;
+               }
+        }
+        private Guid _fileId;
+        public Guid fileId
+        {
+           get {
+                   return _fileId;
+               }
+           set {
+                  _fileId = value;
+               }
+        }
+        private string _recipient;
+        public string recipient
+        {
+           get {
+                   return _recipient;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _recipient = value;
+               }
+        }
+        internal string recipientNoLengthCheck
+        {
+           get {
+                   return _recipient;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _recipient = value;
+               }
+        }
+        private Int32 _type;
+        public Int32 type
+        {
+           get {
+                   return _type;
+               }
+           set {
+                  _type = value;
+               }
+        }
+        private Int32 _priority;
+        public Int32 priority
+        {
+           get {
+                   return _priority;
+               }
+           set {
+                  _priority = value;
+               }
+        }
+        private Guid? _dependencyFileId;
+        public Guid? dependencyFileId
+        {
+           get {
+                   return _dependencyFileId;
+               }
+           set {
+                  _dependencyFileId = value;
+               }
+        }
+        private Int32 _checkOutCount;
+        public Int32 checkOutCount
+        {
+           get {
+                   return _checkOutCount;
+               }
+           set {
+                  _checkOutCount = value;
+               }
+        }
+        private UnixTimeUtc _nextRunTime;
+        public UnixTimeUtc nextRunTime
+        {
+           get {
+                   return _nextRunTime;
+               }
+           set {
+                  _nextRunTime = value;
+               }
+        }
+        private byte[] _value;
+        public byte[] value
+        {
+           get {
+                   return _value;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _value = value;
+               }
+        }
+        internal byte[] valueNoLengthCheck
+        {
+           get {
+                   return _value;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _value = value;
+               }
+        }
+        private Guid? _checkOutStamp;
+        public Guid? checkOutStamp
+        {
+           get {
+                   return _checkOutStamp;
+               }
+           set {
+                  _checkOutStamp = value;
+               }
+        }
+        private string _correlationId;
+        public string correlationId
+        {
+           get {
+                   return _correlationId;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _correlationId = value;
+               }
+        }
+        internal string correlationIdNoLengthCheck
+        {
+           get {
+                   return _correlationId;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _correlationId = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class OutboxOldRecord
+
+    public abstract class TableOutboxOldCRUD
+    {
+        private readonly ScopedIdentityConnectionFactory _scopedConnectionFactory;
+
+        protected TableOutboxOldCRUD(CacheHelper cache, ScopedIdentityConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS OutboxOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS OutboxOld("
+                   +"identityId BYTEA NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL, "
+                   +"recipient TEXT NOT NULL, "
+                   +"type BIGINT NOT NULL, "
+                   +"priority BIGINT NOT NULL, "
+                   +"dependencyFileId BYTEA , "
+                   +"checkOutCount BIGINT NOT NULL, "
+                   +"nextRunTime BIGINT NOT NULL, "
+                   +"value BYTEA , "
+                   +"checkOutStamp BYTEA , "
+                   +"correlationId TEXT , "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (identityId,driveId,fileId,recipient)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0OutboxOld ON OutboxOld(identityId,nextRunTime);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(OutboxOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.dependencyFileId.AssertGuidNotEmpty("Guid parameter dependencyFileId cannot be set to Empty GUID.");
+            item.checkOutStamp.AssertGuidNotEmpty("Guid parameter checkOutStamp cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO OutboxOld (identityId,driveId,fileId,recipient,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created,modified) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@recipient,@type,@priority,@dependencyFileId,@checkOutCount,@nextRunTime,@value,@checkOutStamp,@correlationId,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@recipient";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@type";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@priority";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@dependencyFileId";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@checkOutCount";
+                insertCommand.Parameters.Add(insertParam8);
+                var insertParam9 = insertCommand.CreateParameter();
+                insertParam9.ParameterName = "@nextRunTime";
+                insertCommand.Parameters.Add(insertParam9);
+                var insertParam10 = insertCommand.CreateParameter();
+                insertParam10.ParameterName = "@value";
+                insertCommand.Parameters.Add(insertParam10);
+                var insertParam11 = insertCommand.CreateParameter();
+                insertParam11.ParameterName = "@checkOutStamp";
+                insertCommand.Parameters.Add(insertParam11);
+                var insertParam12 = insertCommand.CreateParameter();
+                insertParam12.ParameterName = "@correlationId";
+                insertCommand.Parameters.Add(insertParam12);
+                var insertParam13 = insertCommand.CreateParameter();
+                insertParam13.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam13);
+                var insertParam14 = insertCommand.CreateParameter();
+                insertParam14.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam14);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.recipient;
+                insertParam5.Value = item.type;
+                insertParam6.Value = item.priority;
+                insertParam7.Value = item.dependencyFileId?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam8.Value = item.checkOutCount;
+                insertParam9.Value = item.nextRunTime.milliseconds;
+                insertParam10.Value = item.value ?? (object)DBNull.Value;
+                insertParam11.Value = item.checkOutStamp?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam12.Value = item.correlationId ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam13.Value = now.milliseconds;
+                item.modified = null;
+                insertParam14.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.created = now;
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(OutboxOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.dependencyFileId.AssertGuidNotEmpty("Guid parameter dependencyFileId cannot be set to Empty GUID.");
+            item.checkOutStamp.AssertGuidNotEmpty("Guid parameter checkOutStamp cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO OutboxOld (identityId,driveId,fileId,recipient,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created,modified) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@recipient,@type,@priority,@dependencyFileId,@checkOutCount,@nextRunTime,@value,@checkOutStamp,@correlationId,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@identityId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@driveId";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@fileId";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@recipient";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@type";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@priority";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@dependencyFileId";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@checkOutCount";
+                insertCommand.Parameters.Add(insertParam8);
+                var insertParam9 = insertCommand.CreateParameter();
+                insertParam9.ParameterName = "@nextRunTime";
+                insertCommand.Parameters.Add(insertParam9);
+                var insertParam10 = insertCommand.CreateParameter();
+                insertParam10.ParameterName = "@value";
+                insertCommand.Parameters.Add(insertParam10);
+                var insertParam11 = insertCommand.CreateParameter();
+                insertParam11.ParameterName = "@checkOutStamp";
+                insertCommand.Parameters.Add(insertParam11);
+                var insertParam12 = insertCommand.CreateParameter();
+                insertParam12.ParameterName = "@correlationId";
+                insertCommand.Parameters.Add(insertParam12);
+                var insertParam13 = insertCommand.CreateParameter();
+                insertParam13.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam13);
+                var insertParam14 = insertCommand.CreateParameter();
+                insertParam14.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam14);
+                insertParam1.Value = item.identityId.ToByteArray();
+                insertParam2.Value = item.driveId.ToByteArray();
+                insertParam3.Value = item.fileId.ToByteArray();
+                insertParam4.Value = item.recipient;
+                insertParam5.Value = item.type;
+                insertParam6.Value = item.priority;
+                insertParam7.Value = item.dependencyFileId?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam8.Value = item.checkOutCount;
+                insertParam9.Value = item.nextRunTime.milliseconds;
+                insertParam10.Value = item.value ?? (object)DBNull.Value;
+                insertParam11.Value = item.checkOutStamp?.ToByteArray() ?? (object)DBNull.Value;
+                insertParam12.Value = item.correlationId ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam13.Value = now.milliseconds;
+                item.modified = null;
+                insertParam14.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    item.created = now;
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(OutboxOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.dependencyFileId.AssertGuidNotEmpty("Guid parameter dependencyFileId cannot be set to Empty GUID.");
+            item.checkOutStamp.AssertGuidNotEmpty("Guid parameter checkOutStamp cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO OutboxOld (identityId,driveId,fileId,recipient,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created) " +
+                                             "VALUES (@identityId,@driveId,@fileId,@recipient,@type,@priority,@dependencyFileId,@checkOutCount,@nextRunTime,@value,@checkOutStamp,@correlationId,@created)"+
+                                             "ON CONFLICT (identityId,driveId,fileId,recipient) DO UPDATE "+
+                                             "SET type = @type,priority = @priority,dependencyFileId = @dependencyFileId,checkOutCount = @checkOutCount,nextRunTime = @nextRunTime,value = @value,checkOutStamp = @checkOutStamp,correlationId = @correlationId,modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@identityId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@driveId";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@fileId";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@recipient";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@type";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@priority";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@dependencyFileId";
+                upsertCommand.Parameters.Add(upsertParam7);
+                var upsertParam8 = upsertCommand.CreateParameter();
+                upsertParam8.ParameterName = "@checkOutCount";
+                upsertCommand.Parameters.Add(upsertParam8);
+                var upsertParam9 = upsertCommand.CreateParameter();
+                upsertParam9.ParameterName = "@nextRunTime";
+                upsertCommand.Parameters.Add(upsertParam9);
+                var upsertParam10 = upsertCommand.CreateParameter();
+                upsertParam10.ParameterName = "@value";
+                upsertCommand.Parameters.Add(upsertParam10);
+                var upsertParam11 = upsertCommand.CreateParameter();
+                upsertParam11.ParameterName = "@checkOutStamp";
+                upsertCommand.Parameters.Add(upsertParam11);
+                var upsertParam12 = upsertCommand.CreateParameter();
+                upsertParam12.ParameterName = "@correlationId";
+                upsertCommand.Parameters.Add(upsertParam12);
+                var upsertParam13 = upsertCommand.CreateParameter();
+                upsertParam13.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam13);
+                var upsertParam14 = upsertCommand.CreateParameter();
+                upsertParam14.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam14);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.identityId.ToByteArray();
+                upsertParam2.Value = item.driveId.ToByteArray();
+                upsertParam3.Value = item.fileId.ToByteArray();
+                upsertParam4.Value = item.recipient;
+                upsertParam5.Value = item.type;
+                upsertParam6.Value = item.priority;
+                upsertParam7.Value = item.dependencyFileId?.ToByteArray() ?? (object)DBNull.Value;
+                upsertParam8.Value = item.checkOutCount;
+                upsertParam9.Value = item.nextRunTime.milliseconds;
+                upsertParam10.Value = item.value ?? (object)DBNull.Value;
+                upsertParam11.Value = item.checkOutStamp?.ToByteArray() ?? (object)DBNull.Value;
+                upsertParam12.Value = item.correlationId ?? (object)DBNull.Value;
+                upsertParam13.Value = now.milliseconds;
+                upsertParam14.Value = now.milliseconds;
+                await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(OutboxOldRecord item)
+        {
+            item.identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
+            item.driveId.AssertGuidNotEmpty("Guid parameter driveId cannot be set to Empty GUID.");
+            item.fileId.AssertGuidNotEmpty("Guid parameter fileId cannot be set to Empty GUID.");
+            item.dependencyFileId.AssertGuidNotEmpty("Guid parameter dependencyFileId cannot be set to Empty GUID.");
+            item.checkOutStamp.AssertGuidNotEmpty("Guid parameter checkOutStamp cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE OutboxOld " +
+                                             "SET type = @type,priority = @priority,dependencyFileId = @dependencyFileId,checkOutCount = @checkOutCount,nextRunTime = @nextRunTime,value = @value,checkOutStamp = @checkOutStamp,correlationId = @correlationId,modified = @modified "+
+                                             "WHERE (identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND recipient = @recipient)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@identityId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@driveId";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@fileId";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@recipient";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@type";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@priority";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@dependencyFileId";
+                updateCommand.Parameters.Add(updateParam7);
+                var updateParam8 = updateCommand.CreateParameter();
+                updateParam8.ParameterName = "@checkOutCount";
+                updateCommand.Parameters.Add(updateParam8);
+                var updateParam9 = updateCommand.CreateParameter();
+                updateParam9.ParameterName = "@nextRunTime";
+                updateCommand.Parameters.Add(updateParam9);
+                var updateParam10 = updateCommand.CreateParameter();
+                updateParam10.ParameterName = "@value";
+                updateCommand.Parameters.Add(updateParam10);
+                var updateParam11 = updateCommand.CreateParameter();
+                updateParam11.ParameterName = "@checkOutStamp";
+                updateCommand.Parameters.Add(updateParam11);
+                var updateParam12 = updateCommand.CreateParameter();
+                updateParam12.ParameterName = "@correlationId";
+                updateCommand.Parameters.Add(updateParam12);
+                var updateParam13 = updateCommand.CreateParameter();
+                updateParam13.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam13);
+                var updateParam14 = updateCommand.CreateParameter();
+                updateParam14.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam14);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.identityId.ToByteArray();
+                updateParam2.Value = item.driveId.ToByteArray();
+                updateParam3.Value = item.fileId.ToByteArray();
+                updateParam4.Value = item.recipient;
+                updateParam5.Value = item.type;
+                updateParam6.Value = item.priority;
+                updateParam7.Value = item.dependencyFileId?.ToByteArray() ?? (object)DBNull.Value;
+                updateParam8.Value = item.checkOutCount;
+                updateParam9.Value = item.nextRunTime.milliseconds;
+                updateParam10.Value = item.value ?? (object)DBNull.Value;
+                updateParam11.Value = item.checkOutStamp?.ToByteArray() ?? (object)DBNull.Value;
+                updateParam12.Value = item.correlationId ?? (object)DBNull.Value;
+                updateParam13.Value = now.milliseconds;
+                updateParam14.Value = now.milliseconds;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.modified = now;
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE outbox RENAME TO OutboxOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM OutboxOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("rowId");
+            sl.Add("identityId");
+            sl.Add("driveId");
+            sl.Add("fileId");
+            sl.Add("recipient");
+            sl.Add("type");
+            sl.Add("priority");
+            sl.Add("dependencyFileId");
+            sl.Add("checkOutCount");
+            sl.Add("nextRunTime");
+            sl.Add("value");
+            sl.Add("checkOutStamp");
+            sl.Add("correlationId");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        // SELECT rowId,identityId,driveId,fileId,recipient,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created,modified
+        public OutboxOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<OutboxOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new OutboxOldRecord();
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.fileId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.recipientNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
+            item.type = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.priority = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.dependencyFileId = (rdr[7] == DBNull.Value) ? null : new Guid((byte[])rdr[7]);
+            item.checkOutCount = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[8];
+            item.nextRunTime = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[9]);
+            item.valueNoLengthCheck = (rdr[10] == DBNull.Value) ? null : (byte[])(rdr[10]);
+            if (item.value?.Length < 0)
+                throw new Exception("Too little data in value...");
+            item.checkOutStamp = (rdr[11] == DBNull.Value) ? null : new Guid((byte[])rdr[11]);
+            item.correlationIdNoLengthCheck = (rdr[12] == DBNull.Value) ? null : (string)rdr[12];
+            item.created = (rdr[13] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[13]);
+            item.modified = (rdr[14] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[14]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid identityId,Guid driveId,Guid fileId,string recipient)
+        {
+            if (recipient == null) throw new Exception("Cannot be null");
+            if (recipient?.Length < 0) throw new Exception("Too short");
+            if (recipient?.Length > 65535) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM OutboxOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND recipient = @recipient";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identityId";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@driveId";
+                delete0Command.Parameters.Add(delete0Param2);
+                var delete0Param3 = delete0Command.CreateParameter();
+                delete0Param3.ParameterName = "@fileId";
+                delete0Command.Parameters.Add(delete0Param3);
+                var delete0Param4 = delete0Command.CreateParameter();
+                delete0Param4.ParameterName = "@recipient";
+                delete0Command.Parameters.Add(delete0Param4);
+
+                delete0Param1.Value = identityId.ToByteArray();
+                delete0Param2.Value = driveId.ToByteArray();
+                delete0Param3.Value = fileId.ToByteArray();
+                delete0Param4.Value = recipient;
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public OutboxOldRecord ReadRecordFromReader0(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId)
+        {
+            var result = new List<OutboxOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new OutboxOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.recipientNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.type = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
+            item.priority = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.dependencyFileId = (rdr[4] == DBNull.Value) ? null : new Guid((byte[])rdr[4]);
+            item.checkOutCount = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.nextRunTime = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[6]);
+            item.valueNoLengthCheck = (rdr[7] == DBNull.Value) ? null : (byte[])(rdr[7]);
+            if (item.value?.Length < 0)
+                throw new Exception("Too little data in value...");
+            item.checkOutStamp = (rdr[8] == DBNull.Value) ? null : new Guid((byte[])rdr[8]);
+            item.correlationIdNoLengthCheck = (rdr[9] == DBNull.Value) ? null : (string)rdr[9];
+            item.created = (rdr[10] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[10]);
+            item.modified = (rdr[11] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[11]);
+            return item;
+       }
+
+        public virtual async Task<List<OutboxOldRecord>> GetAsync(Guid identityId,Guid driveId,Guid fileId)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT rowId,recipient,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created,modified FROM OutboxOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identityId";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@driveId";
+                get0Command.Parameters.Add(get0Param2);
+                var get0Param3 = get0Command.CreateParameter();
+                get0Param3.ParameterName = "@fileId";
+                get0Command.Parameters.Add(get0Param3);
+
+                get0Param1.Value = identityId.ToByteArray();
+                get0Param2.Value = driveId.ToByteArray();
+                get0Param3.Value = fileId.ToByteArray();
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<OutboxOldRecord>();
+                        }
+                        var result = new List<OutboxOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr,identityId,driveId,fileId));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public OutboxOldRecord ReadRecordFromReader1(DbDataReader rdr)
+        {
+            var result = new List<OutboxOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new OutboxOldRecord();
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.identityId = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[1]);
+            item.driveId = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[2]);
+            item.fileId = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[3]);
+            item.recipientNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
+            item.type = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.priority = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.dependencyFileId = (rdr[7] == DBNull.Value) ? null : new Guid((byte[])rdr[7]);
+            item.checkOutCount = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[8];
+            item.nextRunTime = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[9]);
+            item.valueNoLengthCheck = (rdr[10] == DBNull.Value) ? null : (byte[])(rdr[10]);
+            if (item.value?.Length < 0)
+                throw new Exception("Too little data in value...");
+            item.checkOutStamp = (rdr[11] == DBNull.Value) ? null : new Guid((byte[])rdr[11]);
+            item.correlationIdNoLengthCheck = (rdr[12] == DBNull.Value) ? null : (string)rdr[12];
+            item.created = (rdr[13] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[13]);
+            item.modified = (rdr[14] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[14]);
+            return item;
+       }
+
+        public virtual async Task<List<OutboxOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT rowId,identityId,driveId,fileId,recipient,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created,modified FROM OutboxOld " +
+                                             "ORDER BY rowId ASC "+
+                                             ";";
+
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<OutboxOldRecord>();
+                        }
+                        var result = new List<OutboxOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader1(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public OutboxOldRecord ReadRecordFromReader2(DbDataReader rdr,Guid identityId,Guid driveId,Guid fileId,string recipient)
+        {
+            if (recipient == null) throw new Exception("Cannot be null");
+            if (recipient?.Length < 0) throw new Exception("Too short");
+            if (recipient?.Length > 65535) throw new Exception("Too long");
+            var result = new List<OutboxOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new OutboxOldRecord();
+            item.identityId = identityId;
+            item.driveId = driveId;
+            item.fileId = fileId;
+            item.recipient = recipient;
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.type = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
+            item.priority = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
+            item.dependencyFileId = (rdr[3] == DBNull.Value) ? null : new Guid((byte[])rdr[3]);
+            item.checkOutCount = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[4];
+            item.nextRunTime = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
+            item.valueNoLengthCheck = (rdr[6] == DBNull.Value) ? null : (byte[])(rdr[6]);
+            if (item.value?.Length < 0)
+                throw new Exception("Too little data in value...");
+            item.checkOutStamp = (rdr[7] == DBNull.Value) ? null : new Guid((byte[])rdr[7]);
+            item.correlationIdNoLengthCheck = (rdr[8] == DBNull.Value) ? null : (string)rdr[8];
+            item.created = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[9]);
+            item.modified = (rdr[10] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[10]);
+            return item;
+       }
+
+        public virtual async Task<OutboxOldRecord> GetAsync(Guid identityId,Guid driveId,Guid fileId,string recipient)
+        {
+            if (recipient == null) throw new Exception("Cannot be null");
+            if (recipient?.Length < 0) throw new Exception("Too short");
+            if (recipient?.Length > 65535) throw new Exception("Too long");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get2Command = cn.CreateCommand();
+            {
+                get2Command.CommandText = "SELECT rowId,type,priority,dependencyFileId,checkOutCount,nextRunTime,value,checkOutStamp,correlationId,created,modified FROM OutboxOld " +
+                                             "WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId AND recipient = @recipient LIMIT 1;"+
+                                             ";";
+                var get2Param1 = get2Command.CreateParameter();
+                get2Param1.ParameterName = "@identityId";
+                get2Command.Parameters.Add(get2Param1);
+                var get2Param2 = get2Command.CreateParameter();
+                get2Param2.ParameterName = "@driveId";
+                get2Command.Parameters.Add(get2Param2);
+                var get2Param3 = get2Command.CreateParameter();
+                get2Param3.ParameterName = "@fileId";
+                get2Command.Parameters.Add(get2Param3);
+                var get2Param4 = get2Command.CreateParameter();
+                get2Param4.ParameterName = "@recipient";
+                get2Command.Parameters.Add(get2Param4);
+
+                get2Param1.Value = identityId.ToByteArray();
+                get2Param2.Value = driveId.ToByteArray();
+                get2Param3.Value = fileId.ToByteArray();
+                get2Param4.Value = recipient;
+                {
+                    using (var rdr = await get2Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader2(rdr,identityId,driveId,fileId,recipient);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/System/Table/TableJobsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/System/Table/TableJobsCRUD.cs
@@ -346,10 +346,10 @@ namespace Odin.Core.Storage.Database.System.Table
                    +"modified BIGINT  "
                    +", UNIQUE(id)"
                    +$"){wori};"
-                   +"CREATE INDEX IF NOT EXISTS Idx0TableJobsCRUD ON jobs(state);"
-                   +"CREATE INDEX IF NOT EXISTS Idx1TableJobsCRUD ON jobs(expiresAt);"
-                   +"CREATE INDEX IF NOT EXISTS Idx2TableJobsCRUD ON jobs(nextRun,priority);"
-                   +"CREATE INDEX IF NOT EXISTS Idx3TableJobsCRUD ON jobs(jobHash);"
+                   +"CREATE INDEX IF NOT EXISTS Idx0jobs ON jobs(state);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1jobs ON jobs(expiresAt);"
+                   +"CREATE INDEX IF NOT EXISTS Idx2jobs ON jobs(nextRun,priority);"
+                   +"CREATE INDEX IF NOT EXISTS Idx3jobs ON jobs(jobHash);"
                    ;
             await cmd.ExecuteNonQueryAsync();
         }
@@ -834,7 +834,7 @@ namespace Odin.Core.Storage.Database.System.Table
             }
         }
 
-        public JobsRecord ReadRecordFromReader0(DbDataReader rdr, Guid id)
+        public JobsRecord ReadRecordFromReader0(DbDataReader rdr,Guid id)
         {
             var result = new List<JobsRecord>();
 #pragma warning disable CS0168
@@ -871,7 +871,8 @@ namespace Odin.Core.Storage.Database.System.Table
             await using var get0Command = cn.CreateCommand();
             {
                 get0Command.CommandText = "SELECT rowId,name,state,priority,nextRun,lastRun,runCount,maxAttempts,retryDelay,onSuccessDeleteAfter,onFailureDeleteAfter,expiresAt,correlationId,jobType,jobData,jobHash,lastError,created,modified FROM jobs " +
-                                             "WHERE id = @id LIMIT 1;";
+                                             "WHERE id = @id LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@id";
                 get0Command.Parameters.Add(get0Param1);
@@ -884,7 +885,7 @@ namespace Odin.Core.Storage.Database.System.Table
                         {
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, id);
+                        var r = ReadRecordFromReader0(rdr,id);
                         return r;
                     } // using
                 } //

--- a/src/core/Odin.Core.Storage/Database/System/Table/TableJobsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/System/Table/TableJobsCRUD.cs
@@ -306,6 +306,9 @@ namespace Odin.Core.Storage.Database.System.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS jobs;";
                 await cmd.ExecuteNonQueryAsync();
             }
+            var wori = "";
+            if (_scopedConnectionFactory.DatabaseType != DatabaseType.Postgres)
+                   wori = " WITHOUT ROWID";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS jobs("
                    +"id BYTEA NOT NULL UNIQUE, "
@@ -328,7 +331,7 @@ namespace Odin.Core.Storage.Database.System.Table
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
                    +", PRIMARY KEY (id)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableJobsCRUD ON jobs(state);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableJobsCRUD ON jobs(expiresAt);"
                    +"CREATE INDEX IF NOT EXISTS Idx2TableJobsCRUD ON jobs(nextRun,priority);"

--- a/src/core/Odin.Core.Storage/Database/System/Table/TableJobsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/System/Table/TableJobsCRUD.cs
@@ -344,7 +344,6 @@ namespace Odin.Core.Storage.Database.System.Table
                    +"lastError TEXT , "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   +", UNIQUE(id)"
                    +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0jobs ON jobs(state);"
                    +"CREATE INDEX IF NOT EXISTS Idx1jobs ON jobs(expiresAt);"

--- a/src/core/Odin.Core.Storage/Database/System/Table/TableJobsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/System/Table/TableJobsCRUD.cs
@@ -306,11 +306,6 @@ namespace Odin.Core.Storage.Database.System.Table
                 cmd.CommandText = "DROP TABLE IF EXISTS jobs;";
                 await cmd.ExecuteNonQueryAsync();
             }
-            var rowid = "";
-            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
-            {
-                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
-            }
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS jobs("
                    +"id BYTEA NOT NULL UNIQUE, "
@@ -332,9 +327,8 @@ namespace Odin.Core.Storage.Database.System.Table
                    +"lastError TEXT , "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   + rowid
                    +", PRIMARY KEY (id)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    +"CREATE INDEX IF NOT EXISTS Idx0TableJobsCRUD ON jobs(state);"
                    +"CREATE INDEX IF NOT EXISTS Idx1TableJobsCRUD ON jobs(expiresAt);"
                    +"CREATE INDEX IF NOT EXISTS Idx2TableJobsCRUD ON jobs(nextRun,priority);"

--- a/src/core/Odin.Core.Storage/Database/System/Table/TableJobsOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/System/Table/TableJobsOldCRUD.cs
@@ -1,0 +1,954 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.Database.System.Table
+{
+    public class JobsOldRecord
+    {
+        private Guid _id;
+        public Guid id
+        {
+           get {
+                   return _id;
+               }
+           set {
+                  _id = value;
+               }
+        }
+        private string _name;
+        public string name
+        {
+           get {
+                   return _name;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _name = value;
+               }
+        }
+        internal string nameNoLengthCheck
+        {
+           get {
+                   return _name;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _name = value;
+               }
+        }
+        private Int32 _state;
+        public Int32 state
+        {
+           get {
+                   return _state;
+               }
+           set {
+                  _state = value;
+               }
+        }
+        private Int32 _priority;
+        public Int32 priority
+        {
+           get {
+                   return _priority;
+               }
+           set {
+                  _priority = value;
+               }
+        }
+        private UnixTimeUtc _nextRun;
+        public UnixTimeUtc nextRun
+        {
+           get {
+                   return _nextRun;
+               }
+           set {
+                  _nextRun = value;
+               }
+        }
+        private UnixTimeUtc? _lastRun;
+        public UnixTimeUtc? lastRun
+        {
+           get {
+                   return _lastRun;
+               }
+           set {
+                  _lastRun = value;
+               }
+        }
+        private Int32 _runCount;
+        public Int32 runCount
+        {
+           get {
+                   return _runCount;
+               }
+           set {
+                  _runCount = value;
+               }
+        }
+        private Int32 _maxAttempts;
+        public Int32 maxAttempts
+        {
+           get {
+                   return _maxAttempts;
+               }
+           set {
+                  _maxAttempts = value;
+               }
+        }
+        private Int64 _retryDelay;
+        public Int64 retryDelay
+        {
+           get {
+                   return _retryDelay;
+               }
+           set {
+                  _retryDelay = value;
+               }
+        }
+        private Int64 _onSuccessDeleteAfter;
+        public Int64 onSuccessDeleteAfter
+        {
+           get {
+                   return _onSuccessDeleteAfter;
+               }
+           set {
+                  _onSuccessDeleteAfter = value;
+               }
+        }
+        private Int64 _onFailureDeleteAfter;
+        public Int64 onFailureDeleteAfter
+        {
+           get {
+                   return _onFailureDeleteAfter;
+               }
+           set {
+                  _onFailureDeleteAfter = value;
+               }
+        }
+        private UnixTimeUtc? _expiresAt;
+        public UnixTimeUtc? expiresAt
+        {
+           get {
+                   return _expiresAt;
+               }
+           set {
+                  _expiresAt = value;
+               }
+        }
+        private string _correlationId;
+        public string correlationId
+        {
+           get {
+                   return _correlationId;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _correlationId = value;
+               }
+        }
+        internal string correlationIdNoLengthCheck
+        {
+           get {
+                   return _correlationId;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _correlationId = value;
+               }
+        }
+        private string _jobType;
+        public string jobType
+        {
+           get {
+                   return _jobType;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _jobType = value;
+               }
+        }
+        internal string jobTypeNoLengthCheck
+        {
+           get {
+                   return _jobType;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _jobType = value;
+               }
+        }
+        private string _jobData;
+        public string jobData
+        {
+           get {
+                   return _jobData;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _jobData = value;
+               }
+        }
+        internal string jobDataNoLengthCheck
+        {
+           get {
+                   return _jobData;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _jobData = value;
+               }
+        }
+        private string _jobHash;
+        public string jobHash
+        {
+           get {
+                   return _jobHash;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _jobHash = value;
+               }
+        }
+        internal string jobHashNoLengthCheck
+        {
+           get {
+                   return _jobHash;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _jobHash = value;
+               }
+        }
+        private string _lastError;
+        public string lastError
+        {
+           get {
+                   return _lastError;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _lastError = value;
+               }
+        }
+        internal string lastErrorNoLengthCheck
+        {
+           get {
+                   return _lastError;
+               }
+           set {
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _lastError = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class JobsOldRecord
+
+    public abstract class TableJobsOldCRUD
+    {
+        private readonly ScopedSystemConnectionFactory _scopedConnectionFactory;
+
+        protected TableJobsOldCRUD(CacheHelper cache, ScopedSystemConnectionFactory scopedConnectionFactory)
+        {
+            _scopedConnectionFactory = scopedConnectionFactory;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(bool dropExisting = false)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS JobsOld;";
+                await cmd.ExecuteNonQueryAsync();
+            }
+            var rowid = "";
+            if (_scopedConnectionFactory.DatabaseType == DatabaseType.Postgres)
+            {
+                   rowid = ", rowid BIGSERIAL NOT NULL UNIQUE ";
+            }
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS JobsOld("
+                   +"id BYTEA NOT NULL UNIQUE, "
+                   +"name TEXT NOT NULL, "
+                   +"state BIGINT NOT NULL, "
+                   +"priority BIGINT NOT NULL, "
+                   +"nextRun BIGINT NOT NULL, "
+                   +"lastRun BIGINT , "
+                   +"runCount BIGINT NOT NULL, "
+                   +"maxAttempts BIGINT NOT NULL, "
+                   +"retryDelay BIGINT NOT NULL, "
+                   +"onSuccessDeleteAfter BIGINT NOT NULL, "
+                   +"onFailureDeleteAfter BIGINT NOT NULL, "
+                   +"expiresAt BIGINT , "
+                   +"correlationId TEXT NOT NULL, "
+                   +"jobType TEXT NOT NULL, "
+                   +"jobData TEXT , "
+                   +"jobHash TEXT  UNIQUE, "
+                   +"lastError TEXT , "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (id)"
+                   +");"
+                   +"CREATE INDEX IF NOT EXISTS Idx0JobsOld ON JobsOld(state);"
+                   +"CREATE INDEX IF NOT EXISTS Idx1JobsOld ON JobsOld(expiresAt);"
+                   +"CREATE INDEX IF NOT EXISTS Idx2JobsOld ON JobsOld(nextRun,priority);"
+                   +"CREATE INDEX IF NOT EXISTS Idx3JobsOld ON JobsOld(jobHash);"
+                   ;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public virtual async Task<int> InsertAsync(JobsOldRecord item)
+        {
+            item.id.AssertGuidNotEmpty("Guid parameter id cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO JobsOld (id,name,state,priority,nextRun,lastRun,runCount,maxAttempts,retryDelay,onSuccessDeleteAfter,onFailureDeleteAfter,expiresAt,correlationId,jobType,jobData,jobHash,lastError,created,modified) " +
+                                             "VALUES (@id,@name,@state,@priority,@nextRun,@lastRun,@runCount,@maxAttempts,@retryDelay,@onSuccessDeleteAfter,@onFailureDeleteAfter,@expiresAt,@correlationId,@jobType,@jobData,@jobHash,@lastError,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@id";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@name";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@state";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@priority";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@nextRun";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@lastRun";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@runCount";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@maxAttempts";
+                insertCommand.Parameters.Add(insertParam8);
+                var insertParam9 = insertCommand.CreateParameter();
+                insertParam9.ParameterName = "@retryDelay";
+                insertCommand.Parameters.Add(insertParam9);
+                var insertParam10 = insertCommand.CreateParameter();
+                insertParam10.ParameterName = "@onSuccessDeleteAfter";
+                insertCommand.Parameters.Add(insertParam10);
+                var insertParam11 = insertCommand.CreateParameter();
+                insertParam11.ParameterName = "@onFailureDeleteAfter";
+                insertCommand.Parameters.Add(insertParam11);
+                var insertParam12 = insertCommand.CreateParameter();
+                insertParam12.ParameterName = "@expiresAt";
+                insertCommand.Parameters.Add(insertParam12);
+                var insertParam13 = insertCommand.CreateParameter();
+                insertParam13.ParameterName = "@correlationId";
+                insertCommand.Parameters.Add(insertParam13);
+                var insertParam14 = insertCommand.CreateParameter();
+                insertParam14.ParameterName = "@jobType";
+                insertCommand.Parameters.Add(insertParam14);
+                var insertParam15 = insertCommand.CreateParameter();
+                insertParam15.ParameterName = "@jobData";
+                insertCommand.Parameters.Add(insertParam15);
+                var insertParam16 = insertCommand.CreateParameter();
+                insertParam16.ParameterName = "@jobHash";
+                insertCommand.Parameters.Add(insertParam16);
+                var insertParam17 = insertCommand.CreateParameter();
+                insertParam17.ParameterName = "@lastError";
+                insertCommand.Parameters.Add(insertParam17);
+                var insertParam18 = insertCommand.CreateParameter();
+                insertParam18.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam18);
+                var insertParam19 = insertCommand.CreateParameter();
+                insertParam19.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam19);
+                insertParam1.Value = item.id.ToByteArray();
+                insertParam2.Value = item.name;
+                insertParam3.Value = item.state;
+                insertParam4.Value = item.priority;
+                insertParam5.Value = item.nextRun.milliseconds;
+                insertParam6.Value = item.lastRun == null ? (object)DBNull.Value : item.lastRun?.milliseconds;
+                insertParam7.Value = item.runCount;
+                insertParam8.Value = item.maxAttempts;
+                insertParam9.Value = item.retryDelay;
+                insertParam10.Value = item.onSuccessDeleteAfter;
+                insertParam11.Value = item.onFailureDeleteAfter;
+                insertParam12.Value = item.expiresAt == null ? (object)DBNull.Value : item.expiresAt?.milliseconds;
+                insertParam13.Value = item.correlationId;
+                insertParam14.Value = item.jobType;
+                insertParam15.Value = item.jobData ?? (object)DBNull.Value;
+                insertParam16.Value = item.jobHash ?? (object)DBNull.Value;
+                insertParam17.Value = item.lastError ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam18.Value = now.milliseconds;
+                item.modified = null;
+                insertParam19.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.created = now;
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(JobsOldRecord item)
+        {
+            item.id.AssertGuidNotEmpty("Guid parameter id cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var insertCommand = cn.CreateCommand();
+            {
+                insertCommand.CommandText = "INSERT INTO JobsOld (id,name,state,priority,nextRun,lastRun,runCount,maxAttempts,retryDelay,onSuccessDeleteAfter,onFailureDeleteAfter,expiresAt,correlationId,jobType,jobData,jobHash,lastError,created,modified) " +
+                                             "VALUES (@id,@name,@state,@priority,@nextRun,@lastRun,@runCount,@maxAttempts,@retryDelay,@onSuccessDeleteAfter,@onFailureDeleteAfter,@expiresAt,@correlationId,@jobType,@jobData,@jobHash,@lastError,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@id";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@name";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@state";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@priority";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@nextRun";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@lastRun";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@runCount";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@maxAttempts";
+                insertCommand.Parameters.Add(insertParam8);
+                var insertParam9 = insertCommand.CreateParameter();
+                insertParam9.ParameterName = "@retryDelay";
+                insertCommand.Parameters.Add(insertParam9);
+                var insertParam10 = insertCommand.CreateParameter();
+                insertParam10.ParameterName = "@onSuccessDeleteAfter";
+                insertCommand.Parameters.Add(insertParam10);
+                var insertParam11 = insertCommand.CreateParameter();
+                insertParam11.ParameterName = "@onFailureDeleteAfter";
+                insertCommand.Parameters.Add(insertParam11);
+                var insertParam12 = insertCommand.CreateParameter();
+                insertParam12.ParameterName = "@expiresAt";
+                insertCommand.Parameters.Add(insertParam12);
+                var insertParam13 = insertCommand.CreateParameter();
+                insertParam13.ParameterName = "@correlationId";
+                insertCommand.Parameters.Add(insertParam13);
+                var insertParam14 = insertCommand.CreateParameter();
+                insertParam14.ParameterName = "@jobType";
+                insertCommand.Parameters.Add(insertParam14);
+                var insertParam15 = insertCommand.CreateParameter();
+                insertParam15.ParameterName = "@jobData";
+                insertCommand.Parameters.Add(insertParam15);
+                var insertParam16 = insertCommand.CreateParameter();
+                insertParam16.ParameterName = "@jobHash";
+                insertCommand.Parameters.Add(insertParam16);
+                var insertParam17 = insertCommand.CreateParameter();
+                insertParam17.ParameterName = "@lastError";
+                insertCommand.Parameters.Add(insertParam17);
+                var insertParam18 = insertCommand.CreateParameter();
+                insertParam18.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam18);
+                var insertParam19 = insertCommand.CreateParameter();
+                insertParam19.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam19);
+                insertParam1.Value = item.id.ToByteArray();
+                insertParam2.Value = item.name;
+                insertParam3.Value = item.state;
+                insertParam4.Value = item.priority;
+                insertParam5.Value = item.nextRun.milliseconds;
+                insertParam6.Value = item.lastRun == null ? (object)DBNull.Value : item.lastRun?.milliseconds;
+                insertParam7.Value = item.runCount;
+                insertParam8.Value = item.maxAttempts;
+                insertParam9.Value = item.retryDelay;
+                insertParam10.Value = item.onSuccessDeleteAfter;
+                insertParam11.Value = item.onFailureDeleteAfter;
+                insertParam12.Value = item.expiresAt == null ? (object)DBNull.Value : item.expiresAt?.milliseconds;
+                insertParam13.Value = item.correlationId;
+                insertParam14.Value = item.jobType;
+                insertParam15.Value = item.jobData ?? (object)DBNull.Value;
+                insertParam16.Value = item.jobHash ?? (object)DBNull.Value;
+                insertParam17.Value = item.lastError ?? (object)DBNull.Value;
+                var now = UnixTimeUtc.Now();
+                insertParam18.Value = now.milliseconds;
+                item.modified = null;
+                insertParam19.Value = DBNull.Value;
+                var count = await insertCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                    item.created = now;
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(JobsOldRecord item)
+        {
+            item.id.AssertGuidNotEmpty("Guid parameter id cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var upsertCommand = cn.CreateCommand();
+            {
+                upsertCommand.CommandText = "INSERT INTO JobsOld (id,name,state,priority,nextRun,lastRun,runCount,maxAttempts,retryDelay,onSuccessDeleteAfter,onFailureDeleteAfter,expiresAt,correlationId,jobType,jobData,jobHash,lastError,created) " +
+                                             "VALUES (@id,@name,@state,@priority,@nextRun,@lastRun,@runCount,@maxAttempts,@retryDelay,@onSuccessDeleteAfter,@onFailureDeleteAfter,@expiresAt,@correlationId,@jobType,@jobData,@jobHash,@lastError,@created)"+
+                                             "ON CONFLICT (id) DO UPDATE "+
+                                             "SET name = @name,state = @state,priority = @priority,nextRun = @nextRun,lastRun = @lastRun,runCount = @runCount,maxAttempts = @maxAttempts,retryDelay = @retryDelay,onSuccessDeleteAfter = @onSuccessDeleteAfter,onFailureDeleteAfter = @onFailureDeleteAfter,expiresAt = @expiresAt,correlationId = @correlationId,jobType = @jobType,jobData = @jobData,jobHash = @jobHash,lastError = @lastError,modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@id";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@name";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@state";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@priority";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@nextRun";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@lastRun";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@runCount";
+                upsertCommand.Parameters.Add(upsertParam7);
+                var upsertParam8 = upsertCommand.CreateParameter();
+                upsertParam8.ParameterName = "@maxAttempts";
+                upsertCommand.Parameters.Add(upsertParam8);
+                var upsertParam9 = upsertCommand.CreateParameter();
+                upsertParam9.ParameterName = "@retryDelay";
+                upsertCommand.Parameters.Add(upsertParam9);
+                var upsertParam10 = upsertCommand.CreateParameter();
+                upsertParam10.ParameterName = "@onSuccessDeleteAfter";
+                upsertCommand.Parameters.Add(upsertParam10);
+                var upsertParam11 = upsertCommand.CreateParameter();
+                upsertParam11.ParameterName = "@onFailureDeleteAfter";
+                upsertCommand.Parameters.Add(upsertParam11);
+                var upsertParam12 = upsertCommand.CreateParameter();
+                upsertParam12.ParameterName = "@expiresAt";
+                upsertCommand.Parameters.Add(upsertParam12);
+                var upsertParam13 = upsertCommand.CreateParameter();
+                upsertParam13.ParameterName = "@correlationId";
+                upsertCommand.Parameters.Add(upsertParam13);
+                var upsertParam14 = upsertCommand.CreateParameter();
+                upsertParam14.ParameterName = "@jobType";
+                upsertCommand.Parameters.Add(upsertParam14);
+                var upsertParam15 = upsertCommand.CreateParameter();
+                upsertParam15.ParameterName = "@jobData";
+                upsertCommand.Parameters.Add(upsertParam15);
+                var upsertParam16 = upsertCommand.CreateParameter();
+                upsertParam16.ParameterName = "@jobHash";
+                upsertCommand.Parameters.Add(upsertParam16);
+                var upsertParam17 = upsertCommand.CreateParameter();
+                upsertParam17.ParameterName = "@lastError";
+                upsertCommand.Parameters.Add(upsertParam17);
+                var upsertParam18 = upsertCommand.CreateParameter();
+                upsertParam18.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam18);
+                var upsertParam19 = upsertCommand.CreateParameter();
+                upsertParam19.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam19);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.id.ToByteArray();
+                upsertParam2.Value = item.name;
+                upsertParam3.Value = item.state;
+                upsertParam4.Value = item.priority;
+                upsertParam5.Value = item.nextRun.milliseconds;
+                upsertParam6.Value = item.lastRun == null ? (object)DBNull.Value : item.lastRun?.milliseconds;
+                upsertParam7.Value = item.runCount;
+                upsertParam8.Value = item.maxAttempts;
+                upsertParam9.Value = item.retryDelay;
+                upsertParam10.Value = item.onSuccessDeleteAfter;
+                upsertParam11.Value = item.onFailureDeleteAfter;
+                upsertParam12.Value = item.expiresAt == null ? (object)DBNull.Value : item.expiresAt?.milliseconds;
+                upsertParam13.Value = item.correlationId;
+                upsertParam14.Value = item.jobType;
+                upsertParam15.Value = item.jobData ?? (object)DBNull.Value;
+                upsertParam16.Value = item.jobHash ?? (object)DBNull.Value;
+                upsertParam17.Value = item.lastError ?? (object)DBNull.Value;
+                upsertParam18.Value = now.milliseconds;
+                upsertParam19.Value = now.milliseconds;
+                await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(JobsOldRecord item)
+        {
+            item.id.AssertGuidNotEmpty("Guid parameter id cannot be set to Empty GUID.");
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var updateCommand = cn.CreateCommand();
+            {
+                updateCommand.CommandText = "UPDATE JobsOld " +
+                                             "SET name = @name,state = @state,priority = @priority,nextRun = @nextRun,lastRun = @lastRun,runCount = @runCount,maxAttempts = @maxAttempts,retryDelay = @retryDelay,onSuccessDeleteAfter = @onSuccessDeleteAfter,onFailureDeleteAfter = @onFailureDeleteAfter,expiresAt = @expiresAt,correlationId = @correlationId,jobType = @jobType,jobData = @jobData,jobHash = @jobHash,lastError = @lastError,modified = @modified "+
+                                             "WHERE (id = @id)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@id";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@name";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@state";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@priority";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@nextRun";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@lastRun";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@runCount";
+                updateCommand.Parameters.Add(updateParam7);
+                var updateParam8 = updateCommand.CreateParameter();
+                updateParam8.ParameterName = "@maxAttempts";
+                updateCommand.Parameters.Add(updateParam8);
+                var updateParam9 = updateCommand.CreateParameter();
+                updateParam9.ParameterName = "@retryDelay";
+                updateCommand.Parameters.Add(updateParam9);
+                var updateParam10 = updateCommand.CreateParameter();
+                updateParam10.ParameterName = "@onSuccessDeleteAfter";
+                updateCommand.Parameters.Add(updateParam10);
+                var updateParam11 = updateCommand.CreateParameter();
+                updateParam11.ParameterName = "@onFailureDeleteAfter";
+                updateCommand.Parameters.Add(updateParam11);
+                var updateParam12 = updateCommand.CreateParameter();
+                updateParam12.ParameterName = "@expiresAt";
+                updateCommand.Parameters.Add(updateParam12);
+                var updateParam13 = updateCommand.CreateParameter();
+                updateParam13.ParameterName = "@correlationId";
+                updateCommand.Parameters.Add(updateParam13);
+                var updateParam14 = updateCommand.CreateParameter();
+                updateParam14.ParameterName = "@jobType";
+                updateCommand.Parameters.Add(updateParam14);
+                var updateParam15 = updateCommand.CreateParameter();
+                updateParam15.ParameterName = "@jobData";
+                updateCommand.Parameters.Add(updateParam15);
+                var updateParam16 = updateCommand.CreateParameter();
+                updateParam16.ParameterName = "@jobHash";
+                updateCommand.Parameters.Add(updateParam16);
+                var updateParam17 = updateCommand.CreateParameter();
+                updateParam17.ParameterName = "@lastError";
+                updateCommand.Parameters.Add(updateParam17);
+                var updateParam18 = updateCommand.CreateParameter();
+                updateParam18.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam18);
+                var updateParam19 = updateCommand.CreateParameter();
+                updateParam19.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam19);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.id.ToByteArray();
+                updateParam2.Value = item.name;
+                updateParam3.Value = item.state;
+                updateParam4.Value = item.priority;
+                updateParam5.Value = item.nextRun.milliseconds;
+                updateParam6.Value = item.lastRun == null ? (object)DBNull.Value : item.lastRun?.milliseconds;
+                updateParam7.Value = item.runCount;
+                updateParam8.Value = item.maxAttempts;
+                updateParam9.Value = item.retryDelay;
+                updateParam10.Value = item.onSuccessDeleteAfter;
+                updateParam11.Value = item.onFailureDeleteAfter;
+                updateParam12.Value = item.expiresAt == null ? (object)DBNull.Value : item.expiresAt?.milliseconds;
+                updateParam13.Value = item.correlationId;
+                updateParam14.Value = item.jobType;
+                updateParam15.Value = item.jobData ?? (object)DBNull.Value;
+                updateParam16.Value = item.jobHash ?? (object)DBNull.Value;
+                updateParam17.Value = item.lastError ?? (object)DBNull.Value;
+                updateParam18.Value = now.milliseconds;
+                updateParam19.Value = now.milliseconds;
+                var count = await updateCommand.ExecuteNonQueryAsync();
+                if (count > 0)
+                {
+                     item.modified = now;
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                getCountCommand.CommandText = "ALTER TABLE jobs RENAME TO JobsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var getCountCommand = cn.CreateCommand();
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM JobsOld;";
+                var count = await getCountCommand.ExecuteScalarAsync();
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("id");
+            sl.Add("name");
+            sl.Add("state");
+            sl.Add("priority");
+            sl.Add("nextRun");
+            sl.Add("lastRun");
+            sl.Add("runCount");
+            sl.Add("maxAttempts");
+            sl.Add("retryDelay");
+            sl.Add("onSuccessDeleteAfter");
+            sl.Add("onFailureDeleteAfter");
+            sl.Add("expiresAt");
+            sl.Add("correlationId");
+            sl.Add("jobType");
+            sl.Add("jobData");
+            sl.Add("jobHash");
+            sl.Add("lastError");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        // SELECT id,name,state,priority,nextRun,lastRun,runCount,maxAttempts,retryDelay,onSuccessDeleteAfter,onFailureDeleteAfter,expiresAt,correlationId,jobType,jobData,jobHash,lastError,created,modified
+        public JobsOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<JobsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new JobsOldRecord();
+            item.id = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.nameNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.state = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
+            item.priority = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.nextRun = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[4]);
+            item.lastRun = (rdr[5] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[5]);
+            item.runCount = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.maxAttempts = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[7];
+            item.retryDelay = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[8];
+            item.onSuccessDeleteAfter = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[9];
+            item.onFailureDeleteAfter = (rdr[10] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[10];
+            item.expiresAt = (rdr[11] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[11]);
+            item.correlationIdNoLengthCheck = (rdr[12] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[12];
+            item.jobTypeNoLengthCheck = (rdr[13] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[13];
+            item.jobDataNoLengthCheck = (rdr[14] == DBNull.Value) ? null : (string)rdr[14];
+            item.jobHashNoLengthCheck = (rdr[15] == DBNull.Value) ? null : (string)rdr[15];
+            item.lastErrorNoLengthCheck = (rdr[16] == DBNull.Value) ? null : (string)rdr[16];
+            item.created = (rdr[17] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[17]);
+            item.modified = (rdr[18] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[18]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(Guid id)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var delete0Command = cn.CreateCommand();
+            {
+                delete0Command.CommandText = "DELETE FROM JobsOld " +
+                                             "WHERE id = @id";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@id";
+                delete0Command.Parameters.Add(delete0Param1);
+
+                delete0Param1.Value = id.ToByteArray();
+                var count = await delete0Command.ExecuteNonQueryAsync();
+                return count;
+            }
+        }
+
+        public JobsOldRecord ReadRecordFromReader0(DbDataReader rdr)
+        {
+            var result = new List<JobsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new JobsOldRecord();
+            item.id = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new Guid((byte[])rdr[0]);
+            item.nameNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.state = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
+            item.priority = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[3];
+            item.nextRun = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[4]);
+            item.lastRun = (rdr[5] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[5]);
+            item.runCount = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.maxAttempts = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[7];
+            item.retryDelay = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[8];
+            item.onSuccessDeleteAfter = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[9];
+            item.onFailureDeleteAfter = (rdr[10] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[10];
+            item.expiresAt = (rdr[11] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[11]);
+            item.correlationIdNoLengthCheck = (rdr[12] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[12];
+            item.jobTypeNoLengthCheck = (rdr[13] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[13];
+            item.jobDataNoLengthCheck = (rdr[14] == DBNull.Value) ? null : (string)rdr[14];
+            item.jobHashNoLengthCheck = (rdr[15] == DBNull.Value) ? null : (string)rdr[15];
+            item.lastErrorNoLengthCheck = (rdr[16] == DBNull.Value) ? null : (string)rdr[16];
+            item.created = (rdr[17] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[17]);
+            item.modified = (rdr[18] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[18]);
+            return item;
+       }
+
+        public virtual async Task<List<JobsOldRecord>> GetAllAsync()
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get0Command = cn.CreateCommand();
+            {
+                get0Command.CommandText = "SELECT id,name,state,priority,nextRun,lastRun,runCount,maxAttempts,retryDelay,onSuccessDeleteAfter,onFailureDeleteAfter,expiresAt,correlationId,jobType,jobData,jobHash,lastError,created,modified FROM JobsOld " +
+                                             ";";
+
+                {
+                    using (var rdr = await get0Command.ExecuteReaderAsync(CommandBehavior.Default))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return new List<JobsOldRecord>();
+                        }
+                        var result = new List<JobsOldRecord>();
+                        while (true)
+                        {
+                            result.Add(ReadRecordFromReader0(rdr));
+                            if (!await rdr.ReadAsync())
+                                break;
+                        }
+                        return result;
+                    } // using
+                } //
+            } // using
+        }
+
+        public JobsOldRecord ReadRecordFromReader1(DbDataReader rdr,Guid id)
+        {
+            var result = new List<JobsOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new JobsOldRecord();
+            item.id = id;
+            item.nameNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[0];
+            item.state = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
+            item.priority = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
+            item.nextRun = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.lastRun = (rdr[4] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[4]);
+            item.runCount = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
+            item.maxAttempts = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[6];
+            item.retryDelay = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[7];
+            item.onSuccessDeleteAfter = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[8];
+            item.onFailureDeleteAfter = (rdr[9] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[9];
+            item.expiresAt = (rdr[10] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[10]);
+            item.correlationIdNoLengthCheck = (rdr[11] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[11];
+            item.jobTypeNoLengthCheck = (rdr[12] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[12];
+            item.jobDataNoLengthCheck = (rdr[13] == DBNull.Value) ? null : (string)rdr[13];
+            item.jobHashNoLengthCheck = (rdr[14] == DBNull.Value) ? null : (string)rdr[14];
+            item.lastErrorNoLengthCheck = (rdr[15] == DBNull.Value) ? null : (string)rdr[15];
+            item.created = (rdr[16] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[16]);
+            item.modified = (rdr[17] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[17]);
+            return item;
+       }
+
+        public virtual async Task<JobsOldRecord> GetAsync(Guid id)
+        {
+            await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var get1Command = cn.CreateCommand();
+            {
+                get1Command.CommandText = "SELECT name,state,priority,nextRun,lastRun,runCount,maxAttempts,retryDelay,onSuccessDeleteAfter,onFailureDeleteAfter,expiresAt,correlationId,jobType,jobData,jobHash,lastError,created,modified FROM JobsOld " +
+                                             "WHERE id = @id LIMIT 1;"+
+                                             ";";
+                var get1Param1 = get1Command.CreateParameter();
+                get1Param1.ParameterName = "@id";
+                get1Command.Parameters.Add(get1Param1);
+
+                get1Param1.Value = id.ToByteArray();
+                {
+                    using (var rdr = await get1Command.ExecuteReaderAsync(CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            return null;
+                        }
+                        var r = ReadRecordFromReader1(rdr,id);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationRequestCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationRequestCRUD.cs
@@ -276,7 +276,7 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
             }
         }
 
-        public AttestationRequestRecord ReadRecordFromReader0(DbDataReader rdr, string attestationId)
+        public AttestationRequestRecord ReadRecordFromReader0(DbDataReader rdr,string attestationId)
         {
             if (attestationId == null) throw new Exception("Cannot be null");
             if (attestationId?.Length < 0) throw new Exception("Too short");
@@ -293,7 +293,7 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
             return item;
        }
 
-        public virtual async Task<AttestationRequestRecord> GetAsync(DatabaseConnection conn, string attestationId)
+        public virtual async Task<AttestationRequestRecord> GetAsync(DatabaseConnection conn,string attestationId)
         {
             if (attestationId == null) throw new Exception("Cannot be null");
             if (attestationId?.Length < 0) throw new Exception("Too short");
@@ -304,7 +304,8 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
             using (var get0Command = conn.db.CreateCommand())
             {
                 get0Command.CommandText = "SELECT requestEnvelope,timestamp FROM attestationRequest " +
-                                             "WHERE attestationId = @attestationId LIMIT 1;";
+                                             "WHERE attestationId = @attestationId LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@attestationId";
                 get0Command.Parameters.Add(get0Param1);
@@ -318,7 +319,7 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
                             _cache.AddOrUpdate("TableAttestationRequestCRUD", attestationId, null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, attestationId);
+                        var r = ReadRecordFromReader0(rdr,attestationId);
                         _cache.AddOrUpdate("TableAttestationRequestCRUD", attestationId, r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationRequestCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationRequestCRUD.cs
@@ -95,13 +95,14 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
                 cmd.CommandText = "DROP TABLE IF EXISTS attestationRequest;";
                 await conn.ExecuteNonQueryAsync(cmd);
             }
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS attestationRequest("
                    +"attestationId TEXT NOT NULL UNIQUE, "
                    +"requestEnvelope TEXT NOT NULL UNIQUE, "
                    +"timestamp BIGINT NOT NULL "
                    +", PRIMARY KEY (attestationId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);
         }

--- a/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationRequestCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationRequestCRUD.cs
@@ -95,15 +95,13 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
                 cmd.CommandText = "DROP TABLE IF EXISTS attestationRequest;";
                 await conn.ExecuteNonQueryAsync(cmd);
             }
-            var rowid = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS attestationRequest("
                    +"attestationId TEXT NOT NULL UNIQUE, "
                    +"requestEnvelope TEXT NOT NULL UNIQUE, "
                    +"timestamp BIGINT NOT NULL "
-                   + rowid
                    +", PRIMARY KEY (attestationId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);
         }
@@ -336,22 +334,22 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
             if (inCursor == null)
                 inCursor = "";
 
-            using (var getPaging1Command = conn.db.CreateCommand())
+            using (var getPaging0Command = conn.db.CreateCommand())
             {
-                getPaging1Command.CommandText = "SELECT attestationId,requestEnvelope,timestamp FROM attestationRequest " +
+                getPaging0Command.CommandText = "SELECT attestationId,requestEnvelope,timestamp FROM attestationRequest " +
                                             "WHERE attestationId > @attestationId  ORDER BY attestationId ASC  LIMIT @count;";
-                var getPaging1Param1 = getPaging1Command.CreateParameter();
-                getPaging1Param1.ParameterName = "@attestationId";
-                getPaging1Command.Parameters.Add(getPaging1Param1);
-                var getPaging1Param2 = getPaging1Command.CreateParameter();
-                getPaging1Param2.ParameterName = "@count";
-                getPaging1Command.Parameters.Add(getPaging1Param2);
+                var getPaging0Param1 = getPaging0Command.CreateParameter();
+                getPaging0Param1.ParameterName = "@attestationId";
+                getPaging0Command.Parameters.Add(getPaging0Param1);
+                var getPaging0Param2 = getPaging0Command.CreateParameter();
+                getPaging0Param2.ParameterName = "@count";
+                getPaging0Command.Parameters.Add(getPaging0Param2);
 
-                getPaging1Param1.Value = inCursor;
-                getPaging1Param2.Value = count+1;
+                getPaging0Param1.Value = inCursor;
+                getPaging0Param2.Value = count+1;
 
                 {
-                    await using (var rdr = await conn.ExecuteReaderAsync(getPaging1Command, System.Data.CommandBehavior.Default))
+                    await using (var rdr = await conn.ExecuteReaderAsync(getPaging0Command, System.Data.CommandBehavior.Default))
                     {
                         var result = new List<AttestationRequestRecord>();
                         string nextCursor;

--- a/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationRequestOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationRequestOldCRUD.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.SQLite.AttestationDatabase
+{
+    public class AttestationRequestOldRecord
+    {
+        private string _attestationId;
+        public string attestationId
+        {
+           get {
+                   return _attestationId;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _attestationId = value;
+               }
+        }
+        internal string attestationIdNoLengthCheck
+        {
+           get {
+                   return _attestationId;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _attestationId = value;
+               }
+        }
+        private string _requestEnvelope;
+        public string requestEnvelope
+        {
+           get {
+                   return _requestEnvelope;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                    if (value?.Length > 65535) throw new Exception("Too long");
+                  _requestEnvelope = value;
+               }
+        }
+        internal string requestEnvelopeNoLengthCheck
+        {
+           get {
+                   return _requestEnvelope;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 0) throw new Exception("Too short");
+                  _requestEnvelope = value;
+               }
+        }
+        private UnixTimeUtc _timestamp;
+        public UnixTimeUtc timestamp
+        {
+           get {
+                   return _timestamp;
+               }
+           set {
+                  _timestamp = value;
+               }
+        }
+    } // End of class AttestationRequestOldRecord
+
+    public class TableAttestationRequestOldCRUD
+    {
+        private readonly CacheHelper _cache;
+
+        public TableAttestationRequestOldCRUD(CacheHelper cache)
+        {
+            _cache = cache;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(DatabaseConnection conn, bool dropExisting = false)
+        {
+            await using var cmd = conn.db.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS AttestationRequestOld;";
+                await conn.ExecuteNonQueryAsync(cmd);
+            }
+            var rowid = "";
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS AttestationRequestOld("
+                   +"attestationId TEXT NOT NULL UNIQUE, "
+                   +"requestEnvelope TEXT NOT NULL UNIQUE, "
+                   +"timestamp BIGINT NOT NULL "
+                   + rowid
+                   +", PRIMARY KEY (attestationId)"
+                   +");"
+                   ;
+            await conn.ExecuteNonQueryAsync(cmd);
+        }
+
+        public virtual async Task<int> InsertAsync(DatabaseConnection conn, AttestationRequestOldRecord item)
+        {
+            using (var insertCommand = conn.db.CreateCommand())
+            {
+                insertCommand.CommandText = "INSERT INTO AttestationRequestOld (attestationId,requestEnvelope,timestamp) " +
+                                             "VALUES (@attestationId,@requestEnvelope,@timestamp)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@attestationId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@requestEnvelope";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@timestamp";
+                insertCommand.Parameters.Add(insertParam3);
+                insertParam1.Value = item.attestationId;
+                insertParam2.Value = item.requestEnvelope;
+                insertParam3.Value = item.timestamp.milliseconds;
+                var count = await conn.ExecuteNonQueryAsync(insertCommand);
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableAttestationRequestOldCRUD", item.attestationId, item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DatabaseConnection conn, AttestationRequestOldRecord item)
+        {
+            using (var insertCommand = conn.db.CreateCommand())
+            {
+                insertCommand.CommandText = "INSERT INTO AttestationRequestOld (attestationId,requestEnvelope,timestamp) " +
+                                             "VALUES (@attestationId,@requestEnvelope,@timestamp) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@attestationId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@requestEnvelope";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@timestamp";
+                insertCommand.Parameters.Add(insertParam3);
+                insertParam1.Value = item.attestationId;
+                insertParam2.Value = item.requestEnvelope;
+                insertParam3.Value = item.timestamp.milliseconds;
+                var count = await conn.ExecuteNonQueryAsync(insertCommand);
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableAttestationRequestOldCRUD", item.attestationId, item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DatabaseConnection conn, AttestationRequestOldRecord item)
+        {
+            using (var upsertCommand = conn.db.CreateCommand())
+            {
+                upsertCommand.CommandText = "INSERT INTO AttestationRequestOld (attestationId,requestEnvelope,timestamp) " +
+                                             "VALUES (@attestationId,@requestEnvelope,@timestamp)"+
+                                             "ON CONFLICT (attestationId) DO UPDATE "+
+                                             "SET requestEnvelope = @requestEnvelope,timestamp = @timestamp "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@attestationId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@requestEnvelope";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@timestamp";
+                upsertCommand.Parameters.Add(upsertParam3);
+                upsertParam1.Value = item.attestationId;
+                upsertParam2.Value = item.requestEnvelope;
+                upsertParam3.Value = item.timestamp.milliseconds;
+                var count = await conn.ExecuteNonQueryAsync(upsertCommand);
+                if (count > 0)
+                    _cache.AddOrUpdate("TableAttestationRequestOldCRUD", item.attestationId, item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(DatabaseConnection conn, AttestationRequestOldRecord item)
+        {
+            using (var updateCommand = conn.db.CreateCommand())
+            {
+                updateCommand.CommandText = "UPDATE AttestationRequestOld " +
+                                             "SET requestEnvelope = @requestEnvelope,timestamp = @timestamp "+
+                                             "WHERE (attestationId = @attestationId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@attestationId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@requestEnvelope";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@timestamp";
+                updateCommand.Parameters.Add(updateParam3);
+                updateParam1.Value = item.attestationId;
+                updateParam2.Value = item.requestEnvelope;
+                updateParam3.Value = item.timestamp.milliseconds;
+                var count = await conn.ExecuteNonQueryAsync(updateCommand);
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableAttestationRequestOldCRUD", item.attestationId, item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync(DatabaseConnection conn)
+        {
+            using (var getCountCommand = conn.db.CreateCommand())
+            {
+                getCountCommand.CommandText = "ALTER TABLE attestationRequest RENAME TO AttestationRequestOld;";
+                var count = await conn.ExecuteScalarAsync(getCountCommand);
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync(DatabaseConnection conn)
+        {
+            using (var getCountCommand = conn.db.CreateCommand())
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM AttestationRequestOld;";
+                var count = await conn.ExecuteScalarAsync(getCountCommand);
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("attestationId");
+            sl.Add("requestEnvelope");
+            sl.Add("timestamp");
+            return sl;
+        }
+
+        // SELECT attestationId,requestEnvelope,timestamp
+        public AttestationRequestOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<AttestationRequestOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AttestationRequestOldRecord();
+            item.attestationIdNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[0];
+            item.requestEnvelopeNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.timestamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(DatabaseConnection conn, string attestationId)
+        {
+            if (attestationId == null) throw new Exception("Cannot be null");
+            if (attestationId?.Length < 0) throw new Exception("Too short");
+            if (attestationId?.Length > 65535) throw new Exception("Too long");
+            using (var delete0Command = conn.db.CreateCommand())
+            {
+                delete0Command.CommandText = "DELETE FROM AttestationRequestOld " +
+                                             "WHERE attestationId = @attestationId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@attestationId";
+                delete0Command.Parameters.Add(delete0Param1);
+
+                delete0Param1.Value = attestationId;
+                var count = await conn.ExecuteNonQueryAsync(delete0Command);
+                if (count > 0)
+                    _cache.Remove("TableAttestationRequestOldCRUD", attestationId);
+                return count;
+            }
+        }
+
+        public AttestationRequestOldRecord ReadRecordFromReader0(DbDataReader rdr,string attestationId)
+        {
+            if (attestationId == null) throw new Exception("Cannot be null");
+            if (attestationId?.Length < 0) throw new Exception("Too short");
+            if (attestationId?.Length > 65535) throw new Exception("Too long");
+            var result = new List<AttestationRequestOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AttestationRequestOldRecord();
+            item.attestationId = attestationId;
+            item.requestEnvelopeNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[0];
+            item.timestamp = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[1]);
+            return item;
+       }
+
+        public virtual async Task<AttestationRequestOldRecord> GetAsync(DatabaseConnection conn,string attestationId)
+        {
+            if (attestationId == null) throw new Exception("Cannot be null");
+            if (attestationId?.Length < 0) throw new Exception("Too short");
+            if (attestationId?.Length > 65535) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableAttestationRequestOldCRUD", attestationId);
+            if (hit)
+                return (AttestationRequestOldRecord)cacheObject;
+            using (var get0Command = conn.db.CreateCommand())
+            {
+                get0Command.CommandText = "SELECT requestEnvelope,timestamp FROM AttestationRequestOld " +
+                                             "WHERE attestationId = @attestationId LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@attestationId";
+                get0Command.Parameters.Add(get0Param1);
+
+                get0Param1.Value = attestationId;
+                {
+                    using (var rdr = await conn.ExecuteReaderAsync(get0Command, System.Data.CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableAttestationRequestOldCRUD", attestationId, null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,attestationId);
+                        _cache.AddOrUpdate("TableAttestationRequestOldCRUD", attestationId, r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+        public virtual async Task<(List<AttestationRequestOldRecord>, string nextCursor)> PagingByAttestationIdAsync(DatabaseConnection conn, int count, string inCursor)
+        {
+            if (count < 1)
+                throw new Exception("Count must be at least 1.");
+            if (count == int.MaxValue)
+                count--; // avoid overflow when doing +1 on the param below
+            if (inCursor == null)
+                inCursor = "";
+
+            using (var getPaging1Command = conn.db.CreateCommand())
+            {
+                getPaging1Command.CommandText = "SELECT attestationId,requestEnvelope,timestamp FROM AttestationRequestOld " +
+                                            "WHERE attestationId > @attestationId  ORDER BY attestationId ASC  LIMIT @count;";
+                var getPaging1Param1 = getPaging1Command.CreateParameter();
+                getPaging1Param1.ParameterName = "@attestationId";
+                getPaging1Command.Parameters.Add(getPaging1Param1);
+                var getPaging1Param2 = getPaging1Command.CreateParameter();
+                getPaging1Param2.ParameterName = "@count";
+                getPaging1Command.Parameters.Add(getPaging1Param2);
+
+                getPaging1Param1.Value = inCursor;
+                getPaging1Param2.Value = count+1;
+
+                {
+                    await using (var rdr = await conn.ExecuteReaderAsync(getPaging1Command, System.Data.CommandBehavior.Default))
+                    {
+                        var result = new List<AttestationRequestOldRecord>();
+                        string nextCursor;
+                        int n = 0;
+                        while ((n < count) && await rdr.ReadAsync())
+                        {
+                            n++;
+                            result.Add(ReadRecordFromReaderAll(rdr));
+                        } // while
+                        if ((n > 0) && await rdr.ReadAsync())
+                        {
+                                nextCursor = result[n - 1].attestationId;
+                        }
+                        else
+                        {
+                            nextCursor = null;
+                        }
+                        return (result, nextCursor);
+                    } // using
+                } //
+            } // using 
+        } // PagingGet
+
+    }
+}

--- a/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationStatusCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationStatusCRUD.cs
@@ -91,16 +91,14 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
                 cmd.CommandText = "DROP TABLE IF EXISTS attestationStatus;";
                 await conn.ExecuteNonQueryAsync(cmd);
             }
-            var rowid = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS attestationStatus("
                    +"attestationId BYTEA NOT NULL UNIQUE, "
                    +"status BIGINT NOT NULL, "
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
-                   + rowid
                    +", PRIMARY KEY (attestationId)"
-                   +");"
+                   +") WITHOUT ROWID;"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);
         }

--- a/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationStatusCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationStatusCRUD.cs
@@ -313,7 +313,7 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
             }
         }
 
-        public AttestationStatusRecord ReadRecordFromReader0(DbDataReader rdr, byte[] attestationId)
+        public AttestationStatusRecord ReadRecordFromReader0(DbDataReader rdr,byte[] attestationId)
         {
             if (attestationId == null) throw new Exception("Cannot be null");
             if (attestationId?.Length < 16) throw new Exception("Too short");
@@ -331,7 +331,7 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
             return item;
        }
 
-        public virtual async Task<AttestationStatusRecord> GetAsync(DatabaseConnection conn, byte[] attestationId)
+        public virtual async Task<AttestationStatusRecord> GetAsync(DatabaseConnection conn,byte[] attestationId)
         {
             if (attestationId == null) throw new Exception("Cannot be null");
             if (attestationId?.Length < 16) throw new Exception("Too short");
@@ -342,7 +342,8 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
             using (var get0Command = conn.db.CreateCommand())
             {
                 get0Command.CommandText = "SELECT status,created,modified FROM attestationStatus " +
-                                             "WHERE attestationId = @attestationId LIMIT 1;";
+                                             "WHERE attestationId = @attestationId LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@attestationId";
                 get0Command.Parameters.Add(get0Param1);
@@ -356,7 +357,7 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
                             _cache.AddOrUpdate("TableAttestationStatusCRUD", attestationId.ToBase64(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, attestationId);
+                        var r = ReadRecordFromReader0(rdr,attestationId);
                         _cache.AddOrUpdate("TableAttestationStatusCRUD", attestationId.ToBase64(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationStatusCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationStatusCRUD.cs
@@ -91,6 +91,7 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
                 cmd.CommandText = "DROP TABLE IF EXISTS attestationStatus;";
                 await conn.ExecuteNonQueryAsync(cmd);
             }
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS attestationStatus("
                    +"attestationId BYTEA NOT NULL UNIQUE, "
@@ -98,7 +99,7 @@ namespace Odin.Core.Storage.SQLite.AttestationDatabase
                    +"created BIGINT NOT NULL, "
                    +"modified BIGINT  "
                    +", PRIMARY KEY (attestationId)"
-                   +") WITHOUT ROWID;"
+                   +$"){wori};"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);
         }

--- a/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationStatusOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/AttestationDatabase/TableAttestationStatusOldCRUD.cs
@@ -1,0 +1,383 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.SQLite.AttestationDatabase
+{
+    public class AttestationStatusOldRecord
+    {
+        private byte[] _attestationId;
+        public byte[] attestationId
+        {
+           get {
+                   return _attestationId;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _attestationId = value;
+               }
+        }
+        internal byte[] attestationIdNoLengthCheck
+        {
+           get {
+                   return _attestationId;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _attestationId = value;
+               }
+        }
+        private Int32 _status;
+        public Int32 status
+        {
+           get {
+                   return _status;
+               }
+           set {
+                  _status = value;
+               }
+        }
+        private UnixTimeUtc _created;
+        public UnixTimeUtc created
+        {
+           get {
+                   return _created;
+               }
+           set {
+                  _created = value;
+               }
+        }
+        private UnixTimeUtc? _modified;
+        public UnixTimeUtc? modified
+        {
+           get {
+                   return _modified;
+               }
+           set {
+                  _modified = value;
+               }
+        }
+    } // End of class AttestationStatusOldRecord
+
+    public class TableAttestationStatusOldCRUD
+    {
+        private readonly CacheHelper _cache;
+
+        public TableAttestationStatusOldCRUD(CacheHelper cache)
+        {
+            _cache = cache;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(DatabaseConnection conn, bool dropExisting = false)
+        {
+            await using var cmd = conn.db.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS AttestationStatusOld;";
+                await conn.ExecuteNonQueryAsync(cmd);
+            }
+            var rowid = "";
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS AttestationStatusOld("
+                   +"attestationId BYTEA NOT NULL UNIQUE, "
+                   +"status BIGINT NOT NULL, "
+                   +"created BIGINT NOT NULL, "
+                   +"modified BIGINT  "
+                   + rowid
+                   +", PRIMARY KEY (attestationId)"
+                   +");"
+                   ;
+            await conn.ExecuteNonQueryAsync(cmd);
+        }
+
+        public virtual async Task<int> InsertAsync(DatabaseConnection conn, AttestationStatusOldRecord item)
+        {
+            using (var insertCommand = conn.db.CreateCommand())
+            {
+                insertCommand.CommandText = "INSERT INTO AttestationStatusOld (attestationId,status,created,modified) " +
+                                             "VALUES (@attestationId,@status,@created,@modified)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@attestationId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@status";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.attestationId;
+                insertParam2.Value = item.status;
+                var now = UnixTimeUtc.Now();
+                insertParam3.Value = now.milliseconds;
+                item.modified = null;
+                insertParam4.Value = DBNull.Value;
+                var count = await conn.ExecuteNonQueryAsync(insertCommand);
+                if (count > 0)
+                {
+                     item.created = now;
+                    _cache.AddOrUpdate("TableAttestationStatusOldCRUD", item.attestationId.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DatabaseConnection conn, AttestationStatusOldRecord item)
+        {
+            using (var insertCommand = conn.db.CreateCommand())
+            {
+                insertCommand.CommandText = "INSERT INTO AttestationStatusOld (attestationId,status,created,modified) " +
+                                             "VALUES (@attestationId,@status,@created,@modified) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@attestationId";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@status";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@created";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@modified";
+                insertCommand.Parameters.Add(insertParam4);
+                insertParam1.Value = item.attestationId;
+                insertParam2.Value = item.status;
+                var now = UnixTimeUtc.Now();
+                insertParam3.Value = now.milliseconds;
+                item.modified = null;
+                insertParam4.Value = DBNull.Value;
+                var count = await conn.ExecuteNonQueryAsync(insertCommand);
+                if (count > 0)
+                {
+                    item.created = now;
+                   _cache.AddOrUpdate("TableAttestationStatusOldCRUD", item.attestationId.ToBase64(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DatabaseConnection conn, AttestationStatusOldRecord item)
+        {
+            using (var upsertCommand = conn.db.CreateCommand())
+            {
+                upsertCommand.CommandText = "INSERT INTO AttestationStatusOld (attestationId,status,created) " +
+                                             "VALUES (@attestationId,@status,@created)"+
+                                             "ON CONFLICT (attestationId) DO UPDATE "+
+                                             "SET status = @status,modified = @modified "+
+                                             "RETURNING created, modified;";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@attestationId";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@status";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@created";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@modified";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var now = UnixTimeUtc.Now();
+                upsertParam1.Value = item.attestationId;
+                upsertParam2.Value = item.status;
+                upsertParam3.Value = now.milliseconds;
+                upsertParam4.Value = now.milliseconds;
+                await using var rdr = await conn.ExecuteReaderAsync(upsertCommand, System.Data.CommandBehavior.SingleRow);
+                if (await rdr.ReadAsync())
+                {
+                   long created = (long) rdr[0];
+                   long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                   item.created = new UnixTimeUtc(created);
+                   if (modified != null)
+                      item.modified = new UnixTimeUtc((long)modified);
+                   else
+                      item.modified = null;
+                   _cache.AddOrUpdate("TableAttestationStatusOldCRUD", item.attestationId.ToBase64(), item);
+                   return 1;
+                }
+                return 0;
+            }
+        }
+
+        public virtual async Task<int> UpdateAsync(DatabaseConnection conn, AttestationStatusOldRecord item)
+        {
+            using (var updateCommand = conn.db.CreateCommand())
+            {
+                updateCommand.CommandText = "UPDATE AttestationStatusOld " +
+                                             "SET status = @status,modified = @modified "+
+                                             "WHERE (attestationId = @attestationId)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@attestationId";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@status";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@created";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@modified";
+                updateCommand.Parameters.Add(updateParam4);
+                var now = UnixTimeUtc.Now();
+                updateParam1.Value = item.attestationId;
+                updateParam2.Value = item.status;
+                updateParam3.Value = now.milliseconds;
+                updateParam4.Value = now.milliseconds;
+                var count = await conn.ExecuteNonQueryAsync(updateCommand);
+                if (count > 0)
+                {
+                     item.modified = now;
+                    _cache.AddOrUpdate("TableAttestationStatusOldCRUD", item.attestationId.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync(DatabaseConnection conn)
+        {
+            using (var getCountCommand = conn.db.CreateCommand())
+            {
+                getCountCommand.CommandText = "ALTER TABLE attestationStatus RENAME TO AttestationStatusOld;";
+                var count = await conn.ExecuteScalarAsync(getCountCommand);
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync(DatabaseConnection conn)
+        {
+            using (var getCountCommand = conn.db.CreateCommand())
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM AttestationStatusOld;";
+                var count = await conn.ExecuteScalarAsync(getCountCommand);
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("attestationId");
+            sl.Add("status");
+            sl.Add("created");
+            sl.Add("modified");
+            return sl;
+        }
+
+        // SELECT attestationId,status,created,modified
+        public AttestationStatusOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<AttestationStatusOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AttestationStatusOldRecord();
+            item.attestationIdNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.attestationId?.Length < 16)
+                throw new Exception("Too little data in attestationId...");
+            item.status = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
+            item.created = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.modified = (rdr[3] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[3]);
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(DatabaseConnection conn, byte[] attestationId)
+        {
+            if (attestationId == null) throw new Exception("Cannot be null");
+            if (attestationId?.Length < 16) throw new Exception("Too short");
+            if (attestationId?.Length > 64) throw new Exception("Too long");
+            using (var delete0Command = conn.db.CreateCommand())
+            {
+                delete0Command.CommandText = "DELETE FROM AttestationStatusOld " +
+                                             "WHERE attestationId = @attestationId";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@attestationId";
+                delete0Command.Parameters.Add(delete0Param1);
+
+                delete0Param1.Value = attestationId;
+                var count = await conn.ExecuteNonQueryAsync(delete0Command);
+                if (count > 0)
+                    _cache.Remove("TableAttestationStatusOldCRUD", attestationId.ToBase64());
+                return count;
+            }
+        }
+
+        public AttestationStatusOldRecord ReadRecordFromReader0(DbDataReader rdr,byte[] attestationId)
+        {
+            if (attestationId == null) throw new Exception("Cannot be null");
+            if (attestationId?.Length < 16) throw new Exception("Too short");
+            if (attestationId?.Length > 64) throw new Exception("Too long");
+            var result = new List<AttestationStatusOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new AttestationStatusOldRecord();
+            item.attestationId = attestationId;
+            item.status = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[0];
+            item.created = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[1]);
+            item.modified = (rdr[2] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[2]);
+            return item;
+       }
+
+        public virtual async Task<AttestationStatusOldRecord> GetAsync(DatabaseConnection conn,byte[] attestationId)
+        {
+            if (attestationId == null) throw new Exception("Cannot be null");
+            if (attestationId?.Length < 16) throw new Exception("Too short");
+            if (attestationId?.Length > 64) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableAttestationStatusOldCRUD", attestationId.ToBase64());
+            if (hit)
+                return (AttestationStatusOldRecord)cacheObject;
+            using (var get0Command = conn.db.CreateCommand())
+            {
+                get0Command.CommandText = "SELECT status,created,modified FROM AttestationStatusOld " +
+                                             "WHERE attestationId = @attestationId LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@attestationId";
+                get0Command.Parameters.Add(get0Param1);
+
+                get0Param1.Value = attestationId;
+                {
+                    using (var rdr = await conn.ExecuteReaderAsync(get0Command, System.Data.CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableAttestationStatusOldCRUD", attestationId.ToBase64(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,attestationId);
+                        _cache.AddOrUpdate("TableAttestationStatusOldCRUD", attestationId.ToBase64(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChain.cs
+++ b/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChain.cs
@@ -22,7 +22,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
         {
             using (var _get0Command = conn.db.CreateCommand())
             {
-                _get0Command.CommandText = "SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM keyChain ORDER BY rowid DESC LIMIT 1;";
+                _get0Command.CommandText = "SELECT rowid,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM keyChain ORDER BY rowid DESC LIMIT 1;";
 
                 using (var rdr = await conn.ExecuteReaderAsync(_get0Command, System.Data.CommandBehavior.SingleRow))
                 {
@@ -46,7 +46,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
 
             using (var get1Command = conn.db.CreateCommand())
             {
-                get1Command.CommandText = "SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM keyChain " +
+                get1Command.CommandText = "SELECT rowId,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM keyChain " +
                                                 "WHERE identity = @identity ORDER BY rowid ASC LIMIT 1;";
                 var get1Param1 = get1Command.CreateParameter();
                 get1Command.Parameters.Add(get1Param1);
@@ -73,7 +73,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
 
             using (var get2Command = conn.db.CreateCommand())
             {
-                get2Command.CommandText = "SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM keyChain " +
+                get2Command.CommandText = "SELECT rowid,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM keyChain " +
                                              "WHERE identity = @identity ORDER BY rowid;";
                 var get2Param1 = get2Command.CreateParameter();
                 get2Command.Parameters.Add(get2Param1);

--- a/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
 {
     public class KeyChainRecord
     {
-        private long _rowId;
-        public long rowId
+        private Int64 _rowId;
+        public Int64 rowId
         {
            get {
                    return _rowId;

--- a/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainCRUD.cs
@@ -203,6 +203,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
             }
             var rowid = "";
             rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyChain("
                    +rowid
@@ -214,7 +215,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
                    +"publicKeyJwkBase64Url TEXT NOT NULL UNIQUE, "
                    +"recordHash BYTEA NOT NULL UNIQUE "
                    +", UNIQUE(identity,publicKeyJwkBase64Url)"
-                   +") ;"
+                   +$"){wori};"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);
         }

--- a/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainCRUD.cs
@@ -17,6 +17,16 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
 {
     public class KeyChainRecord
     {
+        private long _rowId;
+        public long rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private byte[] _previousHash;
         public byte[] previousHash
         {
@@ -192,8 +202,10 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
                 await conn.ExecuteNonQueryAsync(cmd);
             }
             var rowid = "";
+            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS keyChain("
+                   +rowid
                    +"previousHash BYTEA NOT NULL UNIQUE, "
                    +"identity TEXT NOT NULL, "
                    +"timestamp BIGINT NOT NULL, "
@@ -201,9 +213,8 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
                    +"algorithm TEXT NOT NULL, "
                    +"publicKeyJwkBase64Url TEXT NOT NULL UNIQUE, "
                    +"recordHash BYTEA NOT NULL UNIQUE "
-                   + rowid
-                   +", PRIMARY KEY (identity,publicKeyJwkBase64Url)"
-                   +");"
+                   +", UNIQUE(identity,publicKeyJwkBase64Url)"
+                   +") ;"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);
         }
@@ -399,6 +410,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("previousHash");
             sl.Add("identity");
             sl.Add("timestamp");
@@ -409,7 +421,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
             return sl;
         }
 
-        // SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash
+        // SELECT rowId,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash
         public KeyChainRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<KeyChainRecord>();
@@ -418,17 +430,18 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new KeyChainRecord();
-            item.previousHashNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.previousHashNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
             if (item.previousHash?.Length < 16)
                 throw new Exception("Too little data in previousHash...");
-            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
-            item.timestamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
-            item.signedPreviousHashNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
+            item.identityNoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[2];
+            item.timestamp = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.signedPreviousHashNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[4]);
             if (item.signedPreviousHash?.Length < 16)
                 throw new Exception("Too little data in signedPreviousHash...");
-            item.algorithmNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
-            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
-            item.recordHashNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[6]);
+            item.algorithmNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
+            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[6];
+            item.recordHashNoLengthCheck = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[7]);
             if (item.recordHash?.Length < 16)
                 throw new Exception("Too little data in recordHash...");
             return item;
@@ -478,15 +491,16 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
             var item = new KeyChainRecord();
             item.identity = identity;
             item.publicKeyJwkBase64Url = publicKeyJwkBase64Url;
-            item.previousHashNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.previousHashNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
             if (item.previousHash?.Length < 16)
                 throw new Exception("Too little data in previousHash...");
-            item.timestamp = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[1]);
-            item.signedPreviousHashNoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[2]);
+            item.timestamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.signedPreviousHashNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
             if (item.signedPreviousHash?.Length < 16)
                 throw new Exception("Too little data in signedPreviousHash...");
-            item.algorithmNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[3];
-            item.recordHashNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[4]);
+            item.algorithmNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
+            item.recordHashNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[5]);
             if (item.recordHash?.Length < 16)
                 throw new Exception("Too little data in recordHash...");
             return item;
@@ -505,7 +519,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
                 return (KeyChainRecord)cacheObject;
             using (var get0Command = conn.db.CreateCommand())
             {
-                get0Command.CommandText = "SELECT previousHash,timestamp,signedPreviousHash,algorithm,recordHash FROM keyChain " +
+                get0Command.CommandText = "SELECT rowId,previousHash,timestamp,signedPreviousHash,algorithm,recordHash FROM keyChain " +
                                              "WHERE identity = @identity AND publicKeyJwkBase64Url = @publicKeyJwkBase64Url LIMIT 1;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identity";

--- a/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainCRUD.cs
@@ -476,7 +476,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
             }
         }
 
-        public KeyChainRecord ReadRecordFromReader0(DbDataReader rdr, string identity,string publicKeyJwkBase64Url)
+        public KeyChainRecord ReadRecordFromReader0(DbDataReader rdr,string identity,string publicKeyJwkBase64Url)
         {
             if (identity == null) throw new Exception("Cannot be null");
             if (identity?.Length < 3) throw new Exception("Too short");
@@ -507,7 +507,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
             return item;
        }
 
-        public virtual async Task<KeyChainRecord> GetAsync(DatabaseConnection conn, string identity,string publicKeyJwkBase64Url)
+        public virtual async Task<KeyChainRecord> GetAsync(DatabaseConnection conn,string identity,string publicKeyJwkBase64Url)
         {
             if (identity == null) throw new Exception("Cannot be null");
             if (identity?.Length < 3) throw new Exception("Too short");
@@ -521,7 +521,8 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
             using (var get0Command = conn.db.CreateCommand())
             {
                 get0Command.CommandText = "SELECT rowId,previousHash,timestamp,signedPreviousHash,algorithm,recordHash FROM keyChain " +
-                                             "WHERE identity = @identity AND publicKeyJwkBase64Url = @publicKeyJwkBase64Url LIMIT 1;";
+                                             "WHERE identity = @identity AND publicKeyJwkBase64Url = @publicKeyJwkBase64Url LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@identity";
                 get0Command.Parameters.Add(get0Param1);
@@ -539,7 +540,7 @@ namespace Odin.Core.Storage.SQLite.KeyChainDatabase
                             _cache.AddOrUpdate("TableKeyChainCRUD", identity+publicKeyJwkBase64Url, null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, identity,publicKeyJwkBase64Url);
+                        var r = ReadRecordFromReader0(rdr,identity,publicKeyJwkBase64Url);
                         _cache.AddOrUpdate("TableKeyChainCRUD", identity+publicKeyJwkBase64Url, r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/KeyChainDatabase/TableKeyChainOldCRUD.cs
@@ -1,0 +1,550 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.SQLite.KeyChainDatabase
+{
+    public class KeyChainOldRecord
+    {
+        private byte[] _previousHash;
+        public byte[] previousHash
+        {
+           get {
+                   return _previousHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _previousHash = value;
+               }
+        }
+        internal byte[] previousHashNoLengthCheck
+        {
+           get {
+                   return _previousHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _previousHash = value;
+               }
+        }
+        private string _identity;
+        public string identity
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 3) throw new Exception("Too short");
+                    if (value?.Length > 256) throw new Exception("Too long");
+                  _identity = value;
+               }
+        }
+        internal string identityNoLengthCheck
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 3) throw new Exception("Too short");
+                  _identity = value;
+               }
+        }
+        private UnixTimeUtc _timestamp;
+        public UnixTimeUtc timestamp
+        {
+           get {
+                   return _timestamp;
+               }
+           set {
+                  _timestamp = value;
+               }
+        }
+        private byte[] _signedPreviousHash;
+        public byte[] signedPreviousHash
+        {
+           get {
+                   return _signedPreviousHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 200) throw new Exception("Too long");
+                  _signedPreviousHash = value;
+               }
+        }
+        internal byte[] signedPreviousHashNoLengthCheck
+        {
+           get {
+                   return _signedPreviousHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _signedPreviousHash = value;
+               }
+        }
+        private string _algorithm;
+        public string algorithm
+        {
+           get {
+                   return _algorithm;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 1) throw new Exception("Too short");
+                    if (value?.Length > 40) throw new Exception("Too long");
+                  _algorithm = value;
+               }
+        }
+        internal string algorithmNoLengthCheck
+        {
+           get {
+                   return _algorithm;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 1) throw new Exception("Too short");
+                  _algorithm = value;
+               }
+        }
+        private string _publicKeyJwkBase64Url;
+        public string publicKeyJwkBase64Url
+        {
+           get {
+                   return _publicKeyJwkBase64Url;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 600) throw new Exception("Too long");
+                  _publicKeyJwkBase64Url = value;
+               }
+        }
+        internal string publicKeyJwkBase64UrlNoLengthCheck
+        {
+           get {
+                   return _publicKeyJwkBase64Url;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _publicKeyJwkBase64Url = value;
+               }
+        }
+        private byte[] _recordHash;
+        public byte[] recordHash
+        {
+           get {
+                   return _recordHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _recordHash = value;
+               }
+        }
+        internal byte[] recordHashNoLengthCheck
+        {
+           get {
+                   return _recordHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _recordHash = value;
+               }
+        }
+    } // End of class KeyChainOldRecord
+
+    public class TableKeyChainOldCRUD
+    {
+        private readonly CacheHelper _cache;
+
+        public TableKeyChainOldCRUD(CacheHelper cache)
+        {
+            _cache = cache;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(DatabaseConnection conn, bool dropExisting = false)
+        {
+            await using var cmd = conn.db.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS KeyChainOld;";
+                await conn.ExecuteNonQueryAsync(cmd);
+            }
+            var rowid = "";
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS KeyChainOld("
+                   +"previousHash BYTEA NOT NULL UNIQUE, "
+                   +"identity TEXT NOT NULL, "
+                   +"timestamp BIGINT NOT NULL, "
+                   +"signedPreviousHash BYTEA NOT NULL UNIQUE, "
+                   +"algorithm TEXT NOT NULL, "
+                   +"publicKeyJwkBase64Url TEXT NOT NULL UNIQUE, "
+                   +"recordHash BYTEA NOT NULL UNIQUE "
+                   + rowid
+                   +", PRIMARY KEY (identity,publicKeyJwkBase64Url)"
+                   +");"
+                   ;
+            await conn.ExecuteNonQueryAsync(cmd);
+        }
+
+        public virtual async Task<int> InsertAsync(DatabaseConnection conn, KeyChainOldRecord item)
+        {
+            using (var insertCommand = conn.db.CreateCommand())
+            {
+                insertCommand.CommandText = "INSERT INTO KeyChainOld (previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash) " +
+                                             "VALUES (@previousHash,@identity,@timestamp,@signedPreviousHash,@algorithm,@publicKeyJwkBase64Url,@recordHash)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@previousHash";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@timestamp";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@signedPreviousHash";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@algorithm";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@publicKeyJwkBase64Url";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@recordHash";
+                insertCommand.Parameters.Add(insertParam7);
+                insertParam1.Value = item.previousHash;
+                insertParam2.Value = item.identity;
+                insertParam3.Value = item.timestamp.milliseconds;
+                insertParam4.Value = item.signedPreviousHash;
+                insertParam5.Value = item.algorithm;
+                insertParam6.Value = item.publicKeyJwkBase64Url;
+                insertParam7.Value = item.recordHash;
+                var count = await conn.ExecuteNonQueryAsync(insertCommand);
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyChainOldCRUD", item.identity+item.publicKeyJwkBase64Url, item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DatabaseConnection conn, KeyChainOldRecord item)
+        {
+            using (var insertCommand = conn.db.CreateCommand())
+            {
+                insertCommand.CommandText = "INSERT INTO KeyChainOld (previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash) " +
+                                             "VALUES (@previousHash,@identity,@timestamp,@signedPreviousHash,@algorithm,@publicKeyJwkBase64Url,@recordHash) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@previousHash";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@timestamp";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@signedPreviousHash";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@algorithm";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@publicKeyJwkBase64Url";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@recordHash";
+                insertCommand.Parameters.Add(insertParam7);
+                insertParam1.Value = item.previousHash;
+                insertParam2.Value = item.identity;
+                insertParam3.Value = item.timestamp.milliseconds;
+                insertParam4.Value = item.signedPreviousHash;
+                insertParam5.Value = item.algorithm;
+                insertParam6.Value = item.publicKeyJwkBase64Url;
+                insertParam7.Value = item.recordHash;
+                var count = await conn.ExecuteNonQueryAsync(insertCommand);
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableKeyChainOldCRUD", item.identity+item.publicKeyJwkBase64Url, item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DatabaseConnection conn, KeyChainOldRecord item)
+        {
+            using (var upsertCommand = conn.db.CreateCommand())
+            {
+                upsertCommand.CommandText = "INSERT INTO KeyChainOld (previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash) " +
+                                             "VALUES (@previousHash,@identity,@timestamp,@signedPreviousHash,@algorithm,@publicKeyJwkBase64Url,@recordHash)"+
+                                             "ON CONFLICT (identity,publicKeyJwkBase64Url) DO UPDATE "+
+                                             "SET previousHash = @previousHash,timestamp = @timestamp,signedPreviousHash = @signedPreviousHash,algorithm = @algorithm,recordHash = @recordHash "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@previousHash";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@identity";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@timestamp";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@signedPreviousHash";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@algorithm";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@publicKeyJwkBase64Url";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@recordHash";
+                upsertCommand.Parameters.Add(upsertParam7);
+                upsertParam1.Value = item.previousHash;
+                upsertParam2.Value = item.identity;
+                upsertParam3.Value = item.timestamp.milliseconds;
+                upsertParam4.Value = item.signedPreviousHash;
+                upsertParam5.Value = item.algorithm;
+                upsertParam6.Value = item.publicKeyJwkBase64Url;
+                upsertParam7.Value = item.recordHash;
+                var count = await conn.ExecuteNonQueryAsync(upsertCommand);
+                if (count > 0)
+                    _cache.AddOrUpdate("TableKeyChainOldCRUD", item.identity+item.publicKeyJwkBase64Url, item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(DatabaseConnection conn, KeyChainOldRecord item)
+        {
+            using (var updateCommand = conn.db.CreateCommand())
+            {
+                updateCommand.CommandText = "UPDATE KeyChainOld " +
+                                             "SET previousHash = @previousHash,timestamp = @timestamp,signedPreviousHash = @signedPreviousHash,algorithm = @algorithm,recordHash = @recordHash "+
+                                             "WHERE (identity = @identity AND publicKeyJwkBase64Url = @publicKeyJwkBase64Url)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@previousHash";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@identity";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@timestamp";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@signedPreviousHash";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@algorithm";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@publicKeyJwkBase64Url";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@recordHash";
+                updateCommand.Parameters.Add(updateParam7);
+                updateParam1.Value = item.previousHash;
+                updateParam2.Value = item.identity;
+                updateParam3.Value = item.timestamp.milliseconds;
+                updateParam4.Value = item.signedPreviousHash;
+                updateParam5.Value = item.algorithm;
+                updateParam6.Value = item.publicKeyJwkBase64Url;
+                updateParam7.Value = item.recordHash;
+                var count = await conn.ExecuteNonQueryAsync(updateCommand);
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableKeyChainOldCRUD", item.identity+item.publicKeyJwkBase64Url, item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync(DatabaseConnection conn)
+        {
+            using (var getCountCommand = conn.db.CreateCommand())
+            {
+                getCountCommand.CommandText = "ALTER TABLE keyChain RENAME TO KeyChainOld;";
+                var count = await conn.ExecuteScalarAsync(getCountCommand);
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync(DatabaseConnection conn)
+        {
+            using (var getCountCommand = conn.db.CreateCommand())
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM KeyChainOld;";
+                var count = await conn.ExecuteScalarAsync(getCountCommand);
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("previousHash");
+            sl.Add("identity");
+            sl.Add("timestamp");
+            sl.Add("signedPreviousHash");
+            sl.Add("algorithm");
+            sl.Add("publicKeyJwkBase64Url");
+            sl.Add("recordHash");
+            return sl;
+        }
+
+        // SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash
+        public KeyChainOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<KeyChainOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyChainOldRecord();
+            item.previousHashNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.previousHash?.Length < 16)
+                throw new Exception("Too little data in previousHash...");
+            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.timestamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.signedPreviousHashNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
+            if (item.signedPreviousHash?.Length < 16)
+                throw new Exception("Too little data in signedPreviousHash...");
+            item.algorithmNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
+            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
+            item.recordHashNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[6]);
+            if (item.recordHash?.Length < 16)
+                throw new Exception("Too little data in recordHash...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(DatabaseConnection conn, string identity,string publicKeyJwkBase64Url)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 256) throw new Exception("Too long");
+            if (publicKeyJwkBase64Url == null) throw new Exception("Cannot be null");
+            if (publicKeyJwkBase64Url?.Length < 16) throw new Exception("Too short");
+            if (publicKeyJwkBase64Url?.Length > 600) throw new Exception("Too long");
+            using (var delete0Command = conn.db.CreateCommand())
+            {
+                delete0Command.CommandText = "DELETE FROM KeyChainOld " +
+                                             "WHERE identity = @identity AND publicKeyJwkBase64Url = @publicKeyJwkBase64Url";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@identity";
+                delete0Command.Parameters.Add(delete0Param1);
+                var delete0Param2 = delete0Command.CreateParameter();
+                delete0Param2.ParameterName = "@publicKeyJwkBase64Url";
+                delete0Command.Parameters.Add(delete0Param2);
+
+                delete0Param1.Value = identity;
+                delete0Param2.Value = publicKeyJwkBase64Url;
+                var count = await conn.ExecuteNonQueryAsync(delete0Command);
+                if (count > 0)
+                    _cache.Remove("TableKeyChainOldCRUD", identity+publicKeyJwkBase64Url);
+                return count;
+            }
+        }
+
+        public KeyChainOldRecord ReadRecordFromReader0(DbDataReader rdr,string identity,string publicKeyJwkBase64Url)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 256) throw new Exception("Too long");
+            if (publicKeyJwkBase64Url == null) throw new Exception("Cannot be null");
+            if (publicKeyJwkBase64Url?.Length < 16) throw new Exception("Too short");
+            if (publicKeyJwkBase64Url?.Length > 600) throw new Exception("Too long");
+            var result = new List<KeyChainOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new KeyChainOldRecord();
+            item.identity = identity;
+            item.publicKeyJwkBase64Url = publicKeyJwkBase64Url;
+            item.previousHashNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.previousHash?.Length < 16)
+                throw new Exception("Too little data in previousHash...");
+            item.timestamp = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[1]);
+            item.signedPreviousHashNoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[2]);
+            if (item.signedPreviousHash?.Length < 16)
+                throw new Exception("Too little data in signedPreviousHash...");
+            item.algorithmNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[3];
+            item.recordHashNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[4]);
+            if (item.recordHash?.Length < 16)
+                throw new Exception("Too little data in recordHash...");
+            return item;
+       }
+
+        public virtual async Task<KeyChainOldRecord> GetAsync(DatabaseConnection conn,string identity,string publicKeyJwkBase64Url)
+        {
+            if (identity == null) throw new Exception("Cannot be null");
+            if (identity?.Length < 3) throw new Exception("Too short");
+            if (identity?.Length > 256) throw new Exception("Too long");
+            if (publicKeyJwkBase64Url == null) throw new Exception("Cannot be null");
+            if (publicKeyJwkBase64Url?.Length < 16) throw new Exception("Too short");
+            if (publicKeyJwkBase64Url?.Length > 600) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableKeyChainOldCRUD", identity+publicKeyJwkBase64Url);
+            if (hit)
+                return (KeyChainOldRecord)cacheObject;
+            using (var get0Command = conn.db.CreateCommand())
+            {
+                get0Command.CommandText = "SELECT previousHash,timestamp,signedPreviousHash,algorithm,recordHash FROM KeyChainOld " +
+                                             "WHERE identity = @identity AND publicKeyJwkBase64Url = @publicKeyJwkBase64Url LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@identity";
+                get0Command.Parameters.Add(get0Param1);
+                var get0Param2 = get0Command.CreateParameter();
+                get0Param2.ParameterName = "@publicKeyJwkBase64Url";
+                get0Command.Parameters.Add(get0Param2);
+
+                get0Param1.Value = identity;
+                get0Param2.Value = publicKeyJwkBase64Url;
+                {
+                    using (var rdr = await conn.ExecuteReaderAsync(get0Command, System.Data.CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableKeyChainOldCRUD", identity+publicKeyJwkBase64Url, null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,identity,publicKeyJwkBase64Url);
+                        _cache.AddOrUpdate("TableKeyChainOldCRUD", identity+publicKeyJwkBase64Url, r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChain.cs
+++ b/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChain.cs
@@ -23,7 +23,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
         {
             using (var get0Command = conn.db.CreateCommand())
             {
-                get0Command.CommandText = "SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash FROM notaryChain ORDER BY rowid DESC LIMIT 1;";
+                get0Command.CommandText = "SELECT rowid,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash FROM notaryChain ORDER BY rowid DESC LIMIT 1;";
 
                 using (var rdr = await conn.ExecuteReaderAsync(get0Command, System.Data.CommandBehavior.SingleRow))
                 {
@@ -45,7 +45,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
 
             using (var get2Command = conn.db.CreateCommand())
             {
-                get2Command.CommandText = "SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash FROM notaryChain " +
+                get2Command.CommandText = "SELECT rowid,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash FROM notaryChain " +
                                              "WHERE identity = @identity ORDER BY rowid;";
                 var get2Param1 = get2Command.CreateParameter();
                 get2Command.Parameters.Add(get2Param1);

--- a/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
@@ -514,7 +514,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
             }
         }
 
-        public NotaryChainRecord ReadRecordFromReader0(DbDataReader rdr, byte[] notarySignature)
+        public NotaryChainRecord ReadRecordFromReader0(DbDataReader rdr,byte[] notarySignature)
         {
             if (notarySignature == null) throw new Exception("Cannot be null");
             if (notarySignature?.Length < 16) throw new Exception("Too short");
@@ -543,7 +543,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
             return item;
        }
 
-        public virtual async Task<NotaryChainRecord> GetAsync(DatabaseConnection conn, byte[] notarySignature)
+        public virtual async Task<NotaryChainRecord> GetAsync(DatabaseConnection conn,byte[] notarySignature)
         {
             if (notarySignature == null) throw new Exception("Cannot be null");
             if (notarySignature?.Length < 16) throw new Exception("Too short");
@@ -554,7 +554,8 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
             using (var get0Command = conn.db.CreateCommand())
             {
                 get0Command.CommandText = "SELECT rowId,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM notaryChain " +
-                                             "WHERE notarySignature = @notarySignature LIMIT 1;";
+                                             "WHERE notarySignature = @notarySignature LIMIT 1;"+
+                                             ";";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@notarySignature";
                 get0Command.Parameters.Add(get0Param1);
@@ -568,7 +569,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
                             _cache.AddOrUpdate("TableNotaryChainCRUD", notarySignature.ToBase64(), null);
                             return null;
                         }
-                        var r = ReadRecordFromReader0(rdr, notarySignature);
+                        var r = ReadRecordFromReader0(rdr,notarySignature);
                         _cache.AddOrUpdate("TableNotaryChainCRUD", notarySignature.ToBase64(), r);
                         return r;
                     } // using

--- a/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
@@ -17,6 +17,16 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
 {
     public class NotaryChainRecord
     {
+        private long _rowId;
+        public long rowId
+        {
+           get {
+                   return _rowId;
+               }
+           set {
+                  _rowId = value;
+               }
+        }
         private byte[] _previousHash;
         public byte[] previousHash
         {
@@ -216,8 +226,10 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
                 await conn.ExecuteNonQueryAsync(cmd);
             }
             var rowid = "";
+            rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS notaryChain("
+                   +rowid
                    +"previousHash BYTEA NOT NULL UNIQUE, "
                    +"identity TEXT NOT NULL, "
                    +"timestamp BIGINT NOT NULL, "
@@ -226,9 +238,8 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
                    +"publicKeyJwkBase64Url TEXT NOT NULL, "
                    +"notarySignature BYTEA NOT NULL UNIQUE, "
                    +"recordHash BYTEA NOT NULL UNIQUE "
-                   + rowid
-                   +", PRIMARY KEY (notarySignature)"
-                   +");"
+                   +", UNIQUE(notarySignature)"
+                   +") ;"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);
         }
@@ -440,6 +451,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
         public static List<string> GetColumnNames()
         {
             var sl = new List<string>();
+            sl.Add("rowId");
             sl.Add("previousHash");
             sl.Add("identity");
             sl.Add("timestamp");
@@ -451,7 +463,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
             return sl;
         }
 
-        // SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash
+        // SELECT rowId,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash
         public NotaryChainRecord ReadRecordFromReaderAll(DbDataReader rdr)
         {
             var result = new List<NotaryChainRecord>();
@@ -460,20 +472,21 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
 #pragma warning restore CS0168
             var guid = new byte[16];
             var item = new NotaryChainRecord();
-            item.previousHashNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.previousHashNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
             if (item.previousHash?.Length < 16)
                 throw new Exception("Too little data in previousHash...");
-            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
-            item.timestamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
-            item.signedPreviousHashNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
+            item.identityNoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[2];
+            item.timestamp = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.signedPreviousHashNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[4]);
             if (item.signedPreviousHash?.Length < 16)
                 throw new Exception("Too little data in signedPreviousHash...");
-            item.algorithmNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
-            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
-            item.notarySignatureNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[6]);
+            item.algorithmNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
+            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[6];
+            item.notarySignatureNoLengthCheck = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[7]);
             if (item.notarySignature?.Length < 16)
                 throw new Exception("Too little data in notarySignature...");
-            item.recordHashNoLengthCheck = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[7]);
+            item.recordHashNoLengthCheck = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[8]);
             if (item.recordHash?.Length < 16)
                 throw new Exception("Too little data in recordHash...");
             return item;
@@ -512,17 +525,18 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
             var guid = new byte[16];
             var item = new NotaryChainRecord();
             item.notarySignature = notarySignature;
-            item.previousHashNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            item.rowId = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (long)rdr[0];
+            item.previousHashNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[1]);
             if (item.previousHash?.Length < 16)
                 throw new Exception("Too little data in previousHash...");
-            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
-            item.timestamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
-            item.signedPreviousHashNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
+            item.identityNoLengthCheck = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[2];
+            item.timestamp = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[3]);
+            item.signedPreviousHashNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[4]);
             if (item.signedPreviousHash?.Length < 16)
                 throw new Exception("Too little data in signedPreviousHash...");
-            item.algorithmNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
-            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
-            item.recordHashNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[6]);
+            item.algorithmNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
+            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[6];
+            item.recordHashNoLengthCheck = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[7]);
             if (item.recordHash?.Length < 16)
                 throw new Exception("Too little data in recordHash...");
             return item;
@@ -538,7 +552,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
                 return (NotaryChainRecord)cacheObject;
             using (var get0Command = conn.db.CreateCommand())
             {
-                get0Command.CommandText = "SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM notaryChain " +
+                get0Command.CommandText = "SELECT rowId,previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM notaryChain " +
                                              "WHERE notarySignature = @notarySignature LIMIT 1;";
                 var get0Param1 = get0Command.CreateParameter();
                 get0Param1.ParameterName = "@notarySignature";

--- a/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
@@ -239,7 +239,6 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
                    +"publicKeyJwkBase64Url TEXT NOT NULL, "
                    +"notarySignature BYTEA NOT NULL UNIQUE, "
                    +"recordHash BYTEA NOT NULL UNIQUE "
-                   +", UNIQUE(notarySignature)"
                    +$"){wori};"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);

--- a/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
@@ -17,8 +17,8 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
 {
     public class NotaryChainRecord
     {
-        private long _rowId;
-        public long rowId
+        private Int64 _rowId;
+        public Int64 rowId
         {
            get {
                    return _rowId;

--- a/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainCRUD.cs
@@ -227,6 +227,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
             }
             var rowid = "";
             rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
             cmd.CommandText =
                 "CREATE TABLE IF NOT EXISTS notaryChain("
                    +rowid
@@ -239,7 +240,7 @@ namespace Odin.Core.Storage.SQLite.NotaryDatabase
                    +"notarySignature BYTEA NOT NULL UNIQUE, "
                    +"recordHash BYTEA NOT NULL UNIQUE "
                    +", UNIQUE(notarySignature)"
-                   +") ;"
+                   +$"){wori};"
                    ;
             await conn.ExecuteNonQueryAsync(cmd);
         }

--- a/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainOldCRUD.cs
+++ b/src/core/Odin.Core.Storage/SQLite/NotaryDatabase/TableNotaryChainOldCRUD.cs
@@ -1,0 +1,579 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Database.System.Connection;
+using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Util;
+
+// THIS FILE IS AUTO GENERATED - DO NOT EDIT
+
+namespace Odin.Core.Storage.SQLite.NotaryDatabase
+{
+    public class NotaryChainOldRecord
+    {
+        private byte[] _previousHash;
+        public byte[] previousHash
+        {
+           get {
+                   return _previousHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _previousHash = value;
+               }
+        }
+        internal byte[] previousHashNoLengthCheck
+        {
+           get {
+                   return _previousHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _previousHash = value;
+               }
+        }
+        private string _identity;
+        public string identity
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 3) throw new Exception("Too short");
+                    if (value?.Length > 256) throw new Exception("Too long");
+                  _identity = value;
+               }
+        }
+        internal string identityNoLengthCheck
+        {
+           get {
+                   return _identity;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 3) throw new Exception("Too short");
+                  _identity = value;
+               }
+        }
+        private UnixTimeUtc _timestamp;
+        public UnixTimeUtc timestamp
+        {
+           get {
+                   return _timestamp;
+               }
+           set {
+                  _timestamp = value;
+               }
+        }
+        private byte[] _signedPreviousHash;
+        public byte[] signedPreviousHash
+        {
+           get {
+                   return _signedPreviousHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 200) throw new Exception("Too long");
+                  _signedPreviousHash = value;
+               }
+        }
+        internal byte[] signedPreviousHashNoLengthCheck
+        {
+           get {
+                   return _signedPreviousHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _signedPreviousHash = value;
+               }
+        }
+        private string _algorithm;
+        public string algorithm
+        {
+           get {
+                   return _algorithm;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 1) throw new Exception("Too short");
+                    if (value?.Length > 40) throw new Exception("Too long");
+                  _algorithm = value;
+               }
+        }
+        internal string algorithmNoLengthCheck
+        {
+           get {
+                   return _algorithm;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 1) throw new Exception("Too short");
+                  _algorithm = value;
+               }
+        }
+        private string _publicKeyJwkBase64Url;
+        public string publicKeyJwkBase64Url
+        {
+           get {
+                   return _publicKeyJwkBase64Url;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 600) throw new Exception("Too long");
+                  _publicKeyJwkBase64Url = value;
+               }
+        }
+        internal string publicKeyJwkBase64UrlNoLengthCheck
+        {
+           get {
+                   return _publicKeyJwkBase64Url;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _publicKeyJwkBase64Url = value;
+               }
+        }
+        private byte[] _notarySignature;
+        public byte[] notarySignature
+        {
+           get {
+                   return _notarySignature;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 200) throw new Exception("Too long");
+                  _notarySignature = value;
+               }
+        }
+        internal byte[] notarySignatureNoLengthCheck
+        {
+           get {
+                   return _notarySignature;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _notarySignature = value;
+               }
+        }
+        private byte[] _recordHash;
+        public byte[] recordHash
+        {
+           get {
+                   return _recordHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                    if (value?.Length > 64) throw new Exception("Too long");
+                  _recordHash = value;
+               }
+        }
+        internal byte[] recordHashNoLengthCheck
+        {
+           get {
+                   return _recordHash;
+               }
+           set {
+                    if (value == null) throw new Exception("Cannot be null");
+                    if (value?.Length < 16) throw new Exception("Too short");
+                  _recordHash = value;
+               }
+        }
+    } // End of class NotaryChainOldRecord
+
+    public class TableNotaryChainOldCRUD
+    {
+        private readonly CacheHelper _cache;
+
+        public TableNotaryChainOldCRUD(CacheHelper cache)
+        {
+            _cache = cache;
+        }
+
+
+        public virtual async Task EnsureTableExistsAsync(DatabaseConnection conn, bool dropExisting = false)
+        {
+            await using var cmd = conn.db.CreateCommand();
+            if (dropExisting)
+            {
+                cmd.CommandText = "DROP TABLE IF EXISTS NotaryChainOld;";
+                await conn.ExecuteNonQueryAsync(cmd);
+            }
+            var rowid = "";
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS NotaryChainOld("
+                   +"previousHash BYTEA NOT NULL UNIQUE, "
+                   +"identity TEXT NOT NULL, "
+                   +"timestamp BIGINT NOT NULL, "
+                   +"signedPreviousHash BYTEA NOT NULL UNIQUE, "
+                   +"algorithm TEXT NOT NULL, "
+                   +"publicKeyJwkBase64Url TEXT NOT NULL, "
+                   +"notarySignature BYTEA NOT NULL UNIQUE, "
+                   +"recordHash BYTEA NOT NULL UNIQUE "
+                   + rowid
+                   +", PRIMARY KEY (notarySignature)"
+                   +");"
+                   ;
+            await conn.ExecuteNonQueryAsync(cmd);
+        }
+
+        public virtual async Task<int> InsertAsync(DatabaseConnection conn, NotaryChainOldRecord item)
+        {
+            using (var insertCommand = conn.db.CreateCommand())
+            {
+                insertCommand.CommandText = "INSERT INTO NotaryChainOld (previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash) " +
+                                             "VALUES (@previousHash,@identity,@timestamp,@signedPreviousHash,@algorithm,@publicKeyJwkBase64Url,@notarySignature,@recordHash)";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@previousHash";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@timestamp";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@signedPreviousHash";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@algorithm";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@publicKeyJwkBase64Url";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@notarySignature";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@recordHash";
+                insertCommand.Parameters.Add(insertParam8);
+                insertParam1.Value = item.previousHash;
+                insertParam2.Value = item.identity;
+                insertParam3.Value = item.timestamp.milliseconds;
+                insertParam4.Value = item.signedPreviousHash;
+                insertParam5.Value = item.algorithm;
+                insertParam6.Value = item.publicKeyJwkBase64Url;
+                insertParam7.Value = item.notarySignature;
+                insertParam8.Value = item.recordHash;
+                var count = await conn.ExecuteNonQueryAsync(insertCommand);
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableNotaryChainOldCRUD", item.notarySignature.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<bool> TryInsertAsync(DatabaseConnection conn, NotaryChainOldRecord item)
+        {
+            using (var insertCommand = conn.db.CreateCommand())
+            {
+                insertCommand.CommandText = "INSERT INTO NotaryChainOld (previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash) " +
+                                             "VALUES (@previousHash,@identity,@timestamp,@signedPreviousHash,@algorithm,@publicKeyJwkBase64Url,@notarySignature,@recordHash) " +
+                                             "ON CONFLICT DO NOTHING";
+                var insertParam1 = insertCommand.CreateParameter();
+                insertParam1.ParameterName = "@previousHash";
+                insertCommand.Parameters.Add(insertParam1);
+                var insertParam2 = insertCommand.CreateParameter();
+                insertParam2.ParameterName = "@identity";
+                insertCommand.Parameters.Add(insertParam2);
+                var insertParam3 = insertCommand.CreateParameter();
+                insertParam3.ParameterName = "@timestamp";
+                insertCommand.Parameters.Add(insertParam3);
+                var insertParam4 = insertCommand.CreateParameter();
+                insertParam4.ParameterName = "@signedPreviousHash";
+                insertCommand.Parameters.Add(insertParam4);
+                var insertParam5 = insertCommand.CreateParameter();
+                insertParam5.ParameterName = "@algorithm";
+                insertCommand.Parameters.Add(insertParam5);
+                var insertParam6 = insertCommand.CreateParameter();
+                insertParam6.ParameterName = "@publicKeyJwkBase64Url";
+                insertCommand.Parameters.Add(insertParam6);
+                var insertParam7 = insertCommand.CreateParameter();
+                insertParam7.ParameterName = "@notarySignature";
+                insertCommand.Parameters.Add(insertParam7);
+                var insertParam8 = insertCommand.CreateParameter();
+                insertParam8.ParameterName = "@recordHash";
+                insertCommand.Parameters.Add(insertParam8);
+                insertParam1.Value = item.previousHash;
+                insertParam2.Value = item.identity;
+                insertParam3.Value = item.timestamp.milliseconds;
+                insertParam4.Value = item.signedPreviousHash;
+                insertParam5.Value = item.algorithm;
+                insertParam6.Value = item.publicKeyJwkBase64Url;
+                insertParam7.Value = item.notarySignature;
+                insertParam8.Value = item.recordHash;
+                var count = await conn.ExecuteNonQueryAsync(insertCommand);
+                if (count > 0)
+                {
+                   _cache.AddOrUpdate("TableNotaryChainOldCRUD", item.notarySignature.ToBase64(), item);
+                }
+                return count > 0;
+            }
+        }
+
+        public virtual async Task<int> UpsertAsync(DatabaseConnection conn, NotaryChainOldRecord item)
+        {
+            using (var upsertCommand = conn.db.CreateCommand())
+            {
+                upsertCommand.CommandText = "INSERT INTO NotaryChainOld (previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash) " +
+                                             "VALUES (@previousHash,@identity,@timestamp,@signedPreviousHash,@algorithm,@publicKeyJwkBase64Url,@notarySignature,@recordHash)"+
+                                             "ON CONFLICT (notarySignature) DO UPDATE "+
+                                             "SET previousHash = @previousHash,identity = @identity,timestamp = @timestamp,signedPreviousHash = @signedPreviousHash,algorithm = @algorithm,publicKeyJwkBase64Url = @publicKeyJwkBase64Url,recordHash = @recordHash "+
+                                             ";";
+                var upsertParam1 = upsertCommand.CreateParameter();
+                upsertParam1.ParameterName = "@previousHash";
+                upsertCommand.Parameters.Add(upsertParam1);
+                var upsertParam2 = upsertCommand.CreateParameter();
+                upsertParam2.ParameterName = "@identity";
+                upsertCommand.Parameters.Add(upsertParam2);
+                var upsertParam3 = upsertCommand.CreateParameter();
+                upsertParam3.ParameterName = "@timestamp";
+                upsertCommand.Parameters.Add(upsertParam3);
+                var upsertParam4 = upsertCommand.CreateParameter();
+                upsertParam4.ParameterName = "@signedPreviousHash";
+                upsertCommand.Parameters.Add(upsertParam4);
+                var upsertParam5 = upsertCommand.CreateParameter();
+                upsertParam5.ParameterName = "@algorithm";
+                upsertCommand.Parameters.Add(upsertParam5);
+                var upsertParam6 = upsertCommand.CreateParameter();
+                upsertParam6.ParameterName = "@publicKeyJwkBase64Url";
+                upsertCommand.Parameters.Add(upsertParam6);
+                var upsertParam7 = upsertCommand.CreateParameter();
+                upsertParam7.ParameterName = "@notarySignature";
+                upsertCommand.Parameters.Add(upsertParam7);
+                var upsertParam8 = upsertCommand.CreateParameter();
+                upsertParam8.ParameterName = "@recordHash";
+                upsertCommand.Parameters.Add(upsertParam8);
+                upsertParam1.Value = item.previousHash;
+                upsertParam2.Value = item.identity;
+                upsertParam3.Value = item.timestamp.milliseconds;
+                upsertParam4.Value = item.signedPreviousHash;
+                upsertParam5.Value = item.algorithm;
+                upsertParam6.Value = item.publicKeyJwkBase64Url;
+                upsertParam7.Value = item.notarySignature;
+                upsertParam8.Value = item.recordHash;
+                var count = await conn.ExecuteNonQueryAsync(upsertCommand);
+                if (count > 0)
+                    _cache.AddOrUpdate("TableNotaryChainOldCRUD", item.notarySignature.ToBase64(), item);
+                return count;
+            }
+        }
+        public virtual async Task<int> UpdateAsync(DatabaseConnection conn, NotaryChainOldRecord item)
+        {
+            using (var updateCommand = conn.db.CreateCommand())
+            {
+                updateCommand.CommandText = "UPDATE NotaryChainOld " +
+                                             "SET previousHash = @previousHash,identity = @identity,timestamp = @timestamp,signedPreviousHash = @signedPreviousHash,algorithm = @algorithm,publicKeyJwkBase64Url = @publicKeyJwkBase64Url,recordHash = @recordHash "+
+                                             "WHERE (notarySignature = @notarySignature)";
+                var updateParam1 = updateCommand.CreateParameter();
+                updateParam1.ParameterName = "@previousHash";
+                updateCommand.Parameters.Add(updateParam1);
+                var updateParam2 = updateCommand.CreateParameter();
+                updateParam2.ParameterName = "@identity";
+                updateCommand.Parameters.Add(updateParam2);
+                var updateParam3 = updateCommand.CreateParameter();
+                updateParam3.ParameterName = "@timestamp";
+                updateCommand.Parameters.Add(updateParam3);
+                var updateParam4 = updateCommand.CreateParameter();
+                updateParam4.ParameterName = "@signedPreviousHash";
+                updateCommand.Parameters.Add(updateParam4);
+                var updateParam5 = updateCommand.CreateParameter();
+                updateParam5.ParameterName = "@algorithm";
+                updateCommand.Parameters.Add(updateParam5);
+                var updateParam6 = updateCommand.CreateParameter();
+                updateParam6.ParameterName = "@publicKeyJwkBase64Url";
+                updateCommand.Parameters.Add(updateParam6);
+                var updateParam7 = updateCommand.CreateParameter();
+                updateParam7.ParameterName = "@notarySignature";
+                updateCommand.Parameters.Add(updateParam7);
+                var updateParam8 = updateCommand.CreateParameter();
+                updateParam8.ParameterName = "@recordHash";
+                updateCommand.Parameters.Add(updateParam8);
+                updateParam1.Value = item.previousHash;
+                updateParam2.Value = item.identity;
+                updateParam3.Value = item.timestamp.milliseconds;
+                updateParam4.Value = item.signedPreviousHash;
+                updateParam5.Value = item.algorithm;
+                updateParam6.Value = item.publicKeyJwkBase64Url;
+                updateParam7.Value = item.notarySignature;
+                updateParam8.Value = item.recordHash;
+                var count = await conn.ExecuteNonQueryAsync(updateCommand);
+                if (count > 0)
+                {
+                    _cache.AddOrUpdate("TableNotaryChainOldCRUD", item.notarySignature.ToBase64(), item);
+                }
+                return count;
+            }
+        }
+
+        public virtual async Task<int> RenameAsync(DatabaseConnection conn)
+        {
+            using (var getCountCommand = conn.db.CreateCommand())
+            {
+                getCountCommand.CommandText = "ALTER TABLE notaryChain RENAME TO NotaryChainOld;";
+                var count = await conn.ExecuteScalarAsync(getCountCommand);
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public virtual async Task<int> GetCountAsync(DatabaseConnection conn)
+        {
+            using (var getCountCommand = conn.db.CreateCommand())
+            {
+                 // TODO: this is SQLite specific
+                getCountCommand.CommandText = "SELECT COUNT(*) FROM NotaryChainOld;";
+                var count = await conn.ExecuteScalarAsync(getCountCommand);
+                if (count == null || count == DBNull.Value || !(count is int || count is long))
+                    return -1;
+                else
+                    return Convert.ToInt32(count);
+            }
+        }
+
+        public static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("previousHash");
+            sl.Add("identity");
+            sl.Add("timestamp");
+            sl.Add("signedPreviousHash");
+            sl.Add("algorithm");
+            sl.Add("publicKeyJwkBase64Url");
+            sl.Add("notarySignature");
+            sl.Add("recordHash");
+            return sl;
+        }
+
+        // SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,notarySignature,recordHash
+        public NotaryChainOldRecord ReadRecordFromReaderAll(DbDataReader rdr)
+        {
+            var result = new List<NotaryChainOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new NotaryChainOldRecord();
+            item.previousHashNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.previousHash?.Length < 16)
+                throw new Exception("Too little data in previousHash...");
+            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.timestamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.signedPreviousHashNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
+            if (item.signedPreviousHash?.Length < 16)
+                throw new Exception("Too little data in signedPreviousHash...");
+            item.algorithmNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
+            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
+            item.notarySignatureNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[6]);
+            if (item.notarySignature?.Length < 16)
+                throw new Exception("Too little data in notarySignature...");
+            item.recordHashNoLengthCheck = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[7]);
+            if (item.recordHash?.Length < 16)
+                throw new Exception("Too little data in recordHash...");
+            return item;
+       }
+
+        public virtual async Task<int> DeleteAsync(DatabaseConnection conn, byte[] notarySignature)
+        {
+            if (notarySignature == null) throw new Exception("Cannot be null");
+            if (notarySignature?.Length < 16) throw new Exception("Too short");
+            if (notarySignature?.Length > 200) throw new Exception("Too long");
+            using (var delete0Command = conn.db.CreateCommand())
+            {
+                delete0Command.CommandText = "DELETE FROM NotaryChainOld " +
+                                             "WHERE notarySignature = @notarySignature";
+                var delete0Param1 = delete0Command.CreateParameter();
+                delete0Param1.ParameterName = "@notarySignature";
+                delete0Command.Parameters.Add(delete0Param1);
+
+                delete0Param1.Value = notarySignature;
+                var count = await conn.ExecuteNonQueryAsync(delete0Command);
+                if (count > 0)
+                    _cache.Remove("TableNotaryChainOldCRUD", notarySignature.ToBase64());
+                return count;
+            }
+        }
+
+        public NotaryChainOldRecord ReadRecordFromReader0(DbDataReader rdr,byte[] notarySignature)
+        {
+            if (notarySignature == null) throw new Exception("Cannot be null");
+            if (notarySignature?.Length < 16) throw new Exception("Too short");
+            if (notarySignature?.Length > 200) throw new Exception("Too long");
+            var result = new List<NotaryChainOldRecord>();
+#pragma warning disable CS0168
+            long bytesRead;
+#pragma warning restore CS0168
+            var guid = new byte[16];
+            var item = new NotaryChainOldRecord();
+            item.notarySignature = notarySignature;
+            item.previousHashNoLengthCheck = (rdr[0] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[0]);
+            if (item.previousHash?.Length < 16)
+                throw new Exception("Too little data in previousHash...");
+            item.identityNoLengthCheck = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[1];
+            item.timestamp = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[2]);
+            item.signedPreviousHashNoLengthCheck = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[3]);
+            if (item.signedPreviousHash?.Length < 16)
+                throw new Exception("Too little data in signedPreviousHash...");
+            item.algorithmNoLengthCheck = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[4];
+            item.publicKeyJwkBase64UrlNoLengthCheck = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (string)rdr[5];
+            item.recordHashNoLengthCheck = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (byte[])(rdr[6]);
+            if (item.recordHash?.Length < 16)
+                throw new Exception("Too little data in recordHash...");
+            return item;
+       }
+
+        public virtual async Task<NotaryChainOldRecord> GetAsync(DatabaseConnection conn,byte[] notarySignature)
+        {
+            if (notarySignature == null) throw new Exception("Cannot be null");
+            if (notarySignature?.Length < 16) throw new Exception("Too short");
+            if (notarySignature?.Length > 200) throw new Exception("Too long");
+            var (hit, cacheObject) = _cache.Get("TableNotaryChainOldCRUD", notarySignature.ToBase64());
+            if (hit)
+                return (NotaryChainOldRecord)cacheObject;
+            using (var get0Command = conn.db.CreateCommand())
+            {
+                get0Command.CommandText = "SELECT previousHash,identity,timestamp,signedPreviousHash,algorithm,publicKeyJwkBase64Url,recordHash FROM NotaryChainOld " +
+                                             "WHERE notarySignature = @notarySignature LIMIT 1;"+
+                                             ";";
+                var get0Param1 = get0Command.CreateParameter();
+                get0Param1.ParameterName = "@notarySignature";
+                get0Command.Parameters.Add(get0Param1);
+
+                get0Param1.Value = notarySignature;
+                {
+                    using (var rdr = await conn.ExecuteReaderAsync(get0Command, System.Data.CommandBehavior.SingleRow))
+                    {
+                        if (await rdr.ReadAsync() == false)
+                        {
+                            _cache.AddOrUpdate("TableNotaryChainOldCRUD", notarySignature.ToBase64(), null);
+                            return null;
+                        }
+                        var r = ReadRecordFromReader0(rdr,notarySignature);
+                        _cache.AddOrUpdate("TableNotaryChainOldCRUD", notarySignature.ToBase64(), r);
+                        return r;
+                    } // using
+                } //
+            } // using
+        }
+
+    }
+}

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableKeyThreeValueTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableKeyThreeValueTests.cs
@@ -280,10 +280,20 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             var ra = await tblKeyThreeValue.GetByKeyTwoAsync(i1);
             if (ra.Count != 2)
                 Assert.Fail();
-            if (ByteArrayUtil.muidcmp(ra[0], v1) != 0)
-                Assert.Fail();
-            if (ByteArrayUtil.muidcmp(ra[1], v2) != 0)
-                Assert.Fail();
+            if (ByteArrayUtil.muidcmp(ra[0], v1) == 0)
+            {
+                if (ByteArrayUtil.muidcmp(ra[0], v1) != 0)
+                    Assert.Fail();
+                if (ByteArrayUtil.muidcmp(ra[1], v2) != 0)
+                    Assert.Fail();
+            }
+            else
+            {
+                if (ByteArrayUtil.muidcmp(ra[0], v2) != 0)
+                    Assert.Fail();
+                if (ByteArrayUtil.muidcmp(ra[1], v1) != 0)
+                    Assert.Fail();
+            }
 
             ra = await tblKeyThreeValue.GetByKeyThreeAsync(u1);
             if (ra.Count != 1)

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableKeyTwoValueTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableKeyTwoValueTests.cs
@@ -260,10 +260,20 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             var ra = await tblKeyTwoValue.GetByKeyTwoAsync(i1);
             if (ra.Count != 2)
                 Assert.Fail();
-            if (ByteArrayUtil.muidcmp(ra[0].data, v1) != 0)
-                Assert.Fail();
-            if (ByteArrayUtil.muidcmp(ra[1].data, v2) != 0)
-                Assert.Fail();
+            if (ByteArrayUtil.muidcmp(ra[0].key1, k1) == 0)
+            {
+                if (ByteArrayUtil.muidcmp(ra[0].data, v1) != 0)
+                    Assert.Fail();
+                if (ByteArrayUtil.muidcmp(ra[1].data, v2) != 0)
+                    Assert.Fail();
+            }
+            else
+            {
+                if (ByteArrayUtil.muidcmp(ra[0].data, v2) != 0)
+                    Assert.Fail();
+                if (ByteArrayUtil.muidcmp(ra[1].data, v1) != 0)
+                    Assert.Fail();
+            }
 
 
             await tblKeyTwoValue.UpdateAsync(new KeyTwoValueRecord() { key1 = k1, key2 = i1, data = v2 });


### PR DESCRIPTION
Had to make ROWID explicit because otherwise we were unable to create indices in SQLite that included ROWID.
Made sure that SQLite and Postgres got streamlined so they get the same treatment.
Note that in SQLite the ROWID must be designated as a PRIMARY KEY (ask the SQLite team), and therefore I applied the same treatment to Postgres.