### PR TITLE
V2 transfer history: return read-receipt timestamp instead of boolean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,29 @@ Test framework is **NUnit** across 10 test projects (~2,000+ tests total). Tests
 
 **Note:** `dotnet test` CLI runs in NUnit "Non-Explicit" mode, which excludes `[Explicit]` tests. The CLI total will be lower than Visual Studio Test Explorer's count. This is expected — not missing tests.
 
+### Writing Integration Tests (Odin.Hosting.Tests)
+
+Two test infrastructures exist side by side:
+
+- **`_Universal/`** -- V1 API tests. Uses `OwnerApiClientRedux` which bundles all clients (`DriveRedux`, `Connections`, `DriveManager`) with helpers like `WaitForEmptyOutbox()`, `ProcessInbox()`, `SendReadReceipt()`. Peer-to-peer flows (transfers, read receipts, reactions) are well-supported here.
+
+- **`_V2/`** -- V2 API tests. Uses separate `DriveReaderV2Client` and `DriveWriterV2Client`. These require manual construction:
+  1. Create an `OwnerTestCase(targetDrive)` (or `AppTestCase`, `GuestTestCase`)
+  2. Call `await callerContext.Initialize(ownerApiClient)` -- **must be called before `GetFactory()`**
+  3. Create client: `new DriveReaderV2Client(identity.OdinId, callerContext.GetFactory())`
+
+  V2 clients lack outbox/inbox helpers. For peer-to-peer flows in V2 tests, fall back to `OwnerApiClientRedux.DriveRedux` for `WaitForEmptyOutbox()`, `ProcessInbox()`, and `SendReadReceipt()`, or add the test to an existing `_Universal/` test class where the infrastructure works.
+
+**Peer file transfer pattern** (for tests that send files between identities):
+1. Create drives on both sender and recipient with the same `TargetDrive`
+2. Create a circle on the recipient granting `DrivePermission.Write` on the target drive
+3. Connect: sender sends connection request, recipient accepts into the circle
+4. Upload with `TransitOptions { Recipients = [...], AllowDistribution = true }`
+5. `WaitForEmptyOutbox()` on sender, then `ProcessInbox()` on recipient
+6. Find recipient's copy via `QueryByGlobalTransitId(uploadResult.GlobalTransitIdFileIdentifier)` -- the recipient has a **different FileId** than the sender
+
+**Test identities**: `TestIdentities.Frodo`, `TestIdentities.Samwise`, etc. Each `WebScaffold` instance runs its own server. Test classes that need peer flows must include at least two identities in `RunBeforeAnyTests()`.
+
 ## Architecture
 
 ### Layer Structure

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/FileTransferHistoryResponseV2.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/FileTransferHistoryResponseV2.cs
@@ -1,0 +1,16 @@
+using System.Linq;
+using Odin.Core;
+using Odin.Core.Identity;
+
+namespace Odin.Hosting.UnifiedV2.Drive.Read;
+
+public class FileTransferHistoryResponseV2
+{
+    public int OriginalRecipientCount { get; set; }
+    public PagedResult<RecipientTransferHistoryItemV2> History { get; set; }
+
+    public RecipientTransferHistoryItemV2 GetHistoryItem(OdinId recipient)
+    {
+        return this.History?.Results.SingleOrDefault(h => h.Recipient == recipient);
+    }
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/RecipientTransferHistoryItemV2.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/RecipientTransferHistoryItemV2.cs
@@ -8,13 +8,13 @@ namespace Odin.Hosting.UnifiedV2.Drive.Read;
 public class RecipientTransferHistoryItemV2
 {
     public OdinId Recipient { get; init; }
-    public UnixTimeUtc LastUpdated { get; set; }
-    public LatestTransferStatus LatestTransferStatus { get; set; }
-    public bool IsInOutbox { get; set; }
-    public Guid? LatestSuccessfullyDeliveredVersionTag { get; set; }
+    public UnixTimeUtc LastUpdated { get; init; }
+    public LatestTransferStatus LatestTransferStatus { get; init; }
+    public bool IsInOutbox { get; init; }
+    public Guid? LatestSuccessfullyDeliveredVersionTag { get; init; }
 
     /// <summary>
     /// Timestamp (Unix epoch milliseconds) when the recipient read the file, or null if not read.
     /// </summary>
-    public long? IsReadByRecipient { get; set; }
+    public long? ReadByRecipientTimestamp { get; init; }
 }

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/RecipientTransferHistoryItemV2.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/RecipientTransferHistoryItemV2.cs
@@ -1,0 +1,20 @@
+using System;
+using Odin.Core.Identity;
+using Odin.Core.Time;
+using Odin.Services.Drives.DriveCore.Storage;
+
+namespace Odin.Hosting.UnifiedV2.Drive.Read;
+
+public class RecipientTransferHistoryItemV2
+{
+    public OdinId Recipient { get; init; }
+    public UnixTimeUtc LastUpdated { get; set; }
+    public LatestTransferStatus LatestTransferStatus { get; set; }
+    public bool IsInOutbox { get; set; }
+    public Guid? LatestSuccessfullyDeliveredVersionTag { get; set; }
+
+    /// <summary>
+    /// Timestamp (Unix epoch milliseconds) when the recipient read the file, or null if not read.
+    /// </summary>
+    public long? IsReadByRecipient { get; set; }
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DriveFileReadonlyController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DriveFileReadonlyController.cs
@@ -167,7 +167,7 @@ namespace Odin.Hosting.UnifiedV2.Drive.Read
                 LatestTransferStatus = item.LatestTransferStatus,
                 IsInOutbox = item.IsInOutbox,
                 LatestSuccessfullyDeliveredVersionTag = item.LatestSuccessfullyDeliveredVersionTag,
-                IsReadByRecipient = item.ReadByRecipientTimestampMs
+                IsReadByRecipient = item.ReadByRecipientTimestampMs > 0 ? item.ReadByRecipientTimestampMs : null
             }).ToList();
 
             return new FileTransferHistoryResponseV2()

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DriveFileReadonlyController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DriveFileReadonlyController.cs
@@ -167,7 +167,7 @@ namespace Odin.Hosting.UnifiedV2.Drive.Read
                 LatestTransferStatus = item.LatestTransferStatus,
                 IsInOutbox = item.IsInOutbox,
                 LatestSuccessfullyDeliveredVersionTag = item.LatestSuccessfullyDeliveredVersionTag,
-                IsReadByRecipient = item.ReadByRecipientTimestampMs > 0 ? item.ReadByRecipientTimestampMs : null
+                ReadByRecipientTimestamp = item.ReadByRecipientTimestampMs > 0 ? item.ReadByRecipientTimestampMs : null
             }).ToList();
 
             return new FileTransferHistoryResponseV2()

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DriveFileReadonlyController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DriveFileReadonlyController.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Odin.Core;
 using Odin.Hosting.Controllers.Base.Drive;
 using Odin.Hosting.UnifiedV2.Authentication.Policy;
 using Odin.Services.Drives;
