### PR TITLE
Include firebaseDeviceToken in GET /notify/push/subscription response

### DIFF
--- a/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2AppPushNotificationController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2AppPushNotificationController.cs
@@ -1,10 +1,8 @@
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Odin.Hosting.Controllers.Base.Notifications;
 using Odin.Hosting.UnifiedV2.Authentication.Policy;
 using Odin.Services.AppNotifications.Push;
-using Odin.Services.Base;
 
 namespace Odin.Hosting.UnifiedV2.Notifications
 {
@@ -17,20 +15,5 @@ namespace Odin.Hosting.UnifiedV2.Notifications
         ILoggerFactory loggerFactory)
         : PushNotificationControllerBase(notificationService, loggerFactory)
     {
-        /// <summary>
-        /// Returns the current device's push notification subscription including the Firebase device token.
-        /// Returns 404 if no subscription exists; use this to verify whether a push notification token is registered.
-        /// </summary>
-        [HttpGet("subscription")]
-        public override async Task<IActionResult> GetSubscriptionDetails()
-        {
-            var subscription = await NotificationService.GetDeviceSubscriptionAsync(WebOdinContext);
-            if (subscription == null)
-            {
-                return NotFound();
-            }
-
-            return new JsonResult(subscription.RedactedV2());
-        }
     }
 }

--- a/src/services/Odin.Services/AppNotifications/Push/PushNotificationSubscription.cs
+++ b/src/services/Odin.Services/AppNotifications/Push/PushNotificationSubscription.cs
@@ -26,20 +26,10 @@ public class PushNotificationSubscription
             AccessRegistrationId = this.AccessRegistrationId,
             SubscriptionStartedDate = this.SubscriptionStartedDate,
             ExpirationTime = this.ExpirationTime,
-        };
-    }
-
-    public RedactedPushNotificationSubscriptionV2 RedactedV2()
-    {
-        return new RedactedPushNotificationSubscriptionV2()
-        {
-            FriendlyName = this.FriendlyName,
-            AccessRegistrationId = this.AccessRegistrationId,
-            SubscriptionStartedDate = this.SubscriptionStartedDate,
-            ExpirationTime = this.ExpirationTime,
             FirebaseDeviceToken = this.FirebaseDeviceToken,
         };
     }
+
 }
 
 public class RedactedPushNotificationSubscription
@@ -50,9 +40,6 @@ public class RedactedPushNotificationSubscription
 
     public UnixTimeUtc ExpirationTime { get; set; }
     public UnixTimeUtc SubscriptionStartedDate { get; set; }
-}
 
-public class RedactedPushNotificationSubscriptionV2 : RedactedPushNotificationSubscription
-{
     public string FirebaseDeviceToken { get; set; }
 }


### PR DESCRIPTION
The GET subscription endpoint was returning RedactedPushNotificationSubscription which omitted firebaseDeviceToken. Mobile clients need this field to verify their push notification registration matches the locally stored Firebase token.

Fix: add FirebaseDeviceToken to RedactedPushNotificationSubscription and the Redacted() mapping, so all endpoints (V1 and V2) now include it. Remove the now-redundant RedactedPushNotificationSubscriptionV2 subclass, RedactedV2() method, and the V2 controller override that existed solely to use them.