### PR TITLE
QueryBatch for Database Upgrade

### DIFF
--- a/src/apps/Odin.Attestation/Controllers/AttestationRequestController.cs
+++ b/src/apps/Odin.Attestation/Controllers/AttestationRequestController.cs
@@ -92,7 +92,7 @@ namespace Odin.Attestation.Controllers
                     return NotFound("No such attestationId found.");
                 }
 
-                var result = new VerifyAttestationResult() { created = r.created.seconds, modified = r.modified?.seconds, status = r.status };
+                var result = new VerifyAttestationResult() { created = r.created.seconds, modified = r.modified.seconds, status = r.status };
 
                 return Ok(JsonSerializer.Serialize(result, options));
             }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCRUD.cs
@@ -123,8 +123,8 @@ namespace Odin.Core.Storage.Database.Identity.Table
                   _created = value;
                }
         }
-        private UnixTimeUtc? _modified;
-        public UnixTimeUtc? modified
+        private UnixTimeUtc _modified;
+        public UnixTimeUtc modified
         {
            get {
                    return _modified;
@@ -172,7 +172,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"timestamp BIGINT NOT NULL, "
                    +"data BYTEA , "
                    +"created BIGINT NOT NULL, "
-                   +"modified BIGINT  "
+                   +"modified BIGINT NOT NULL "
                    +", UNIQUE(identityId,notificationId)"
                    +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0AppNotifications ON AppNotifications(identityId,created);"
@@ -187,13 +187,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                string sqlNowStr;
-                if (_scopedConnectionFactory.DatabaseType == DatabaseType.Sqlite)
-                    sqlNowStr = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
-                else
-                    sqlNowStr = "EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'UTC') * 1000";
+                string sqlNowStr = SqlExtensions.SqlNowString(_scopedConnectionFactory.DatabaseType);
                 insertCommand.CommandText = "INSERT INTO AppNotifications (identityId,notificationId,unread,senderId,timestamp,data,created,modified) " +
-                                             $"VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,{sqlNowStr},NULL)"+
+                                             $"VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,{sqlNowStr},{sqlNowStr})"+
                                             "RETURNING created,modified,rowId;";
                 var insertParam1 = insertCommand.CreateParameter();
                 insertParam1.ParameterName = "@identityId";
@@ -223,12 +219,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 if (await rdr.ReadAsync())
                 {
                     long created = (long) rdr[0];
-                    long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                    long modified = (long) rdr[1];
                     item.created = new UnixTimeUtc(created);
-                    if (modified != null)
-                        item.modified = new UnixTimeUtc((long)modified);
-                    else
-                        item.modified = null;
+                    item.modified = new UnixTimeUtc((long)modified);
                     item.rowId = (long) rdr[2];
                     _cache.AddOrUpdate("TableAppNotificationsCRUD", item.identityId.ToString()+item.notificationId.ToString(), item);
                     return 1;
@@ -244,13 +237,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var insertCommand = cn.CreateCommand();
             {
-                string sqlNowStr;
-                if (_scopedConnectionFactory.DatabaseType == DatabaseType.Sqlite)
-                    sqlNowStr = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
-                else
-                    sqlNowStr = "EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'UTC') * 1000";
+                string sqlNowStr = SqlExtensions.SqlNowString(_scopedConnectionFactory.DatabaseType);
                 insertCommand.CommandText = "INSERT INTO AppNotifications (identityId,notificationId,unread,senderId,timestamp,data,created,modified) " +
-                                            $"VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,{sqlNowStr},NULL) " +
+                                            $"VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,{sqlNowStr},{sqlNowStr}) " +
                                             "ON CONFLICT DO NOTHING "+
                                             "RETURNING created,modified,rowId;";
                 var insertParam1 = insertCommand.CreateParameter();
@@ -281,12 +270,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 if (await rdr.ReadAsync())
                 {
                     long created = (long) rdr[0];
-                    long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                    long modified = (long) rdr[1];
                     item.created = new UnixTimeUtc(created);
-                    if (modified != null)
-                        item.modified = new UnixTimeUtc((long)modified);
-                    else
-                        item.modified = null;
+                    item.modified = new UnixTimeUtc((long)modified);
                     item.rowId = (long) rdr[2];
                    _cache.AddOrUpdate("TableAppNotificationsCRUD", item.identityId.ToString()+item.notificationId.ToString(), item);
                     return true;
@@ -302,15 +288,11 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var upsertCommand = cn.CreateCommand();
             {
-                string sqlNowStr;
-                if (_scopedConnectionFactory.DatabaseType == DatabaseType.Sqlite)
-                    sqlNowStr = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
-                else
-                    sqlNowStr = "EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'UTC') * 1000";
+                string sqlNowStr = SqlExtensions.SqlNowString(_scopedConnectionFactory.DatabaseType);
                 upsertCommand.CommandText = "INSERT INTO AppNotifications (identityId,notificationId,unread,senderId,timestamp,data,created,modified) " +
-                                            $"VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,{sqlNowStr},NULL)"+
+                                            $"VALUES (@identityId,@notificationId,@unread,@senderId,@timestamp,@data,{sqlNowStr},{sqlNowStr})"+
                                             "ON CONFLICT (identityId,notificationId) DO UPDATE "+
-                                            $"SET unread = @unread,senderId = @senderId,timestamp = @timestamp,data = @data,modified = {sqlNowStr} "+
+                                            $"SET unread = @unread,senderId = @senderId,timestamp = @timestamp,data = @data,modified = MAX(modified+1,{sqlNowStr}) "+
                                             "RETURNING created,modified,rowId;";
                 var upsertParam1 = upsertCommand.CreateParameter();
                 upsertParam1.ParameterName = "@identityId";
@@ -340,12 +322,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 if (await rdr.ReadAsync())
                 {
                     long created = (long) rdr[0];
-                    long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                    long modified = (long) rdr[1];
                     item.created = new UnixTimeUtc(created);
-                    if (modified != null)
-                        item.modified = new UnixTimeUtc((long)modified);
-                    else
-                        item.modified = null;
+                    item.modified = new UnixTimeUtc((long)modified);
                     item.rowId = (long) rdr[2];
                    _cache.AddOrUpdate("TableAppNotificationsCRUD", item.identityId.ToString()+item.notificationId.ToString(), item);
                     return 1;
@@ -361,13 +340,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
             await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var updateCommand = cn.CreateCommand();
             {
-                string sqlNowStr;
-                if (_scopedConnectionFactory.DatabaseType == DatabaseType.Sqlite)
-                    sqlNowStr = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
-                else
-                    sqlNowStr = "EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'UTC') * 1000";
+                string sqlNowStr = SqlExtensions.SqlNowString(_scopedConnectionFactory.DatabaseType);
                 updateCommand.CommandText = "UPDATE AppNotifications " +
-                                            $"SET unread = @unread,senderId = @senderId,timestamp = @timestamp,data = @data,modified = {sqlNowStr} "+
+                                            $"SET unread = @unread,senderId = @senderId,timestamp = @timestamp,data = @data,modified = MAX(modified+1,{sqlNowStr}) "+
                                             "WHERE (identityId = @identityId AND notificationId = @notificationId) "+
                                             "RETURNING created,modified,rowId;";
                 var updateParam1 = updateCommand.CreateParameter();
@@ -398,12 +373,9 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 if (await rdr.ReadAsync())
                 {
                     long created = (long) rdr[0];
-                    long? modified = (rdr[1] == DBNull.Value) ? null : (long) rdr[1];
+                    long modified = (long) rdr[1];
                     item.created = new UnixTimeUtc(created);
-                    if (modified != null)
-                        item.modified = new UnixTimeUtc((long)modified);
-                    else
-                        item.modified = null;
+                    item.modified = new UnixTimeUtc((long)modified);
                     item.rowId = (long) rdr[2];
                    _cache.AddOrUpdate("TableAppNotificationsCRUD", item.identityId.ToString()+item.notificationId.ToString(), item);
                     return 1;
@@ -461,7 +433,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             item.created = (rdr[7] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[7]);
-            item.modified = (rdr[8] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[8]);
+            item.modified = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[8]);
             return item;
        }
 
@@ -506,7 +478,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             if (item.data?.Length < 0)
                 throw new Exception("Too little data in data...");
             item.created = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
-            item.modified = (rdr[6] == DBNull.Value) ? null : new UnixTimeUtc((long)rdr[6]);
+            item.modified = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[6]);
             return item;
        }
 

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndex.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveLocalTagIndex.cs
@@ -63,12 +63,12 @@ public class TableDriveLocalTagIndex(
         string forUpdate;
         if (_scopedConnectionFactory.DatabaseType == DatabaseType.Sqlite)
         {
-            sqlNowStr = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
+            sqlNowStr = SqlExtensions.SqlNowString(DatabaseType.Sqlite);
             forUpdate = "";
         }
         else
         {
-            sqlNowStr = "EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'UTC') * 1000";
+            sqlNowStr = SqlExtensions.SqlNowString(DatabaseType.Postgres);
             forUpdate = "FOR UPDATE";
         }
 
@@ -102,7 +102,7 @@ public class TableDriveLocalTagIndex(
         updateCommand.CommandText =
             $"""
             UPDATE driveMainIndex
-            SET hdrLocalVersionTag = @newVersionTag, hdrLocalAppData = @hdrLocalAppData, modified = {sqlNowStr}
+            SET hdrLocalVersionTag = @newVersionTag, hdrLocalAppData = @hdrLocalAppData, modified = MAX(modified+1,{sqlNowStr})
             WHERE identityId = @identityId AND driveId = @driveId AND fileId = @fileId
                   AND COALESCE(hdrLocalVersionTag, @emptyGuid) = @hdrLocalVersionTag
             """;

--- a/src/core/Odin.Core.Storage/SQLite/DatabaseBase.cs
+++ b/src/core/Odin.Core.Storage/SQLite/DatabaseBase.cs
@@ -1,12 +1,13 @@
-﻿using System;
+﻿using Microsoft.Data.Sqlite;
+using Odin.Core.Cryptography.Crypto;
+using Odin.Core.Exceptions;
+using Odin.Core.Storage.Database;
+using Odin.Core.Storage.Factory;
+using System;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Sqlite;
-using Odin.Core.Cryptography.Crypto;
-using Odin.Core.Exceptions;
-using Odin.Core.Storage.Database;
 
 
 /*

--- a/src/core/Odin.Core.Storage/SqlExtensions.cs
+++ b/src/core/Odin.Core.Storage/SqlExtensions.cs
@@ -19,4 +19,12 @@ public static class SqlExtensions
     {
         return guid.ToByteArray().ToSql(databaseType);
     }
+
+    public static string SqlNowString(DatabaseType dbType)
+    {
+        if (dbType == DatabaseType.Sqlite)
+            return "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
+        else
+            return "EXTRACT(EPOCH FROM NOW() AT TIME ZONE 'UTC') * 1000";
+    }
 }

--- a/src/services/Odin.Services/Drives/DriveCore/Storage/FileMetadata.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/FileMetadata.cs
@@ -149,11 +149,7 @@ namespace Odin.Services.Drives.DriveCore.Storage
             GlobalTransitId = record.globalTransitId;
             FileState = (FileState)record.fileState;
             Created = record.created;
-            Updated = record.modified == null
-                ? record.created
-                : record.modified
-                    .Value; // Todd said NULL means UnixTimeUtc.ZeroTime, but it seems the FE code expects modified == created if modified is NULL
-            // But I would prefer if it was nullable - except of course if we change it so that it's always set
+            Updated = record.modified;
 
             ReactionPreview = string.IsNullOrEmpty(record.hdrReactionSummary)
                 ? null

--- a/src/services/Odin.Services/Membership/Connections/CircleNetworkStorage.cs
+++ b/src/services/Odin.Services/Membership/Connections/CircleNetworkStorage.cs
@@ -239,7 +239,7 @@ public class CircleNetworkStorage
             OdinId = record.identity,
             Status = (ConnectionStatus)record.status,
             Created = record.created.milliseconds,
-            LastUpdated = record.modified.HasValue ? record.modified.Value.milliseconds : 0,
+            LastUpdated = record.modified,
             AccessGrant = data.AccessGrant,
             OriginalContactData = data.OriginalContactData,
             EncryptedClientAccessToken = data.EncryptedClientAccessToken == null

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Abstractions/DatabaseCreatedModifiedTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Abstractions/DatabaseCreatedModifiedTests.cs
@@ -38,9 +38,9 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             };
             var n = await tblConnections.InsertAsync(item1);
 
-            // Validate that INSERT has a NULL modified and a "now" created
+            // Validate that INSERT has a modified and a "now" created that are equal
             ClassicAssert.IsTrue(n == 1);
-            ClassicAssert.IsTrue(item1.modified == null);
+            ClassicAssert.IsTrue(item1.modified == item1.created);
             ClassicAssert.IsTrue(item1.created <= UnixTimeUtc.Now());
             ClassicAssert.IsTrue(item1.created > UnixTimeUtc.Now().AddSeconds(-1));
 
@@ -56,15 +56,66 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             {
             }
             // Validate that trying to insert it again doesn't mess up the values
-            ClassicAssert.IsTrue(item1.modified == null);
+            ClassicAssert.IsTrue(item1.modified == item1.created);
             ClassicAssert.IsTrue(item1.created.milliseconds == copy.milliseconds);
 
             // Validate that loading the record yields the same results
             var loaded = await tblConnections.GetAsync(new OdinId("frodo.baggins.me"));
-            ClassicAssert.IsTrue(loaded.modified == null);
+            ClassicAssert.IsTrue(loaded.modified == loaded.created);
             ClassicAssert.IsTrue(item1.created == loaded.created);
         }
 
+        // Using the connections table just because it happens to have FinallyAddCreatedModified();
+        [Test]
+        [TestCase(DatabaseType.Sqlite)]
+#if RUN_POSTGRES_TESTS
+        [TestCase(DatabaseType.Postgres)]
+#endif
+        public async Task QuickInsertUpdateTimersTest(DatabaseType databaseType)
+        {
+            await RegisterServicesAsync(databaseType);
+            await using var scope = Services.BeginLifetimeScope();
+            var tblConnections = scope.Resolve<TableConnections>();
+
+            var g1 = Guid.NewGuid();
+
+            var item1 = new ConnectionsRecord()
+            {
+                identity = new OdinId("frodo.baggins.me"),
+                displayName = "Frodo",
+                status = 42,
+                accessIsRevoked = 1,
+                data = g1.ToByteArray()
+            };
+
+
+            // Ensure that a quick Insert / Update cannot result in created == modified.
+            // When created == modified it means it's an item that has never been modified, only created.
+            //
+            for (int i = 0; i < 100; i++)
+            {
+                item1.identity = new OdinId($"{i}.frodo.baggins.me");
+                var n = await tblConnections.InsertAsync(item1);
+                ClassicAssert.IsTrue(n == 1);
+                n = await tblConnections.UpdateAsync(item1);
+                ClassicAssert.IsTrue(n == 1);
+                ClassicAssert.IsTrue(item1.modified != item1.created);
+            }
+
+            // Ensure that a quick Insert / Update always results in a monotonically
+            // increasing modified value
+            //
+            var prev = item1.modified;
+            for (int i = 0; i < 100; i++)
+            {
+                var n = await tblConnections.UpdateAsync(item1);
+                ClassicAssert.IsTrue(n == 1);
+
+                // Ensure monotonically increasing modified even if updated faster than per ms
+                ClassicAssert.IsTrue(item1.modified > prev);
+                prev = item1.modified;
+            }
+        }
         // Using the connections table just because it happens to have FinallyAddCreatedModified();
         [Test]
         [TestCase(DatabaseType.Sqlite)]
@@ -95,14 +146,14 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             await tblConnections.UpdateAsync(item1);
 
             // Validate that UPDATE has a value in modified and created was unchanged
-            ClassicAssert.IsTrue(item1.modified != null);
+            ClassicAssert.IsTrue(item1.modified != item1.created);
             ClassicAssert.IsTrue(item1.modified <= UnixTimeUtc.Now());
             ClassicAssert.IsTrue(item1.modified > UnixTimeUtc.Now().AddSeconds(-1));
             ClassicAssert.IsTrue(item1.created == copyCreated);
 
             // Load it and be sure the values are the same
             var loaded = await tblConnections.GetAsync(new OdinId("frodo.baggins.me"));
-            ClassicAssert.IsTrue(loaded.modified != null);
+            ClassicAssert.IsTrue(loaded.modified != loaded.created);
             ClassicAssert.IsTrue(loaded.modified == item1.modified);
             ClassicAssert.IsTrue(loaded.created == item1.created);
 
@@ -111,7 +162,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             await tblConnections.UpdateAsync(item1);
 
             // Validate that UPDATE is cuurent and as expected
-            ClassicAssert.IsTrue(item1.modified != null);
+            ClassicAssert.IsTrue(item1.modified != item1.created);
             ClassicAssert.IsTrue(item1.modified <= UnixTimeUtc.Now());
             ClassicAssert.IsTrue(item1.modified > UnixTimeUtc.Now().AddSeconds(-1));
             ClassicAssert.IsTrue(item1.modified != copyModified);
@@ -143,7 +194,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
 
             // Validate the Upsert behaves as an INSERT for the first record
             ClassicAssert.IsTrue(n == 1);
-            ClassicAssert.IsTrue(item1.modified == null);
+            ClassicAssert.IsTrue(item1.modified == item1.created);
             ClassicAssert.IsTrue(item1.created <= UnixTimeUtc.Now());
             ClassicAssert.IsTrue(item1.created > UnixTimeUtc.Now().AddSeconds(-1));
 
@@ -152,14 +203,14 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
 
             await tblConnections.UpsertAsync(item1);
             // Validate the Upsert behaves as an UPDATE for the next calls
-            ClassicAssert.IsTrue(item1.modified != null);
+            ClassicAssert.IsTrue(item1.modified != item1.created);
             ClassicAssert.IsTrue(item1.modified <= UnixTimeUtc.Now());
             ClassicAssert.IsTrue(item1.modified > UnixTimeUtc.Now().AddSeconds(-1));
             ClassicAssert.IsTrue(item1.created == copyCreated);
 
             var loaded = await tblConnections.GetAsync(new OdinId("frodo.baggins.me"));
             // Validate that it loads the same values
-            ClassicAssert.IsTrue(loaded.modified != null);
+            ClassicAssert.IsTrue(loaded.modified != loaded.created);
             ClassicAssert.IsTrue(loaded.modified == item1.modified);
             ClassicAssert.IsTrue(loaded.created == item1.created);
         }

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Abstractions/DriveIndexDatabaseTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Abstractions/DriveIndexDatabaseTests.cs
@@ -112,7 +112,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1); // Newest chat item
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1); // Newest chat item
 
             QueryBatchCursor cursor = null;
 
@@ -149,6 +149,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             ClassicAssert.IsTrue(moreRows == false);
         }
 
+
+
         /// <summary>
         /// Scenario: Chat client gets everything but in three batches (3 pages out of 5 items)
         /// subsequent queries. Again, newest chat items returned in the first query, etc.
@@ -174,11 +176,11 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f4 = SequentialGuid.CreateGuid();
             var f5 = SequentialGuid.CreateGuid();
 
-            var c1 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c3 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c4 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);;
+            var (c3, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c4, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
 
             QueryBatchCursor cursor = null;
             var (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, cursor, requiredSecurityGroup: allIntRange);
@@ -241,11 +243,11 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f4 = SequentialGuid.CreateGuid();
             var f5 = SequentialGuid.CreateGuid();
 
-            var c1 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c3 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c4 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c3, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c4, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
 
             QueryBatchCursor cursor = null;
             var (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 100, cursor, requiredSecurityGroup: allIntRange);
@@ -267,8 +269,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             // Add two more items
             var f6 = SequentialGuid.CreateGuid();
             var f7 = SequentialGuid.CreateGuid();
-            var c6 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c7 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f7, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c6, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c7, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f7, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
 
             // Later we do a new query, with a NULL startFromCursor, because then we'll get the newest items first.
             // But stop at stopAtBoundaryCursor: pagingCursor
@@ -351,7 +353,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             {
                 (result, moreRows, var refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, cursor, requiredSecurityGroup: allIntRange);
                 c += result.Count;
-                if (result.Count == 0)
+                if (moreRows == false)
                     break;
             }
 
@@ -371,7 +373,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             {
                 (result, moreRows, var refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, cursor, requiredSecurityGroup: allIntRange);
                 c += result.Count;
-                if (result.Count == 0)
+                if (moreRows == false)
                     break;
             }
 
@@ -404,13 +406,13 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f4 = SequentialGuid.CreateGuid(new UnixTimeUtc(2000));
             var f5 = SequentialGuid.CreateGuid(new UnixTimeUtc(2001));
 
-            var c1 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 1, null, null, 1);
-            var c3 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 2, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 1, null, null, 1);
+            var (c3, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 2, null, null, 1);
             await Task.Delay(10);
-            var c4 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 2, null, null, 1);
+            var (c4, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 2, null, null, 1);
             await Task.Delay(10);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 3, null, null, 1);
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, 0, 3, null, null, 1);
 
             QueryBatchCursor cursor = new QueryBatchCursor(c4);
             var (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 100, cursor, sortOrder: QueryBatchSortOrder.OldestFirst, sortField: QueryBatchSortField.CreatedDate, requiredSecurityGroup: allIntRange);
@@ -741,6 +743,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             r.archivalStatus = 7;
             await metaIndex.BaseUpsertEntryZapZapAsync(r, null, null);
 
+            await Task.Delay(2);
+
             cursor = null;
             (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 10, cursor, archivalStatusAnyOf: new List<Int32>() { 0 }, requiredSecurityGroup: allIntRange);
             ClassicAssert.IsTrue(result.Count == 1);
@@ -774,11 +778,11 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f4 = SequentialGuid.CreateGuid();
             var f5 = SequentialGuid.CreateGuid();
 
-            var c1= await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c3 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c4 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c3, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c4, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
 
             QueryBatchCursor cursor = null;
             var (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 100, cursor, requiredSecurityGroup: allIntRange);
@@ -791,8 +795,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             // Add two more items
             var f6 = SequentialGuid.CreateGuid();
             var f7 = SequentialGuid.CreateGuid();
-            var c6 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c7 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f7, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c6, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c7, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f7, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
 
             // Now there should be no more items (recursive call in QueryBatch())
             (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 10, refCursor, requiredSecurityGroup: allIntRange);
@@ -853,7 +857,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
 
             // Get everything from the chat database
             QueryBatchCursor cursor = null;
@@ -881,9 +885,9 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f6 = SequentialGuid.CreateGuid();
             var f7 = SequentialGuid.CreateGuid();
             var f8 = SequentialGuid.CreateGuid();
-            var c6 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c7 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f7, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c8 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f8, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c6, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c7, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f7, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c8, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f8, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
 
             // Now we get two of the three new items, we get the newest first f8 & f7
             (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, refCursor, requiredSecurityGroup: allIntRange);
@@ -899,8 +903,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             // Now add two more items
             var f9 = SequentialGuid.CreateGuid();
             var f10 = SequentialGuid.CreateGuid();
-            var c9 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f9, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c10 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f10, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c9, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f9, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c10, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f10, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
 
             // Now we get two more items. Internally, this will turn into two QueryBatchRaw()
             // because there is only 1 left in the previous range. A second request will get the
@@ -929,6 +933,136 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
 
         }
 
+
+
+        /// <summary>
+        /// READ THIS EXAMPLE TO UNDERSTAND HOW THE AUTO CURSOR WITH ANYCHANGE WORKS IN A REAL LIFE SCENARIO
+        ///
+        /// Scenario: First we get the entire chat history of five items.
+        /// Then three new items are added.
+        /// We check to get a page of TWO those (one is left).
+        /// Then two new items are added.
+        /// We check to get TWO items. We'll get only 1 because that's the leftover from the three items where we only got 2
+        /// Then we check to get TWO more items, and we get the last two.
+        ///
+        /// In summary items are retrieved as [f5,f4,f3,f2,f1], [f8,f7], [f6], [f10,f9]
+        ///
+        /// </summary>
+        [Test]
+        [TestCase(DatabaseType.Sqlite)]
+#if RUN_POSTGRES_TESTS
+        [TestCase(DatabaseType.Postgres)]
+#endif
+        public async Task CursorsBatch07AnyChangeExampleTest(DatabaseType databaseType)
+        {
+            await RegisterServicesAsync(databaseType);
+            await using var scope = Services.BeginLifetimeScope();
+            var metaIndex = scope.Resolve<MainIndexMeta>();
+            var tblDriveMainIndex = scope.Resolve<TableDriveMainIndex>();
+
+            var driveId = Guid.NewGuid();
+
+            var f1 = SequentialGuid.CreateGuid();
+            var s1 = SequentialGuid.CreateGuid().ToString();
+            var t1 = SequentialGuid.CreateGuid();
+            var f2 = SequentialGuid.CreateGuid();
+            var f3 = SequentialGuid.CreateGuid();
+            var f4 = SequentialGuid.CreateGuid();
+            var f5 = SequentialGuid.CreateGuid();
+
+            // Add five items to the chat database
+            await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            await Task.Delay(2);
+            var (c5, m5) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
+            await Task.Delay(2);
+
+            // Get everything from the chat database
+            QueryBatchCursor cursor = null;
+            var (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 100, cursor, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
+            ClassicAssert.IsTrue(result.Count == 5);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[0].fileId, f5) == 0);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[1].fileId, f4) == 0);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[2].fileId, f3) == 0);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[3].fileId, f2) == 0);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[4].fileId, f1) == 0);
+            ClassicAssert.IsTrue(new TimeRowCursor(c5, 5).Equals(refCursor.stopAtBoundary));
+            ClassicAssert.IsTrue(refCursor.nextBoundaryCursor == null);
+            ClassicAssert.IsTrue(refCursor.pagingCursor == null);
+            ClassicAssert.IsTrue(moreRows == false);
+
+            // Now we'll touch two items from above
+            await Task.Delay(2);
+            (_, var m2) = await tblDriveMainIndex.TestTouchAsync(driveId, f2);
+            await Task.Delay(2);
+            (_, var m3) = await tblDriveMainIndex.TestTouchAsync(driveId, f3);
+            await Task.Delay(2);
+
+            // Now there should be no more items
+            (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 10, refCursor, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
+            ClassicAssert.IsTrue(result.Count == 2);
+            ClassicAssert.IsTrue(refCursor.nextBoundaryCursor == null);
+            ClassicAssert.IsTrue(refCursor.pagingCursor == null);
+            ClassicAssert.IsTrue(new TimeRowCursor(m3, 3).Equals(refCursor.stopAtBoundary));
+            ClassicAssert.IsTrue(moreRows == false);
+
+            // Now add three more items
+            var f6 = SequentialGuid.CreateGuid();
+            var f7 = SequentialGuid.CreateGuid();
+            var f8 = SequentialGuid.CreateGuid();
+            await Task.Delay(2);
+            var (c6, m6) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            await Task.Delay(2);
+            var (c7, m7) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f7, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            await Task.Delay(2);
+            var (c8, m8) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f8, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            await Task.Delay(2);
+
+            // Now we get two of the three new items, we get the newest first f8 & f7
+            (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, refCursor, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
+            ClassicAssert.IsTrue(result.Count == 2);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[0].fileId, f8) == 0);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[1].fileId, f7) == 0);
+            ClassicAssert.IsTrue(new TimeRowCursor(m7, 7).Equals(refCursor.pagingCursor));
+            ClassicAssert.IsTrue(new TimeRowCursor(m3, 3).Equals(refCursor.stopAtBoundary));
+            ClassicAssert.IsTrue(new TimeRowCursor(m8, 8).Equals(refCursor.nextBoundaryCursor));
+            ClassicAssert.IsTrue(moreRows == true);
+
+
+            // Now add two more items
+            var f9 = SequentialGuid.CreateGuid();
+            var f10 = SequentialGuid.CreateGuid();
+            var (c9, m9) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f9, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c10, m10) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f10, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+
+            // Now we get two more items. Internally, this will turn into two QueryBatchRaw()
+            // because there is only 1 left in the previous range. A second request will get the
+            // next item. Leaving us with 1 left over. The order of the items will be newest first,
+            // so f10, f6. Note that you'll get a gap between {f8,f7,f6} and {f10,f9}, i.e. f9 still
+            // waiting for the next query
+            //
+            await Task.Delay(2); // Wait for the ms for QueryBatch()
+            (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, refCursor, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
+            ClassicAssert.IsTrue(result.Count == 2);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[0].fileId, f10) == 0);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[1].fileId, f6) == 0);
+            ClassicAssert.IsTrue(new TimeRowCursor(m10, 10).Equals(refCursor.pagingCursor));
+            ClassicAssert.IsTrue(new TimeRowCursor(m8, 8).Equals(refCursor.stopAtBoundary));
+            ClassicAssert.IsTrue(new TimeRowCursor(m10, 10).Equals(refCursor.nextBoundaryCursor));
+            ClassicAssert.IsTrue(moreRows == true);
+
+            // Now we get two more items, only one should be left (f9)
+            (result, moreRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, refCursor, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
+            ClassicAssert.IsTrue(result.Count == 1);
+            ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[0].fileId, f9) == 0);
+            ClassicAssert.IsTrue(moreRows == false);
+
+            ClassicAssert.IsTrue(refCursor.nextBoundaryCursor == null);
+            ClassicAssert.IsTrue(refCursor.pagingCursor == null);
+            ClassicAssert.IsTrue(new TimeRowCursor(c10, 10).Equals(refCursor.stopAtBoundary));
+        }
 
         [Test]
         [TestCase(DatabaseType.Sqlite)]
@@ -1109,9 +1243,9 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f2 = SequentialGuid.CreateGuid();
             var f3 = SequentialGuid.CreateGuid(); // Newest
 
-            var c1 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c3 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c3, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
 
             QueryBatchCursor cursor = null;
             var (result, hasRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, cursor, sortOrder: QueryBatchSortOrder.NewestFirst, requiredSecurityGroup: allIntRange);
@@ -1291,8 +1425,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f3 = SequentialGuid.CreateGuid(); // Newest
 
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
-            var c3 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c3, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f3, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
 
             QueryBatchCursor cursor = null;
             var (result, hasRows, refCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, cursor, sortOrder: QueryBatchSortOrder.OldestFirst, requiredSecurityGroup: allIntRange);
@@ -1417,15 +1551,15 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f5 = SequentialGuid.CreateGuid();
             var f6 = SequentialGuid.CreateGuid(); // Newest
 
-            var c1 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
             await Task.Delay(10);
             var c3 = UnixTimeUtc.Now();
             ClassicAssert.IsTrue(c1.milliseconds < c3.milliseconds);
             await Task.Delay(10);
-            var c4 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c6 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c4, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c6, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
             ClassicAssert.IsTrue(c4.milliseconds > c3.milliseconds);
 
             // Set the start point to f3 (which we didn't put in the DB)
@@ -1477,8 +1611,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f5 = SequentialGuid.CreateGuid();
             var f6 = SequentialGuid.CreateGuid(); // Newest
 
-            var c1 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
 
             Thread.Sleep(10);
             var t3 = UnixTimeUtc.Now();
@@ -1486,7 +1620,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
 
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c6 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c6, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
 
             // Set the start point to f3 (which we didn't put in the DB)
             var cursor = new QueryBatchCursor();
@@ -1598,14 +1732,14 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f5 = SequentialGuid.CreateGuid();
             var f6 = SequentialGuid.CreateGuid(); // Newest
 
-            var c1 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
             await Task.Delay(10);
             var c3 = UnixTimeUtc.Now();
             await Task.Delay(10);
-            var c4 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c6 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c4, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c6, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
 
             // Set the boundary item to f3 (which we didn't put in the DB)
             var cursor = new QueryBatchCursor(c3);
@@ -1666,14 +1800,14 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             var f5 = SequentialGuid.CreateGuid();
             var f6 = SequentialGuid.CreateGuid(); // Newest
 
-            var c1 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
-            var c2 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
+            var (c1, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f1, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 0, null, null, 1);
+            var (c2, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f2, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 1, null, null, 1);
             Thread.Sleep(10);
             var t3 = UnixTimeUtc.Now();
             Thread.Sleep(10);
-            var c4 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c5 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
-            var c6 = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c4, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c5, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
+            var (c6, _) = await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f6, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
 
             // Set the boundary item to f3 (which we didn't put in the DB)
             var cursor = new QueryBatchCursor(t3, false);
@@ -1742,6 +1876,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
 
+            await Task.Delay(2); // Wait a few ms for QB()
+
             var cursor = new QueryBatchCursor();
             var (result, moreRows, outCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 100, cursor, sortOrder: QueryBatchSortOrder.OldestFirst, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
             ClassicAssert.IsTrue(result.Count == 5); // Nothing in the DB should be modified
@@ -1787,6 +1923,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f4, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 2, null, null, 1);
             await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, f5, Guid.NewGuid(), 1, 1, s1, t1, null, 42, new UnixTimeUtc(0), 3, null, null, 1);
 
+            await Task.Delay(2);
 
             QueryBatchCursor cursor = null;
             var (result, moreRows, outCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 10, cursor, sortOrder: QueryBatchSortOrder.OldestFirst, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
@@ -1795,8 +1932,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
 
 
             // Modify one item make sure we get it first.
-            await Task.Delay(1);
             await tblDriveMainIndex.TestTouchAsync(driveId, f2);
+            await Task.Delay(2);
             (result, moreRows, outCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 2, outCursor, sortOrder: QueryBatchSortOrder.OldestFirst, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
             ClassicAssert.IsTrue(result.Count == 1);
             ClassicAssert.IsTrue(ByteArrayUtil.muidcmp(result[0].fileId, f2) == 0);
@@ -1918,6 +2055,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             await tblDriveMainIndex.TestTouchAsync(driveId, f4);
             await tblDriveMainIndex.TestTouchAsync(driveId, f5);
 
+            await Task.Delay(2);
             outCursor = null;
             (result, moreRows, outCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 400, inCursor, sortOrder: QueryBatchSortOrder.OldestFirst, sortField: QueryBatchSortField.AnyChangeDate, requiredSecurityGroup: allIntRange);
             ClassicAssert.IsTrue(result.Count == 5); // Ensure everything is now "modified"
@@ -2222,6 +2360,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             await tblDriveMainIndex.TestTouchAsync(driveId, f4);
             await tblDriveMainIndex.TestTouchAsync(driveId, f5);
 
+            await Task.Delay(2);
+
             // ===== TEST RSG, no circles
 
             // ACL: Any security group, no circles. We should have 5 entries
@@ -2515,6 +2655,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             QueryBatchCursor inCursor = null;
             QueryBatchCursor outCursor = null;
             await tblDriveMainIndex.TestTouchAsync(driveId, f1); // Make sure we can find it
+            await Task.Delay(5); // Wait a few ms for QB / modified
             (result, moreRows, outCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 1, inCursor, sortOrder: QueryBatchSortOrder.OldestFirst, sortField: QueryBatchSortField.AnyChangeDate, globalTransitIdAnyOf: new List<Guid>() { t1, g1 }, requiredSecurityGroup: allIntRange);
             ClassicAssert.IsTrue(result.Count == 1);
             ClassicAssert.IsTrue(moreRows == false);
@@ -2740,6 +2881,8 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             QueryBatchCursor inCursor = null;
             QueryBatchCursor outCursor = null;
             await tblDriveMainIndex.TestTouchAsync(driveId, f1); // Make sure we can find it
+
+            await Task.Delay(2);
 
             (result, moreRows, outCursor) = await metaIndex.QueryBatchSmartCursorAsync(driveId, 1, inCursor, sortOrder: QueryBatchSortOrder.OldestFirst, sortField: QueryBatchSortField.AnyChangeDate, uniqueIdAnyOf: new List<Guid>() { t1, u1 }, requiredSecurityGroup: allIntRange); 
             ClassicAssert.IsTrue(result.Count == 1);

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableMainIndexTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableMainIndexTests.cs
@@ -37,14 +37,14 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             var r = await tblDriveMainIndex.GetAsync(driveId, f1);
             var s = r.hdrReactionSummary;
             var m = r.modified;
-            ClassicAssert.IsTrue(m == null);
+            ClassicAssert.IsTrue(m == r.created);
 
             var s2 = "a new summary";
             await tblDriveMainIndex.UpdateReactionSummaryAsync(driveId, f1, s2);
             var r2 = await tblDriveMainIndex.GetAsync(driveId, f1);
             var m2 = r2.modified;
             ClassicAssert.IsTrue(r2.hdrReactionSummary == s2);
-            ClassicAssert.IsTrue(m2 != null);
+            ClassicAssert.IsTrue(m2 != r2.created);
         }
 
         [Test]
@@ -70,14 +70,14 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             var r = await tblDriveMainIndex.GetAsync(driveId, f1);
             var s = r.hdrTransferHistory;
             var m = r.modified;
-            ClassicAssert.IsTrue(m == null);
+            ClassicAssert.IsTrue(m == r.created);
 
             var s2 = "a new transfer status";
             var (count, modified) = await tblDriveMainIndex.UpdateTransferSummaryAsync(driveId, f1, s2);
             var r2 = await tblDriveMainIndex.GetAsync(driveId, f1);
             var m2 = r2.modified;
             ClassicAssert.IsTrue(r2.hdrTransferHistory == s2);
-            ClassicAssert.IsTrue(m2 != null);
+            ClassicAssert.IsTrue(m2 != r2.created);
         }
 
         [Test]
@@ -224,7 +224,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
 
             // The SQL clock is not necessarily precisely the same as the C# clock. Proven empirically...
 
-            ClassicAssert.IsTrue(rec.modified == null);
+            ClassicAssert.IsTrue(rec.modified == rec.created);
             ClassicAssert.IsTrue(rec.created.AddSeconds(+1) >= cts1);
             ClassicAssert.IsTrue(rec.created.AddSeconds(-1) <= cts2);
 
@@ -238,7 +238,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
 
             ClassicAssert.IsTrue((md.created.AddSeconds(1) >= cts1) && (md.created.AddSeconds(-1) <= cts2));
 
-            if (md.modified != null)
+            if (md.modified != md.created)
                 Assert.Fail();
 
             if (md.fileType != 7)
@@ -396,7 +396,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             });
 
             var md = await tblDriveMainIndex.GetAsync(driveId, k1);
-            if (md.modified != null)
+            if (md.modified != md.created)
                 Assert.Fail();
 
             md.fileType = 8;
@@ -529,7 +529,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             // Retrieve the record and verify
             var md = await tblDriveMainIndex.GetAsync(driveId, k1);
             ClassicAssert.IsNotNull(md, "Retrieved record is null");
-            ClassicAssert.IsNull(md.modified, "Retrieved record should not have 'modified' set");
+            ClassicAssert.IsTrue(md.modified == md.created, "Retrieved record should not have 'modified' set");
 
             // Validate all fields match between ndr and md
             ClassicAssert.AreEqual(ndr.driveId, md.driveId, "DriveId mismatch");
@@ -676,7 +676,7 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             // Retrieve the record and verify
             var md = await tblDriveMainIndex.GetAsync(driveId, k1);
             ClassicAssert.IsNotNull(md, "Retrieved record is null");
-            ClassicAssert.IsNull(md.modified, "Retrieved record should not have 'modified' set");
+            ClassicAssert.IsTrue(md.modified == md.created, "Retrieved record should not have 'modified' set");
 
             // Validate all fields match between ndr and md
             ClassicAssert.AreEqual(ndr.driveId, md.driveId, "DriveId mismatch");


### PR DESCRIPTION
Here are the changes that make modified a NOT NULL value. (modified = created means the item is created, not modified).

Improves speed of QB(), COALESCE no longer needed.

This database upgrade will be required:

// Only if Todd merges before this
// UPDATE DriveDefinitions SET modified = created WHERE modified IS NULL;
// ALTER TABLE DriveDefinitions ALTER COLUMN modified SET NOT NULL;

UPDATE DriveMainIndex SET modified = created WHERE modified IS NULL;
ALTER TABLE DriveMainIndex ALTER COLUMN modified SET NOT NULL;

UPDATE AppNotifications SET modified = created WHERE modified IS NULL;
ALTER TABLE AppNotifications ALTER COLUMN modified SET NOT NULL;

UPDATE Connections SET modified = created WHERE modified IS NULL;
ALTER TABLE Connections ALTER COLUMN modified SET NOT NULL;

UPDATE ImFollowing SET modified = created WHERE modified IS NULL;
ALTER TABLE ImFollowing ALTER COLUMN modified SET NOT NULL;

UPDATE FollowsMe SET modified = created WHERE modified IS NULL;
ALTER TABLE FollowsMe ALTER COLUMN modified SET NOT NULL;

UPDATE Inbox SET modified = created WHERE modified IS NULL;
ALTER TABLE Inbox ALTER COLUMN modified SET NOT NULL;

UPDATE Outbox SET modified = created WHERE modified IS NULL;
ALTER TABLE Outbox ALTER COLUMN modified SET NOT NULL;

UPDATE Jobs SET modified = created WHERE modified IS NULL;
ALTER TABLE Jobs ALTER COLUMN modified SET NOT NULL;