@@ -138,7 +140,7 @@ namespace Odin.Hosting.UnifiedV2.Drive.Read
 
         [HttpGet("transfer-history")]
         [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
-        public async Task<FileTransferHistoryResponse> GetFileTransferHistory(
+        public async Task<FileTransferHistoryResponseV2> GetFileTransferHistory(
             [FromRoute] Guid driveId,
             [FromRoute] Guid fileId)
         {
@@ -158,10 +160,21 @@ namespace Odin.Hosting.UnifiedV2.Drive.Read
                 return null;
             }
 
-            return new FileTransferHistoryResponse()
+            var v2Items = history.Results.Select(item => new RecipientTransferHistoryItemV2
+            {
+                Recipient = item.Recipient,
+                LastUpdated = item.LastUpdated,
+                LatestTransferStatus = item.LatestTransferStatus,
+                IsInOutbox = item.IsInOutbox,
+                LatestSuccessfullyDeliveredVersionTag = item.LatestSuccessfullyDeliveredVersionTag,
+                IsReadByRecipient = item.ReadByRecipientTimestampMs
+            }).ToList();
+
+            return new FileTransferHistoryResponseV2()
             {
                 OriginalRecipientCount = count,
-                History = history
+                History = new PagedResult<RecipientTransferHistoryItemV2>(
+                    history.Request, history.TotalPages, v2Items)
             };
         }
 

--- a/src/core/Odin.Core.Storage/Database/Identity/Migrations/TableDriveTransferHistoryMigrationList.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Migrations/TableDriveTransferHistoryMigrationList.cs
@@ -9,6 +9,7 @@ public class TableDriveTransferHistoryMigrationList : MigrationListBase
     {
         Migrations = new List<MigrationBase>() {
             new TableDriveTransferHistoryMigrationV0(-1),
+            new TableDriveTransferHistoryMigrationV202604050941(0),
             // AUTO-INSERT-MARKER
         };
     }

--- a/src/core/Odin.Core.Storage/Database/Identity/Migrations/TableDriveTransferHistoryMigrationV202604050941.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Migrations/TableDriveTransferHistoryMigrationV202604050941.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Odin.Core.Time;
+using Odin.Core.Util;
+using Odin.Core.Storage;
+using Odin.Core.Storage.Database;
+using Odin.Core.Storage.Factory;
+using Odin.Core.Storage.Database.Identity.Connection;
+
+#nullable disable
+
+// THIS FILE WAS INITIALLY AUTO GENERATED
+
+namespace Odin.Core.Storage.Database.Identity.Migrations
+{
+    public class TableDriveTransferHistoryMigrationV202604050941 : MigrationBase
+    {
+        public override Int64 MigrationVersion => 202604050941;
+        public TableDriveTransferHistoryMigrationV202604050941(Int64 previousVersion) : base(previousVersion)
+        {
+        }
+
+        public override async Task CreateTableWithCommentAsync(IConnectionWrapper cn)
+        {
+            var rowid = "";
+            var commentSql = "";
+            if (cn.DatabaseType == DatabaseType.Postgres)
+            {
+               rowid = "rowId BIGSERIAL PRIMARY KEY,";
+               commentSql = "COMMENT ON TABLE DriveTransferHistoryMigrationsV202604050941 IS '{ \"Version\": 202604050941 }';";
+            }
+            else
+               rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
+            var wori = "";
+            string createSql =
+                "CREATE TABLE IF NOT EXISTS DriveTransferHistoryMigrationsV202604050941( -- { \"Version\": 202604050941 }\n"
+                   +rowid
+                   +"identityId BYTEA NOT NULL, "
+                   +"driveId BYTEA NOT NULL, "
+                   +"fileId BYTEA NOT NULL, "
+                   +"remoteIdentityId TEXT NOT NULL, "
+                   +"latestTransferStatus BIGINT NOT NULL, "
+                   +"isInOutbox BOOLEAN NOT NULL, "
+                   +"latestSuccessfullyDeliveredVersionTag BYTEA , "
+                   +"isReadByRecipient BIGINT NOT NULL "
+                   +", UNIQUE(identityId,driveId,fileId,remoteIdentityId)"
+                   +$"){wori};"
+                   +"CREATE INDEX IF NOT EXISTS Idx0DriveTransferHistoryMigrationsV202604050941 ON DriveTransferHistoryMigrationsV202604050941(identityId,driveId,fileId);"
+                   ;
+            await SqlHelper.CreateTableWithCommentAsync(cn, "DriveTransferHistoryMigrationsV202604050941", createSql, commentSql);
+        }
+
+        public new static List<string> GetColumnNames()
+        {
+            var sl = new List<string>();
+            sl.Add("rowId");
+            sl.Add("identityId");
+            sl.Add("driveId");
+            sl.Add("fileId");
+            sl.Add("remoteIdentityId");
+            sl.Add("latestTransferStatus");
+            sl.Add("isInOutbox");
+            sl.Add("latestSuccessfullyDeliveredVersionTag");
+            sl.Add("isReadByRecipient");
+            return sl;
+        }
+
+        public async Task<int> CopyDataAsync(IConnectionWrapper cn)
+        {
+            await CheckSqlTableVersion(cn, "DriveTransferHistoryMigrationsV202604050941", MigrationVersion);
+            await CheckSqlTableVersion(cn, "DriveTransferHistory", PreviousVersion);
+            var nowMs = UnixTimeUtc.Now().milliseconds;
+            await using var copyCommand = cn.CreateCommand();
+            {
+                copyCommand.CommandText = "INSERT INTO DriveTransferHistoryMigrationsV202604050941 (rowId,identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient) " +
+               $"SELECT rowId,identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag," +
+               $"CASE WHEN isReadByRecipient = 1 THEN {nowMs} ELSE 0 END "+
+               $"FROM DriveTransferHistory;";
+               return await copyCommand.ExecuteNonQueryAsync();
+            }
+        }
+
+        // Will upgrade from the previous version to version 202604050941
+        public override async Task UpAsync(IConnectionWrapper cn)
+        {
+            await CheckSqlTableVersion(cn, "DriveTransferHistory", PreviousVersion);
+            try
+            {
+                using (var trn = await cn.BeginStackedTransactionAsync())
+                {
+                    await CreateTableWithCommentAsync(cn);
+                    await CheckSqlTableVersion(cn, "DriveTransferHistoryMigrationsV202604050941", MigrationVersion);
+                    if (await CopyDataAsync(cn) < 0)
+                        throw new MigrationException("Unable to copy the data");
+                    if (await VerifyRowCount(cn, "DriveTransferHistory", "DriveTransferHistoryMigrationsV202604050941") == false)
+                        throw new MigrationException("Mismatching row counts");
+                    await SqlHelper.RenameAsync(cn, "DriveTransferHistory", $"DriveTransferHistoryMigrationsV{PreviousVersion}");
+                    await SqlHelper.RenameAsync(cn, "DriveTransferHistoryMigrationsV202604050941", "DriveTransferHistory");
+                    await CheckSqlTableVersion(cn, "DriveTransferHistory", MigrationVersion);
+                    trn.Commit();
+                }
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        public override async Task DownAsync(IConnectionWrapper cn)
+        {
+            await CheckSqlTableVersion(cn, "DriveTransferHistory", MigrationVersion);
+            try
+            {
+                using (var trn = await cn.BeginStackedTransactionAsync())
+                {
+                    if (await VerifyRowCount(cn, $"DriveTransferHistoryMigrationsV{PreviousVersion}", "DriveTransferHistory") == false)
+                        throw new MigrationException("Mismatching row counts - bad idea to downgrade");
+                    await SqlHelper.RenameAsync(cn, "DriveTransferHistory", "DriveTransferHistoryMigrationsV202604050941");
+                    await SqlHelper.RenameAsync(cn, $"DriveTransferHistoryMigrationsV{PreviousVersion}", "DriveTransferHistory");
+                    await CheckSqlTableVersion(cn, "DriveTransferHistory", PreviousVersion);
+                    trn.Commit();
+                }
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+    }
+}

--- a/src/core/Odin.Core.Storage/Database/Identity/Migrations/TableDriveTransferHistoryMigrationV202604050941.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Migrations/TableDriveTransferHistoryMigrationV202604050941.cs
@@ -78,7 +78,7 @@ namespace Odin.Core.Storage.Database.Identity.Migrations
             {
                 copyCommand.CommandText = "INSERT INTO DriveTransferHistoryMigrationsV202604050941 (rowId,identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag,isReadByRecipient) " +
                $"SELECT rowId,identityId,driveId,fileId,remoteIdentityId,latestTransferStatus,isInOutbox,latestSuccessfullyDeliveredVersionTag," +
-               $"CASE WHEN isReadByRecipient = 1 THEN {nowMs} ELSE 0 END "+
+               $"CASE WHEN isReadByRecipient THEN {nowMs} ELSE 0 END "+
                $"FROM DriveTransferHistory;";
                return await copyCommand.ExecuteNonQueryAsync();
             }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistory.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistory.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Odin.Core.Identity;
 using Odin.Core.Storage.Database.Identity.Connection;
+using Odin.Core.Time;
 
 namespace Odin.Core.Storage.Database.Identity.Table;
 
@@ -18,7 +19,7 @@ public class TableDriveTransferHistory(
         int? latestTransferStatus,
         Guid? latestSuccessfullyDeliveredVersionTag,
         bool? isInOutbox,
-        bool? isReadByRecipient)
+        Int64? readByRecipientTimestamp)
     {
         await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
         await using var tx = await cn.BeginStackedTransactionAsync();
@@ -44,10 +45,10 @@ public class TableDriveTransferHistory(
             parameters["@latestSuccessfullyDeliveredVersionTag"] = latestSuccessfullyDeliveredVersionTag.Value.ToByteArray();
         }
 
-        if (isReadByRecipient.HasValue)
+        if (readByRecipientTimestamp.HasValue)
         {
             updateFields.Add("isReadByRecipient = @isReadByRecipient");
-            parameters["@isReadByRecipient"] = isReadByRecipient.Value;
+            parameters["@isReadByRecipient"] = readByRecipientTimestamp.Value;
         }
 
         if (latestTransferStatus.HasValue)
@@ -128,7 +129,7 @@ public class TableDriveTransferHistory(
             latestTransferStatus = 0,
             isInOutbox = true,
             latestSuccessfullyDeliveredVersionTag = null,
-            isReadByRecipient = false
+            isReadByRecipient = new UnixTimeUtc(0)
         };
 
         return base.TryInsertAsync(item);

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveTransferHistoryCRUD.cs
@@ -29,7 +29,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
         public Int32 latestTransferStatus { get; set; }
         public Boolean isInOutbox { get; set; }
         public Guid? latestSuccessfullyDeliveredVersionTag { get; set; }
-        public Boolean isReadByRecipient { get; set; }
+        public UnixTimeUtc isReadByRecipient { get; set; }
         public void Validate()
         {
             identityId.AssertGuidNotEmpty("Guid parameter identityId cannot be set to Empty GUID.");
@@ -64,13 +64,13 @@ namespace Odin.Core.Storage.Database.Identity.Table
             if (cn.DatabaseType == DatabaseType.Postgres)
             {
                rowid = "rowId BIGSERIAL PRIMARY KEY,";
-               commentSql = "COMMENT ON TABLE DriveTransferHistory IS '{ \"Version\": 0 }';";
+               commentSql = "COMMENT ON TABLE DriveTransferHistory IS '{ \"Version\": 202604050941 }';";
             }
             else
                rowid = "rowId INTEGER PRIMARY KEY AUTOINCREMENT,";
             var wori = "";
             string createSql =
-                "CREATE TABLE IF NOT EXISTS DriveTransferHistory( -- { \"Version\": 0 }\n"
+                "CREATE TABLE IF NOT EXISTS DriveTransferHistory( -- { \"Version\": 202604050941 }\n"
                    +rowid
                    +"identityId BYTEA NOT NULL, "
                    +"driveId BYTEA NOT NULL, "
@@ -79,7 +79,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                    +"latestTransferStatus BIGINT NOT NULL, "
                    +"isInOutbox BOOLEAN NOT NULL, "
                    +"latestSuccessfullyDeliveredVersionTag BYTEA , "
-                   +"isReadByRecipient BOOLEAN NOT NULL "
+                   +"isReadByRecipient BIGINT NOT NULL "
                    +", UNIQUE(identityId,driveId,fileId,remoteIdentityId)"
                    +$"){wori};"
                    +"CREATE INDEX IF NOT EXISTS Idx0DriveTransferHistory ON DriveTransferHistory(identityId,driveId,fileId);"
@@ -104,7 +104,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 insertCommand.AddParameter("@latestTransferStatus", DbType.Int32, item.latestTransferStatus);
                 insertCommand.AddParameter("@isInOutbox", DbType.Boolean, item.isInOutbox);
                 insertCommand.AddParameter("@latestSuccessfullyDeliveredVersionTag", DbType.Binary, item.latestSuccessfullyDeliveredVersionTag);
-                insertCommand.AddParameter("@isReadByRecipient", DbType.Boolean, item.isReadByRecipient);
+                insertCommand.AddParameter("@isReadByRecipient", DbType.Int64, item.isReadByRecipient.milliseconds);
                 await using var rdr = await insertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
                 if (await rdr.ReadAsync())
                 {
@@ -132,7 +132,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 insertCommand.AddParameter("@latestTransferStatus", DbType.Int32, item.latestTransferStatus);
                 insertCommand.AddParameter("@isInOutbox", DbType.Boolean, item.isInOutbox);
                 insertCommand.AddParameter("@latestSuccessfullyDeliveredVersionTag", DbType.Binary, item.latestSuccessfullyDeliveredVersionTag);
-                insertCommand.AddParameter("@isReadByRecipient", DbType.Boolean, item.isReadByRecipient);
+                insertCommand.AddParameter("@isReadByRecipient", DbType.Int64, item.isReadByRecipient.milliseconds);
                 await using var rdr = await insertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
                 if (await rdr.ReadAsync())
                 {
@@ -161,7 +161,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 upsertCommand.AddParameter("@latestTransferStatus", DbType.Int32, item.latestTransferStatus);
                 upsertCommand.AddParameter("@isInOutbox", DbType.Boolean, item.isInOutbox);
                 upsertCommand.AddParameter("@latestSuccessfullyDeliveredVersionTag", DbType.Binary, item.latestSuccessfullyDeliveredVersionTag);
-                upsertCommand.AddParameter("@isReadByRecipient", DbType.Boolean, item.isReadByRecipient);
+                upsertCommand.AddParameter("@isReadByRecipient", DbType.Int64, item.isReadByRecipient.milliseconds);
                 await using var rdr = await upsertCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
                 if (await rdr.ReadAsync())
                 {
@@ -189,7 +189,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
                 updateCommand.AddParameter("@latestTransferStatus", DbType.Int32, item.latestTransferStatus);
                 updateCommand.AddParameter("@isInOutbox", DbType.Boolean, item.isInOutbox);
                 updateCommand.AddParameter("@latestSuccessfullyDeliveredVersionTag", DbType.Binary, item.latestSuccessfullyDeliveredVersionTag);
-                updateCommand.AddParameter("@isReadByRecipient", DbType.Boolean, item.isReadByRecipient);
+                updateCommand.AddParameter("@isReadByRecipient", DbType.Int64, item.isReadByRecipient.milliseconds);
                 await using var rdr = await updateCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
                 if (await rdr.ReadAsync())
                 {
@@ -263,7 +263,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.latestTransferStatus = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[5];
             item.isInOutbox = (rdr[6] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[6]);
             item.latestSuccessfullyDeliveredVersionTag = (rdr[7] == DBNull.Value) ? null : new Guid((byte[])rdr[7]);
-            item.isReadByRecipient = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[8]);
+            item.isReadByRecipient = (rdr[8] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[8]);
             return item;
        }
 
@@ -343,7 +343,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.latestTransferStatus = (rdr[1] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[1];
             item.isInOutbox = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[2]);
             item.latestSuccessfullyDeliveredVersionTag = (rdr[3] == DBNull.Value) ? null : new Guid((byte[])rdr[3]);
-            item.isReadByRecipient = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[4]);
+            item.isReadByRecipient = (rdr[4] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[4]);
             return item;
        }
 
@@ -390,7 +390,7 @@ namespace Odin.Core.Storage.Database.Identity.Table
             item.latestTransferStatus = (rdr[2] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : (int)(long)rdr[2];
             item.isInOutbox = (rdr[3] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[3]);
             item.latestSuccessfullyDeliveredVersionTag = (rdr[4] == DBNull.Value) ? null : new Guid((byte[])rdr[4]);
-            item.isReadByRecipient = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : Convert.ToBoolean(rdr[5]);
+            item.isReadByRecipient = (rdr[5] == DBNull.Value) ? throw new Exception("item is NULL, but set as NOT NULL") : new UnixTimeUtc((long)rdr[5]);
             return item;
        }
 

--- a/src/services/Odin.Services/Drives/DriveCore/Storage/LongTermStorageManager.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/LongTermStorageManager.cs
@@ -87,7 +87,7 @@ namespace Odin.Services.Drives.DriveCore.Storage
                     latestTransferStatus: null,
                     latestSuccessfullyDeliveredVersionTag: null,
                     isInOutbox: true,
-                    isReadByRecipient: null);
+                    readByRecipientTimestamp: null);
 
                 if (affectedRows != 1)
                 {
@@ -118,7 +118,7 @@ namespace Odin.Services.Drives.DriveCore.Storage
                 (int?)updateData.LatestTransferStatus,
                 updateData.VersionTag,
                 updateData.IsInOutbox,
-                updateData.IsReadByRecipient);
+                updateData.ReadByRecipientTimestamp);
 
             var (history, modified) = await UpdateTransferHistorySummary(driveId, fileId);
 
@@ -347,7 +347,7 @@ namespace Odin.Services.Drives.DriveCore.Storage
                     LatestTransferStatus = (LatestTransferStatus)item.latestTransferStatus,
                     IsInOutbox = item.isInOutbox,
                     LatestSuccessfullyDeliveredVersionTag = item.latestSuccessfullyDeliveredVersionTag,
-                    IsReadByRecipient = item.isReadByRecipient
+                    ReadByRecipientTimestampMs = item.isReadByRecipient.milliseconds
                 }
             ).ToList();
         }

--- a/src/services/Odin.Services/Drives/DriveCore/Storage/RecipientTransferHistory.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/RecipientTransferHistory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 using Odin.Core.Identity;
 using Odin.Core.Time;
 
@@ -39,9 +40,15 @@ public class RecipientTransferHistoryItem
     public Guid? LatestSuccessfullyDeliveredVersionTag { get; set; }
 
     /// <summary>
+    /// The timestamp (Unix epoch milliseconds) when the recipient read the file, 0 if not read.
+    /// </summary>
+    [JsonIgnore]
+    public long ReadByRecipientTimestampMs { get; set; }
+
+    /// <summary>
     /// Indicates the recipient replied that the file was read (as called by the app)
     /// </summary>
-    public bool IsReadByRecipient { get; set; }
+    public bool IsReadByRecipient => ReadByRecipientTimestampMs > 0;
 }
 
 public enum LatestTransferStatus

--- a/src/services/Odin.Services/Drives/DriveCore/Storage/RecipientTransferHistory.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/RecipientTransferHistory.cs
@@ -48,7 +48,11 @@ public class RecipientTransferHistoryItem
     /// <summary>
     /// Indicates the recipient replied that the file was read (as called by the app)
     /// </summary>
-    public bool IsReadByRecipient => ReadByRecipientTimestampMs > 0;
+    public bool IsReadByRecipient
+    {
+        get => ReadByRecipientTimestampMs > 0;
+        set => ReadByRecipientTimestampMs = value ? 1 : 0;
+    }
 }
 
 public enum LatestTransferStatus

--- a/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
@@ -876,13 +876,13 @@ namespace Odin.Services.Drives.FileSystem.Base
                 AssertValidFileSystemType(header.ServerMetadata);
 
                 _logger.LogDebug(
-                    "Updating transfer history success on file:{file} for recipient:{recipient} Version:{versionTag}\t Status:{status}\t IsInOutbox:{outbox}\t IsReadByRecipient: {isRead}",
+                    "Updating transfer history success on file:{file} for recipient:{recipient} Version:{versionTag}\t Status:{status}\t IsInOutbox:{outbox}\t ReadByRecipientTimestamp: {readTs}",
                     file,
                     recipient,
                     updateData.VersionTag,
                     updateData.LatestTransferStatus,
                     updateData.IsInOutbox,
-                    updateData.IsReadByRecipient);
+                    updateData.ReadByRecipientTimestamp);
 
                 await using (var tx = await db.BeginStackedTransactionAsync())
                 {

--- a/src/services/Odin.Services/Drives/FileSystem/Base/UpdateTransferHistoryData.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/UpdateTransferHistoryData.cs
@@ -11,11 +11,14 @@ public class UpdateTransferHistoryData
 
     public bool? IsInOutbox { get; set; }
 
-    public bool? IsReadByRecipient { get; set; }
+    /// <summary>
+    /// 0 = not read, positive value = read-at timestamp in milliseconds (UnixTimeUtc)
+    /// </summary>
+    public Int64? ReadByRecipientTimestamp { get; set; }
 
 
     public string ToDebug()
     {
-        return $"LatestTransferStatus: {LatestTransferStatus} VersionTag: {VersionTag} IsInOutbox: {IsInOutbox} IsReadByRecipient: {IsReadByRecipient}";
+        return $"LatestTransferStatus: {LatestTransferStatus} VersionTag: {VersionTag} IsInOutbox: {IsInOutbox} ReadByRecipientTimestamp: {ReadByRecipientTimestamp}";
     }
 }

--- a/src/services/Odin.Services/Peer/Incoming/Drive/Transfer/PeerFileWriter.cs
+++ b/src/services/Odin.Services/Peer/Incoming/Drive/Transfer/PeerFileWriter.cs
@@ -171,7 +171,7 @@ namespace Odin.Services.Peer.Incoming.Drive.Transfer
 
             var update = new UpdateTransferHistoryData()
             {
-                IsReadByRecipient = true,
+                ReadByRecipientTimestamp = UnixTimeUtc.Now().milliseconds,
                 IsInOutbox = false
             };
 

--- a/src/services/Odin.Services/Peer/Outgoing/Drive/Transfer/Outbox/OutboxWorkerBase.cs
+++ b/src/services/Odin.Services/Peer/Outgoing/Drive/Transfer/Outbox/OutboxWorkerBase.cs
@@ -215,7 +215,7 @@ public abstract class OutboxWorkerBase(
         var update = new UpdateTransferHistoryData()
         {
             IsInOutbox = false,
-            IsReadByRecipient = false,
+            ReadByRecipientTimestamp = 0,
             LatestTransferStatus = LatestTransferStatus.Delivered,
             VersionTag = versionTag
         };

--- a/tests/apps/Odin.Hosting.Tests/_Universal/Peer/TransferHistory/TransferHistoryTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/Peer/TransferHistory/TransferHistoryTests.cs
@@ -10,6 +10,8 @@ using Odin.Core;
 using Odin.Core.Time;
 using Odin.Hosting.Tests._Universal.ApiClient.Drive;
 using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Hosting.Tests._V2.ApiClient;
+using Odin.Hosting.Tests._V2.ApiClient.Factory;
 using Odin.Services.Apps;
 using Odin.Services.Authorization.Acl;
 using Odin.Services.Authorization.ExchangeGrants;
@@ -166,6 +168,69 @@ namespace Odin.Hosting.Tests._Universal.Peer.TransferHistory
             ClassicAssert.IsTrue(updatedFileResponse.IsSuccessStatusCode);
             var updatedFile = updatedFileResponse.Content;
             ClassicAssert.IsTrue(updatedFile.ServerMetadata.OriginalRecipientCount == transitOptions.Recipients.Count);
+
+            await this.DeleteScenario(senderOwnerClient, recipientOwnerClient);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(OwnerAllowed))]
+        public async Task V2TransferHistoryReturnsReadByRecipientTimestamp(IApiClientContext callerContext,
+            HttpStatusCode expectedStatusCode)
+        {
+            var senderOwnerClient = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+            var recipientOwnerClient = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Samwise);
+
+            const DrivePermission drivePermissions = DrivePermission.Write;
+            var targetDrive = callerContext.TargetDrive;
+            await PrepareScenario(senderOwnerClient, recipientOwnerClient, targetDrive, drivePermissions);
+
+            var transitOptions = new TransitOptions()
+            {
+                Recipients = [recipientOwnerClient.Identity.OdinId]
+            };
+
+            var (uploadResult, _, recipientFiles, _, _) =
+                await TransferEncryptedMetadata(senderOwnerClient, targetDrive, transitOptions);
+
+            // Create V2 reader for sender using owner auth
+            var senderToken = senderOwnerClient.GetTokenContext();
+            var v2Factory = new ApiClientFactoryV2("DI", senderToken.AuthenticationResult, senderToken.SharedSecret.GetKey());
+            var v2Reader = new DriveReaderV2Client(senderOwnerClient.Identity.OdinId, v2Factory);
+
+            // Before read receipt: V2 should return null
+            var beforeHistory = await v2Reader.GetTransferHistoryAsync(targetDrive.Alias, uploadResult.File.FileId);
+            ClassicAssert.IsTrue(beforeHistory.IsSuccessStatusCode);
+            var beforeItem = beforeHistory.Content.GetHistoryItem(recipientOwnerClient.Identity.OdinId);
+            ClassicAssert.IsNotNull(beforeItem);
+            ClassicAssert.IsNull(beforeItem.IsReadByRecipient, "V2 should return null before read receipt");
+
+            // Send read receipt
+            var recipientFile = recipientFiles.Single();
+            var client = _scaffold.CreateOwnerApiClientRedux(TestIdentities.InitializedIdentities[recipientFile.Key]);
+            var fileForReadReceipt = new ExternalFileIdentifier()
+            {
+                FileId = recipientFile.Value.FileId,
+                TargetDrive = recipientFile.Value.TargetDrive
+            };
+
+            var beforeTs = UnixTimeUtc.Now().milliseconds;
+            var sendResult = await client.DriveRedux.SendReadReceipt([fileForReadReceipt]);
+            ClassicAssert.IsTrue(sendResult.IsSuccessStatusCode);
+            await client.DriveRedux.WaitForEmptyOutbox(fileForReadReceipt.TargetDrive);
+            await senderOwnerClient.DriveRedux.ProcessInbox(targetDrive);
+            var afterTs = UnixTimeUtc.Now().milliseconds;
+
+            // After read receipt: V2 should return a positive timestamp
+            var afterHistory = await v2Reader.GetTransferHistoryAsync(targetDrive.Alias, uploadResult.File.FileId);
+            ClassicAssert.IsTrue(afterHistory.IsSuccessStatusCode);
+            var afterItem = afterHistory.Content.GetHistoryItem(recipientOwnerClient.Identity.OdinId);
+            ClassicAssert.IsNotNull(afterItem);
+            ClassicAssert.IsNotNull(afterItem.IsReadByRecipient, "V2 should return a timestamp after read receipt");
+            ClassicAssert.IsTrue(afterItem.IsReadByRecipient > 0, "Timestamp should be positive");
+            ClassicAssert.IsTrue(afterItem.IsReadByRecipient >= beforeTs,
+                $"Timestamp {afterItem.IsReadByRecipient} should be >= {beforeTs}");
+            ClassicAssert.IsTrue(afterItem.IsReadByRecipient <= afterTs,
+                $"Timestamp {afterItem.IsReadByRecipient} should be <= {afterTs}");
 
             await this.DeleteScenario(senderOwnerClient, recipientOwnerClient);
         }

--- a/tests/apps/Odin.Hosting.Tests/_Universal/Peer/TransferHistory/TransferHistoryTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/Peer/TransferHistory/TransferHistoryTests.cs
@@ -202,7 +202,7 @@ namespace Odin.Hosting.Tests._Universal.Peer.TransferHistory
             ClassicAssert.IsTrue(beforeHistory.IsSuccessStatusCode);
             var beforeItem = beforeHistory.Content.GetHistoryItem(recipientOwnerClient.Identity.OdinId);
             ClassicAssert.IsNotNull(beforeItem);
-            ClassicAssert.IsNull(beforeItem.IsReadByRecipient, "V2 should return null before read receipt");
+            ClassicAssert.IsNull(beforeItem.ReadByRecipientTimestamp, "V2 should return null before read receipt");
 
             // Send read receipt
             var recipientFile = recipientFiles.Single();
@@ -225,12 +225,12 @@ namespace Odin.Hosting.Tests._Universal.Peer.TransferHistory
             ClassicAssert.IsTrue(afterHistory.IsSuccessStatusCode);
             var afterItem = afterHistory.Content.GetHistoryItem(recipientOwnerClient.Identity.OdinId);
             ClassicAssert.IsNotNull(afterItem);
-            ClassicAssert.IsNotNull(afterItem.IsReadByRecipient, "V2 should return a timestamp after read receipt");
-            ClassicAssert.IsTrue(afterItem.IsReadByRecipient > 0, "Timestamp should be positive");
-            ClassicAssert.IsTrue(afterItem.IsReadByRecipient >= beforeTs,
-                $"Timestamp {afterItem.IsReadByRecipient} should be >= {beforeTs}");
-            ClassicAssert.IsTrue(afterItem.IsReadByRecipient <= afterTs,
-                $"Timestamp {afterItem.IsReadByRecipient} should be <= {afterTs}");
+            ClassicAssert.IsNotNull(afterItem.ReadByRecipientTimestamp, "V2 should return a timestamp after read receipt");
+            ClassicAssert.IsTrue(afterItem.ReadByRecipientTimestamp > 0, "Timestamp should be positive");
+            ClassicAssert.IsTrue(afterItem.ReadByRecipientTimestamp >= beforeTs,
+                $"Timestamp {afterItem.ReadByRecipientTimestamp} should be >= {beforeTs}");
+            ClassicAssert.IsTrue(afterItem.ReadByRecipientTimestamp <= afterTs,
+                $"Timestamp {afterItem.ReadByRecipientTimestamp} should be <= {afterTs}");
 
             await this.DeleteScenario(senderOwnerClient, recipientOwnerClient);
         }

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DriveReaderV2Client.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DriveReaderV2Client.cs
@@ -118,7 +118,7 @@ public class DriveReaderV2Client(OdinId identity, IApiClientFactory factory)
         return await svc.GetBatchCollection(request);
     }
 
-    public async Task<ApiResponse<FileTransferHistoryResponse>> GetTransferHistoryAsync(Guid driveId, Guid fileId,
+    public async Task<ApiResponse<FileTransferHistoryResponseV2>> GetTransferHistoryAsync(Guid driveId, Guid fileId,
         FileSystemType fileSystemType = FileSystemType.Standard)
     {
         var client = factory.CreateHttpClient(identity, out var sharedSecret);

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDriveReaderHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDriveReaderHttpClientApiV2.cs
@@ -2,8 +2,8 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Odin.Core.Storage;
-using Odin.Hosting.Controllers.Base.Drive;
 using Odin.Hosting.UnifiedV2;
+using Odin.Hosting.UnifiedV2.Drive.Read;
 using Odin.Services.Apps;
 using Refit;
 
@@ -47,6 +47,6 @@ public interface IDriveReaderHttpClientApiV2
         FileSystemType fileSystemType);
 
     [Get(Endpoint + "/transfer-history")]
-    Task<ApiResponse<FileTransferHistoryResponse>> GetTransferHistory([AliasAs("driveId:guid")] Guid driveId,
+    Task<ApiResponse<FileTransferHistoryResponseV2>> GetTransferHistory([AliasAs("driveId:guid")] Guid driveId,
         [AliasAs("fileId:guid")] Guid fileId, FileSystemType fileSystemType);
 }

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/Drive/DriveReaderTests/GetTransferHistoryTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/Drive/DriveReaderTests/GetTransferHistoryTests.cs
@@ -13,6 +13,7 @@ using Odin.Hosting.Tests._V2.ApiClient.TestCases;
 using Odin.Hosting.Tests.OwnerApi.ApiClient.Drive;
 using Odin.Services.Authorization.Acl;
 using Odin.Services.Drives;
+using Odin.Core.Time;
 using Odin.Services.Drives.DriveCore.Storage;
 using Odin.Services.Drives.FileSystem.Base.Upload;
 using Odin.Services.Peer.Outgoing.Drive;
@@ -104,6 +105,63 @@ public class GetTransferHistoryTests
         }
 
         await Cleanup(identity, recipients);
+    }
+
+    [Test]
+    public async Task GetTransferHistory_IsReadByRecipient_ReturnsTimestamp()
+    {
+        var senderIdentity = TestIdentities.Samwise;
+        var recipientIdentity = TestIdentities.Frodo;
+
+        var callerContext = new OwnerTestCase(TargetDrive.NewTargetDrive());
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(senderIdentity);
+
+        var metadata = SampleMetadataData.Create(fileType: 100);
+        metadata.AccessControlList = AccessControlList.Authenticated;
+        metadata.AllowDistribution = true;
+        var payload = SamplePayloadDefinitions.GetPayloadDefinitionWithThumbnail1();
+
+        List<TestIdentity> recipients = [recipientIdentity];
+        var uploadResult = await TransferFile(senderIdentity, metadata, payload, recipients, callerContext);
+
+        // Get transfer history before read receipt — IsReadByRecipient should be null
+        var readerClient = new DriveReaderV2Client(senderIdentity.OdinId, new OwnerTestCase(callerContext.TargetDrive).GetFactory());
+        await new OwnerTestCase(callerContext.TargetDrive).Initialize(ownerApiClient);
+        readerClient = new DriveReaderV2Client(senderIdentity.OdinId, new OwnerTestCase(callerContext.TargetDrive).GetFactory());
+
+        var file = uploadResult.File;
+        var beforeReadReceipt = await readerClient.GetTransferHistoryAsync(file.TargetDrive.Alias, file.FileId);
+        ClassicAssert.IsTrue(beforeReadReceipt.StatusCode == HttpStatusCode.OK);
+        var itemBefore = beforeReadReceipt.Content.GetHistoryItem(recipientIdentity.OdinId);
+        ClassicAssert.IsNotNull(itemBefore);
+        ClassicAssert.IsNull(itemBefore.IsReadByRecipient, "Should be null before read receipt");
+
+        // Sam sends a read receipt from Frodo's side
+        var recipientOwnerClient = _scaffold.CreateOwnerApiClientRedux(recipientIdentity);
+        var recipientWriterContext = new OwnerTestCase(callerContext.TargetDrive);
+        await recipientWriterContext.Initialize(recipientOwnerClient);
+        var writerClient = new DriveWriterV2Client(recipientIdentity.OdinId, recipientWriterContext.GetFactory());
+
+        var beforeTs = UnixTimeUtc.Now().milliseconds;
+        var sendResult = await writerClient.SendReadReceipt(callerContext.TargetDrive.Alias, [file.FileId]);
+        ClassicAssert.IsTrue(sendResult.IsSuccessStatusCode, $"SendReadReceipt failed: {sendResult.StatusCode}");
+
+        // Wait for outbox drain on recipient and process inbox on sender
+        await recipientOwnerClient.DriveRedux.WaitForEmptyOutbox(callerContext.TargetDrive);
+        await ownerApiClient.DriveRedux.ProcessInbox(callerContext.TargetDrive);
+        var afterTs = UnixTimeUtc.Now().milliseconds;
+
+        // Get transfer history after read receipt — IsReadByRecipient should be a positive timestamp
+        var afterReadReceipt = await readerClient.GetTransferHistoryAsync(file.TargetDrive.Alias, file.FileId);
+        ClassicAssert.IsTrue(afterReadReceipt.StatusCode == HttpStatusCode.OK);
+        var itemAfter = afterReadReceipt.Content.GetHistoryItem(recipientIdentity.OdinId);
+        ClassicAssert.IsNotNull(itemAfter);
+        ClassicAssert.IsNotNull(itemAfter.IsReadByRecipient, "Should be a timestamp after read receipt");
+        ClassicAssert.IsTrue(itemAfter.IsReadByRecipient > 0, "Timestamp should be positive");
+        ClassicAssert.IsTrue(itemAfter.IsReadByRecipient >= beforeTs, $"Timestamp {itemAfter.IsReadByRecipient} should be >= {beforeTs}");
+        ClassicAssert.IsTrue(itemAfter.IsReadByRecipient <= afterTs, $"Timestamp {itemAfter.IsReadByRecipient} should be <= {afterTs}");
+
+        await Cleanup(senderIdentity, recipients);
     }
 
     public async Task Cleanup(TestIdentity identity, List<TestIdentity> recipients)

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/Drive/DriveReaderTests/GetTransferHistoryTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/Drive/DriveReaderTests/GetTransferHistoryTests.cs
@@ -140,7 +140,7 @@ public class GetTransferHistoryTests
 
             // V2 returns IsReadByRecipient as long? (null = not read, positive = timestamp)
             // Before any read receipt, it should be null
-            ClassicAssert.IsNull(item.IsReadByRecipient,
+            ClassicAssert.IsNull(item.ReadByRecipientTimestamp,
                 "V2 IsReadByRecipient should be null for unread items (not false)");
         }
 

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/Drive/DriveReaderTests/GetTransferHistoryTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/Drive/DriveReaderTests/GetTransferHistoryTests.cs
@@ -13,7 +13,6 @@ using Odin.Hosting.Tests._V2.ApiClient.TestCases;
 using Odin.Hosting.Tests.OwnerApi.ApiClient.Drive;
 using Odin.Services.Authorization.Acl;
 using Odin.Services.Drives;
-using Odin.Core.Time;
 using Odin.Services.Drives.DriveCore.Storage;
 using Odin.Services.Drives.FileSystem.Base.Upload;
 using Odin.Services.Peer.Outgoing.Drive;
@@ -108,60 +107,44 @@ public class GetTransferHistoryTests
     }
 
     [Test]
-    public async Task GetTransferHistory_IsReadByRecipient_ReturnsTimestamp()
+    public async Task GetTransferHistory_IsReadByRecipient_ReturnsNullableTimestamp()
     {
-        var senderIdentity = TestIdentities.Samwise;
-        var recipientIdentity = TestIdentities.Frodo;
-
+        var identity = TestIdentities.Samwise;
         var callerContext = new OwnerTestCase(TargetDrive.NewTargetDrive());
-        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(senderIdentity);
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
 
         var metadata = SampleMetadataData.Create(fileType: 100);
         metadata.AccessControlList = AccessControlList.Authenticated;
         metadata.AllowDistribution = true;
         var payload = SamplePayloadDefinitions.GetPayloadDefinitionWithThumbnail1();
 
-        List<TestIdentity> recipients = [recipientIdentity];
-        var uploadResult = await TransferFile(senderIdentity, metadata, payload, recipients, callerContext);
+        List<TestIdentity> recipients = [TestIdentities.Frodo];
+        var uploadResult = await TransferFile(identity, metadata, payload, recipients, callerContext);
 
-        // Get transfer history before read receipt — IsReadByRecipient should be null
-        var readerClient = new DriveReaderV2Client(senderIdentity.OdinId, new OwnerTestCase(callerContext.TargetDrive).GetFactory());
-        await new OwnerTestCase(callerContext.TargetDrive).Initialize(ownerApiClient);
-        readerClient = new DriveReaderV2Client(senderIdentity.OdinId, new OwnerTestCase(callerContext.TargetDrive).GetFactory());
+        await callerContext.Initialize(ownerApiClient);
+        var client = new DriveReaderV2Client(identity.OdinId, callerContext.GetFactory());
 
         var file = uploadResult.File;
-        var beforeReadReceipt = await readerClient.GetTransferHistoryAsync(file.TargetDrive.Alias, file.FileId);
-        ClassicAssert.IsTrue(beforeReadReceipt.StatusCode == HttpStatusCode.OK);
-        var itemBefore = beforeReadReceipt.Content.GetHistoryItem(recipientIdentity.OdinId);
-        ClassicAssert.IsNotNull(itemBefore);
-        ClassicAssert.IsNull(itemBefore.IsReadByRecipient, "Should be null before read receipt");
+        var getTransferHistory = await client.GetTransferHistoryAsync(file.TargetDrive.Alias, file.FileId);
+        ClassicAssert.IsTrue(getTransferHistory.StatusCode == HttpStatusCode.OK);
 
-        // Sam sends a read receipt from Frodo's side
-        var recipientOwnerClient = _scaffold.CreateOwnerApiClientRedux(recipientIdentity);
-        var recipientWriterContext = new OwnerTestCase(callerContext.TargetDrive);
-        await recipientWriterContext.Initialize(recipientOwnerClient);
-        var writerClient = new DriveWriterV2Client(recipientIdentity.OdinId, recipientWriterContext.GetFactory());
+        var transferHistory = getTransferHistory.Content;
+        ClassicAssert.IsNotNull(transferHistory);
 
-        var beforeTs = UnixTimeUtc.Now().milliseconds;
-        var sendResult = await writerClient.SendReadReceipt(callerContext.TargetDrive.Alias, [file.FileId]);
-        ClassicAssert.IsTrue(sendResult.IsSuccessStatusCode, $"SendReadReceipt failed: {sendResult.StatusCode}");
+        foreach (var recipient in recipients)
+        {
+            var item = transferHistory.GetHistoryItem(recipient.OdinId);
+            ClassicAssert.IsNotNull(item);
+            ClassicAssert.IsTrue(item.LatestTransferStatus == LatestTransferStatus.Delivered,
+                $"actual status was {item.LatestTransferStatus}");
 
-        // Wait for outbox drain on recipient and process inbox on sender
-        await recipientOwnerClient.DriveRedux.WaitForEmptyOutbox(callerContext.TargetDrive);
-        await ownerApiClient.DriveRedux.ProcessInbox(callerContext.TargetDrive);
-        var afterTs = UnixTimeUtc.Now().milliseconds;
+            // V2 returns IsReadByRecipient as long? (null = not read, positive = timestamp)
+            // Before any read receipt, it should be null
+            ClassicAssert.IsNull(item.IsReadByRecipient,
+                "V2 IsReadByRecipient should be null for unread items (not false)");
+        }
 
-        // Get transfer history after read receipt — IsReadByRecipient should be a positive timestamp
-        var afterReadReceipt = await readerClient.GetTransferHistoryAsync(file.TargetDrive.Alias, file.FileId);
-        ClassicAssert.IsTrue(afterReadReceipt.StatusCode == HttpStatusCode.OK);
-        var itemAfter = afterReadReceipt.Content.GetHistoryItem(recipientIdentity.OdinId);
-        ClassicAssert.IsNotNull(itemAfter);
-        ClassicAssert.IsNotNull(itemAfter.IsReadByRecipient, "Should be a timestamp after read receipt");
-        ClassicAssert.IsTrue(itemAfter.IsReadByRecipient > 0, "Timestamp should be positive");
-        ClassicAssert.IsTrue(itemAfter.IsReadByRecipient >= beforeTs, $"Timestamp {itemAfter.IsReadByRecipient} should be >= {beforeTs}");
-        ClassicAssert.IsTrue(itemAfter.IsReadByRecipient <= afterTs, $"Timestamp {itemAfter.IsReadByRecipient} should be <= {afterTs}");
-
-        await Cleanup(senderIdentity, recipients);
+        await Cleanup(identity, recipients);
     }
 
     public async Task Cleanup(TestIdentity identity, List<TestIdentity> recipients)

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableTransferHistoryTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableTransferHistoryTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework.Legacy;
 using Odin.Core.Identity;
 using Odin.Core.Storage.Database.Identity.Table;
 using Odin.Core.Storage.Factory;
+using Odin.Core.Time;
 
 namespace Odin.Core.Storage.Tests.Database.Identity.Table
 {
@@ -62,16 +63,17 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             r = await tbl.GetAsync(d1, f1);
             ClassicAssert.IsTrue(r[0].isInOutbox == false);
 
-            // IsInOutbox
-            n = await tbl.UpdateTransferHistoryRecordAsync(d1, f1, frodoId, null, null, null, isReadByRecipient: true);
+            // IsReadByRecipient (now a timestamp: 0 = not read, >0 = read-at ms)
+            var readAtMs = UnixTimeUtc.Now().milliseconds;
+            n = await tbl.UpdateTransferHistoryRecordAsync(d1, f1, frodoId, null, null, null, readByRecipientTimestamp: readAtMs);
             ClassicAssert.IsTrue(n == 1);
             r = await tbl.GetAsync(d1, f1);
-            ClassicAssert.IsTrue(r[0].isReadByRecipient == true);
+            ClassicAssert.IsTrue(r[0].isReadByRecipient.milliseconds == readAtMs);
 
-            n = await tbl.UpdateTransferHistoryRecordAsync(d1, f1, frodoId, null, null, null, isReadByRecipient: false);
+            n = await tbl.UpdateTransferHistoryRecordAsync(d1, f1, frodoId, null, null, null, readByRecipientTimestamp: 0);
             ClassicAssert.IsTrue(n == 1);
             r = await tbl.GetAsync(d1, f1);
-            ClassicAssert.IsTrue(r[0].isReadByRecipient == false);
+            ClassicAssert.IsTrue(r[0].isReadByRecipient.milliseconds == 0);
 
             // LatestTransferStatus
             n = await tbl.UpdateTransferHistoryRecordAsync(d1, f1, frodoId, latestTransferStatus: 42, null, null, null);
@@ -108,9 +110,9 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Table
             var rid2 = new OdinId("sam.gamgee.me");
             var rid3 = new OdinId("gandalf.white.me");
 
-            await tbl.InsertAsync(new DriveTransferHistoryRecord() { driveId = driveId, fileId = f1, remoteIdentityId = rid1, latestTransferStatus = 1, isInOutbox = false, isReadByRecipient = false, latestSuccessfullyDeliveredVersionTag = null });
-            await tbl.InsertAsync(new DriveTransferHistoryRecord() { driveId = driveId, fileId = f2, remoteIdentityId = rid2, latestTransferStatus = 2, isInOutbox = false, isReadByRecipient = false, latestSuccessfullyDeliveredVersionTag = null });
-            await tbl.InsertAsync(new DriveTransferHistoryRecord() { driveId = driveId, fileId = f3, remoteIdentityId = rid3, latestTransferStatus = 3, isInOutbox = false, isReadByRecipient = false, latestSuccessfullyDeliveredVersionTag = null });
+            await tbl.InsertAsync(new DriveTransferHistoryRecord() { driveId = driveId, fileId = f1, remoteIdentityId = rid1, latestTransferStatus = 1, isInOutbox = false, isReadByRecipient = new UnixTimeUtc(0), latestSuccessfullyDeliveredVersionTag = null });
+            await tbl.InsertAsync(new DriveTransferHistoryRecord() { driveId = driveId, fileId = f2, remoteIdentityId = rid2, latestTransferStatus = 2, isInOutbox = false, isReadByRecipient = new UnixTimeUtc(0), latestSuccessfullyDeliveredVersionTag = null });
+            await tbl.InsertAsync(new DriveTransferHistoryRecord() { driveId = driveId, fileId = f3, remoteIdentityId = rid3, latestTransferStatus = 3, isInOutbox = false, isReadByRecipient = new UnixTimeUtc(0), latestSuccessfullyDeliveredVersionTag = null });
 
             var (page1, cursor1) = await tbl.PagingByRowIdAsync(2, null);
             Assert.That(page1.Count, Is.EqualTo(2));


### PR DESCRIPTION
Migrate DB isReadByRecipient from BOOLEAN to BIGINT (Unix epoch ms) in the database, and expose the raw timestamp through the V2 API endpoint while keeping V1 unchanged (still returns bool).

- Add DB migration V202604050941 to convert column type
- Change UpdateTransferHistoryData to use Int64? ReadByRecipientTimestamp
- Add V2-specific DTOs (RecipientTransferHistoryItemV2, FileTransferHistoryResponseV2) where IsReadByRecipient is long? instead of bool
- Use computed getter + [JsonIgnore] on shared DTO to prevent timestamp leaking into V1 responses
- Add V2 integration test asserting timestamp semantics