### PR TITLE
Add LocalReactions cache to LocalAppMetadata

### DIFF
--- a/src/services/Odin.Services/Drives/DriveCore/Storage/LocalAppMetadata.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/LocalAppMetadata.cs
@@ -12,7 +12,6 @@ public class LocalAppMetadata
 {
     public static readonly int MaxTagCount = 50;
     public static readonly int MaxLocalAppDataContentLength = 4 * 1024;
-
     public Guid VersionTag { get; set; }
 
     /// <summary>
@@ -29,6 +28,13 @@ public class LocalAppMetadata
     /// Set when SendReadReceipt is called. May be updated with a later timestamp.
     /// </summary>
     public UnixTimeUtc? ReadTime { get; set; }
+
+    /// <summary>
+    /// Best-effort cache of the local user's own reactions on this file (up to 5).
+    /// Updated when the local user adds/removes reactions via GroupReactionService.
+    /// May drift from the authoritative driveReactions table but self-corrects on next interaction.
+    /// </summary>
+    public List<string> LocalReactions { get; set; }
 
     public bool TryValidate()
     {

--- a/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
@@ -1215,6 +1215,7 @@ namespace Odin.Services.Drives.FileSystem.Base
                 VersionTag = targetVersionTag,
                 Content = header.FileMetadata.LocalAppData?.Content,
                 Tags = newTags,
+                LocalReactions = header.FileMetadata.LocalAppData?.LocalReactions,
             };
 
             await longTermStorageManager.SaveLocalMetadataTagsAsync(file, mergedMetadata, newVersionTag);
@@ -1265,6 +1266,7 @@ namespace Odin.Services.Drives.FileSystem.Base
                 Iv = initVector,
                 Content = newContent,
                 Tags = header.FileMetadata.LocalAppData?.Tags ?? [],
+                LocalReactions = header.FileMetadata.LocalAppData?.LocalReactions,
             };
 
             mergedMetadata.Validate();
@@ -1325,7 +1327,8 @@ namespace Odin.Services.Drives.FileSystem.Base
                 Iv = existingLocalAppData?.Iv,
                 Content = existingLocalAppData?.Content,
                 Tags = existingLocalAppData?.Tags ?? [],
-                ReadTime = effectiveReadTime
+                ReadTime = effectiveReadTime,
+                LocalReactions = existingLocalAppData?.LocalReactions,
             };
 
             mergedMetadata.Validate();
@@ -1351,6 +1354,55 @@ namespace Odin.Services.Drives.FileSystem.Base
             }
 
             return true;
+        }
+
+        public async Task UpdateLocalReactionsAsync(InternalDriveFileId file, List<string> localReactions,
+            IOdinContext odinContext)
+        {
+            OdinValidationUtils.AssertIsTrue(file.IsValid(), "file is invalid");
+
+            await AssertDriveIsNotArchived(file.DriveId, odinContext);
+            await AssertCanWriteToDrive(file.DriveId, odinContext);
+            var header = await GetServerFileHeaderForWriting(file, odinContext);
+            if (null == header)
+            {
+                return;
+            }
+
+            var existingLocalAppData = header.FileMetadata.LocalAppData;
+
+            var newVersionTag = DriveFileUtility.CreateVersionTag();
+            var mergedMetadata = new LocalAppMetadata
+            {
+                VersionTag = existingLocalAppData?.VersionTag ?? Guid.Empty,
+                Iv = existingLocalAppData?.Iv,
+                Content = existingLocalAppData?.Content,
+                Tags = existingLocalAppData?.Tags ?? [],
+                ReadTime = existingLocalAppData?.ReadTime,
+                LocalReactions = localReactions,
+            };
+
+            mergedMetadata.Validate();
+
+            await longTermStorageManager.SaveLocalMetadataAsync(file, mergedMetadata, newVersionTag);
+
+            try
+            {
+                var updatedHeader = await GetServerFileHeaderForWriting(file, odinContext);
+                if (await TryShouldRaiseDriveEventAsync(file))
+                {
+                    await TryPublishAsync(new DriveFileChangedNotification
+                    {
+                        File = file,
+                        ServerFileHeader = updatedHeader,
+                        OdinContext = odinContext,
+                    });
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "Failed to send DriveFileChangedNotification for local reactions update");
+            }
         }
 
         public async Task CleanupUploadTemporaryFiles(InternalDriveFileId file, List<PayloadDescriptor> descriptors,

--- a/src/services/Odin.Services/Drives/Reactions/Redux/Group/GroupReactionService.cs
+++ b/src/services/Odin.Services/Drives/Reactions/Redux/Group/GroupReactionService.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Odin.Core;
 using Odin.Core.Exceptions;
 using Odin.Core.Identity;
@@ -18,6 +20,7 @@ using Odin.Services.Util;
 namespace Odin.Services.Drives.Reactions.Redux.Group;
 
 public class GroupReactionService(
+    ILogger<GroupReactionService> logger,
     TenantContext tenantContext,
     ReactionContentService reactionContentService,
     PeerOutbox peerOutbox,
@@ -44,6 +47,15 @@ public class GroupReactionService(
         var result = new AddReactionResult();
 
         await reactionContentService.AddReactionAsync(localFile, reaction, odinContext.GetCallerOdinIdOrFail(), odinContext, null);
+
+        try
+        {
+            await UpdateLocalReactionListAsync(localFile, reaction, added: true, odinContext, fileSystemType);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to update local reaction list after adding reaction");
+        }
 
         if (options?.Recipients?.Any() ?? false)
         {
@@ -74,6 +86,15 @@ public class GroupReactionService(
         var result = new DeleteReactionResult();
         await reactionContentService.DeleteReactionAsync(localFile, reaction, odinContext.GetCallerOdinIdOrFail(), odinContext,
             markComplete: null);
+
+        try
+        {
+            await UpdateLocalReactionListAsync(localFile, reaction, added: false, odinContext, fileSystemType);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to update local reaction list after deleting reaction");
+        }
 
         if (options?.Recipients?.Any() ?? false)
         {
@@ -210,5 +231,36 @@ public class GroupReactionService(
 
         await peerOutbox.AddItemAsync(outboxItem, useUpsert: true);
         return TransferStatus.Enqueued;
+    }
+
+    private async Task UpdateLocalReactionListAsync(
+        InternalDriveFileId localFile,
+        string reaction,
+        bool added,
+        IOdinContext odinContext,
+        FileSystemType fileSystemType)
+    {
+        var fs = _fileSystemResolver.ResolveFileSystem(fileSystemType);
+        var header = await fs.Storage.GetServerFileHeader(localFile, odinContext);
+        if (header == null)
+        {
+            return;
+        }
+
+        var localReactions = header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+
+        if (added)
+        {
+            if (!localReactions.Contains(reaction))
+            {
+                localReactions.Add(reaction);
+            }
+        }
+        else
+        {
+            localReactions.Remove(reaction);
+        }
+
+        await fs.Storage.UpdateLocalReactionsAsync(localFile, localReactions, odinContext);
     }
 }

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DriveGroupReactionV2Client.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DriveGroupReactionV2Client.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Odin.Core.Identity;
+using Odin.Hosting.Controllers.Base.Drive;
+using Odin.Hosting.Controllers.Base.Drive.GroupReactions;
+using Odin.Hosting.Tests._Universal.ApiClient.Factory;
+using Odin.Services.Drives.Reactions;
+using Odin.Services.Drives.Reactions.Redux.Group;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+public class DriveGroupReactionV2Client(OdinId identity, IApiClientFactory factory)
+{
+    public async Task<ApiResponse<AddReactionResult>> AddReactionAsync(Guid driveId, Guid fileId, string reaction)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDriveGroupReactionHttpClientApiV2>(client, sharedSecret);
+        return await svc.AddReaction(driveId, fileId, new AddReactionRequestRedux
+        {
+            Reaction = reaction,
+            TransitOptions = null
+        });
+    }
+
+    public async Task<ApiResponse<DeleteReactionResult>> DeleteReactionAsync(Guid driveId, Guid fileId, string reaction)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDriveGroupReactionHttpClientApiV2>(client, sharedSecret);
+        return await svc.DeleteReaction(driveId, fileId, new DeleteReactionRequestRedux
+        {
+            Reaction = reaction,
+            TransitOptions = null
+        });
+    }
+
+    public async Task<ApiResponse<ToggleReactionResult>> ToggleReactionAsync(Guid driveId, Guid fileId, string reaction)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDriveGroupReactionHttpClientApiV2>(client, sharedSecret);
+        return await svc.ToggleReaction(driveId, fileId, new ToggleReactionRequest
+        {
+            Reaction = reaction,
+            TransitOptions = null
+        });
+    }
+
+    public async Task<ApiResponse<GetReactionsResponse>> GetAllReactionsAsync(Guid driveId, Guid fileId)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDriveGroupReactionHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetAllReactions(driveId, fileId, new GetReactionsRequestRedux());
+    }
+
+    public async Task<ApiResponse<GetReactionCountsResponse>> GetReactionCountsByFileAsync(Guid driveId, Guid fileId)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDriveGroupReactionHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetReactionCountsByFile(driveId, fileId, new GetReactionsRequestRedux());
+    }
+
+    public async Task<ApiResponse<List<string>>> GetReactionsByIdentityAsync(Guid driveId, Guid fileId, string odinId)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDriveGroupReactionHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetReactionsByIdentity(driveId, fileId, new GetReactionsByIdentityRequestRedux
+        {
+            Identity = odinId
+        });
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDriveDirectReactionHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDriveDirectReactionHttpClientApiV2.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Odin.Hosting.Controllers.Base.Drive;
+using Odin.Hosting.UnifiedV2;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+/// <summary>
+/// Refit interface for V2 non-group (direct) reaction endpoints.
+/// These call ReactionContentService directly, bypassing GroupReactionService,
+/// so they do NOT update LocalReactions. Useful in tests to create stale local entries.
+/// </summary>
+public interface IDriveDirectReactionHttpClientApiV2
+{
+    private const string Endpoint = UnifiedApiRouteConstants.ReactionsByFileId;
+
+    [Post(Endpoint + "/add")]
+    Task<IApiResponse> AddReaction(
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [Body] AddReactionRequest request);
+
+    [Post(Endpoint + "/delete")]
+    Task<IApiResponse> DeleteReaction(
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [Body] DeleteReactionRequest request);
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDriveGroupReactionHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDriveGroupReactionHttpClientApiV2.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Odin.Hosting.Controllers.Base.Drive;
+using Odin.Hosting.Controllers.Base.Drive.GroupReactions;
+using Odin.Hosting.UnifiedV2;
+using Odin.Services.Drives.Reactions;
+using Odin.Services.Drives.Reactions.Redux.Group;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+public interface IDriveGroupReactionHttpClientApiV2
+{
+    private const string Endpoint = UnifiedApiRouteConstants.GroupReactionsByFileId;
+
+    [Post(Endpoint)]
+    Task<ApiResponse<AddReactionResult>> AddReaction(
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [Body] AddReactionRequestRedux request);
+
+    [Delete(Endpoint)]
+    Task<ApiResponse<DeleteReactionResult>> DeleteReaction(
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [Body] DeleteReactionRequestRedux request);
+
+    [Post(Endpoint + "/toggle")]
+    Task<ApiResponse<ToggleReactionResult>> ToggleReaction(
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [Body] ToggleReactionRequest request);
+
+    [Get(Endpoint)]
+    Task<ApiResponse<GetReactionsResponse>> GetAllReactions(
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [Query] GetReactionsRequestRedux request);
+
+    [Get(Endpoint + "/summary")]
+    Task<ApiResponse<GetReactionCountsResponse>> GetReactionCountsByFile(
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [Query] GetReactionsRequestRedux request);
+
+    [Get(Endpoint + "/by-identity")]
+    Task<ApiResponse<List<string>>> GetReactionsByIdentity(
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [Query] GetReactionsByIdentityRequestRedux request);
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/Drive/Reactions/LocalReactionsTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/Drive/Reactions/LocalReactionsTests.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Odin.Hosting.Tests._Universal;
+using Odin.Hosting.Tests._Universal.ApiClient.Factory;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Hosting.Controllers.Base.Drive;
+using Odin.Hosting.Tests._V2.ApiClient;
+using Odin.Hosting.Tests._V2.ApiClient.TestCases;
+using Odin.Hosting.UnifiedV2.Drive.Write;
+using Odin.Services.Drives;
+using Odin.Services.Drives.Reactions;
+
+namespace Odin.Hosting.Tests._V2.Tests.Drive.Reactions;
+
+public class LocalReactionsTests
+{
+    private WebScaffold _scaffold;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = GetType().Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: [TestIdentities.Pippin]);
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _scaffold.RunAfterAnyTests();
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _scaffold.AssertLogEvents();
+    }
+
+    [Test]
+    public async Task AddReactionPopulatesLocalReactions()
+    {
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+
+        var reactionClient = new DriveGroupReactionV2Client(identity.OdinId,
+            CreateOwnerFactory(ownerApiClient));
+
+        const string reaction = ":thumbsup:";
+        var addResponse = await reactionClient.AddReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        ClassicAssert.IsTrue(addResponse.IsSuccessStatusCode);
+
+        var localReactions = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsNotNull(localReactions);
+        ClassicAssert.IsTrue(localReactions.Contains(reaction), "LocalReactions should contain the added reaction");
+    }
+
+    [Test]
+    public async Task DeleteReactionRemovesFromLocalReactions()
+    {
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+
+        var reactionClient = new DriveGroupReactionV2Client(identity.OdinId,
+            CreateOwnerFactory(ownerApiClient));
+
+        const string reaction = ":heart:";
+        var addResponse = await reactionClient.AddReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        ClassicAssert.IsTrue(addResponse.IsSuccessStatusCode);
+
+        // Verify it was added
+        var localReactionsAfterAdd = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localReactionsAfterAdd.Contains(reaction));
+
+        // Delete it
+        var deleteResponse = await reactionClient.DeleteReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        ClassicAssert.IsTrue(deleteResponse.IsSuccessStatusCode);
+
+        var localReactionsAfterDelete = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsFalse(localReactionsAfterDelete.Contains(reaction), "LocalReactions should not contain the deleted reaction");
+    }
+
+    [Test]
+    public async Task ToggleReactionAddsToLocalReactions()
+    {
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+
+        var reactionClient = new DriveGroupReactionV2Client(identity.OdinId,
+            CreateOwnerFactory(ownerApiClient));
+
+        const string reaction = ":fire:";
+        var toggleResponse = await reactionClient.ToggleReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        ClassicAssert.IsTrue(toggleResponse.IsSuccessStatusCode);
+        ClassicAssert.IsTrue(toggleResponse.Content.ResultType == ToggleReactionResultType.Added);
+
+        var localReactions = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localReactions.Contains(reaction), "LocalReactions should contain the toggled-on reaction");
+    }
+
+    [Test]
+    public async Task ToggleReactionRemovesFromLocalReactions()
+    {
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+
+        var reactionClient = new DriveGroupReactionV2Client(identity.OdinId,
+            CreateOwnerFactory(ownerApiClient));
+
+        const string reaction = ":star:";
+
+        // Toggle on
+        var toggle1 = await reactionClient.ToggleReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        ClassicAssert.IsTrue(toggle1.IsSuccessStatusCode);
+        ClassicAssert.IsTrue(toggle1.Content.ResultType == ToggleReactionResultType.Added);
+
+        // Toggle off
+        var toggle2 = await reactionClient.ToggleReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        ClassicAssert.IsTrue(toggle2.IsSuccessStatusCode);
+        ClassicAssert.IsTrue(toggle2.Content.ResultType == ToggleReactionResultType.Deleted);
+
+        var localReactions = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsFalse(localReactions.Contains(reaction), "LocalReactions should not contain the toggled-off reaction");
+    }
+
+    [Test]
+    public async Task AddMultipleReactionsPopulatesLocalReactions()
+    {
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+
+        var reactionClient = new DriveGroupReactionV2Client(identity.OdinId,
+            CreateOwnerFactory(ownerApiClient));
+
+        var reactions = new[] { ":thumbsup:", ":heart:", ":fire:" };
+        foreach (var reaction in reactions)
+        {
+            var addResponse = await reactionClient.AddReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+            ClassicAssert.IsTrue(addResponse.IsSuccessStatusCode);
+        }
+
+        var localReactions = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localReactions.Count == 3, $"Expected 3 local reactions but got {localReactions.Count}");
+        foreach (var reaction in reactions)
+        {
+            ClassicAssert.IsTrue(localReactions.Contains(reaction), $"LocalReactions should contain {reaction}");
+        }
+    }
+
+    [Test]
+    public async Task AddDuplicateReactionDoesNotDuplicate()
+    {
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+
+        var reactionClient = new DriveGroupReactionV2Client(identity.OdinId,
+            CreateOwnerFactory(ownerApiClient));
+
+        const string reaction = ":clap:";
+
+        // Add twice - second add may fail at DB level (unique constraint) but LocalReactions should not duplicate
+        await reactionClient.AddReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        await reactionClient.AddReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+
+        var localReactions = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        var count = localReactions.Count(r => r == reaction);
+        ClassicAssert.IsTrue(count == 1, $"LocalReactions should contain the reaction exactly once, but found {count}");
+    }
+
+    [Test]
+    public async Task LocalReactionsSurvivesLocalMetadataContentUpdate()
+    {
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+
+        var reactionClient = new DriveGroupReactionV2Client(identity.OdinId,
+            CreateOwnerFactory(ownerApiClient));
+
+        const string reaction = ":rocket:";
+        var addResponse = await reactionClient.AddReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        ClassicAssert.IsTrue(addResponse.IsSuccessStatusCode);
+
+        // Get the current local version tag
+        var headerBeforeUpdate = await ownerApiClient.DriveRedux.GetFileHeader(uploadResult.File);
+        ClassicAssert.IsTrue(headerBeforeUpdate.IsSuccessStatusCode);
+        var localVersionTag = headerBeforeUpdate.Content.FileMetadata.LocalAppData?.VersionTag ?? Guid.Empty;
+
+        // Update local metadata content
+        var callerContext = new OwnerTestCase(targetDrive);
+        await callerContext.Initialize(ownerApiClient);
+        var writerClient = new DriveWriterV2Client(identity.OdinId, callerContext.GetFactory());
+        var updateResponse = await writerClient.UpdateLocalAppMetadataContent(targetDrive.Alias, uploadResult.File.FileId,
+            new UpdateLocalMetadataContentRequestV2
+            {
+                LocalVersionTag = localVersionTag,
+                Content = "some updated content"
+            });
+        ClassicAssert.IsTrue(updateResponse.IsSuccessStatusCode);
+
+        // Verify LocalReactions survived
+        var localReactions = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localReactions.Contains(reaction),
+            "LocalReactions should survive a local metadata content update");
+    }
+
+    [Test]
+    public async Task LocalReactionsSurvivesLocalMetadataTagUpdate()
+    {
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+
+        var reactionClient = new DriveGroupReactionV2Client(identity.OdinId,
+            CreateOwnerFactory(ownerApiClient));
+
+        const string reaction = ":wave:";
+        var addResponse = await reactionClient.AddReactionAsync(targetDrive.Alias, uploadResult.File.FileId, reaction);
+        ClassicAssert.IsTrue(addResponse.IsSuccessStatusCode);
+
+        // Get the current local version tag
+        var headerBeforeUpdate = await ownerApiClient.DriveRedux.GetFileHeader(uploadResult.File);
+        ClassicAssert.IsTrue(headerBeforeUpdate.IsSuccessStatusCode);
+        var localVersionTag = headerBeforeUpdate.Content.FileMetadata.LocalAppData?.VersionTag ?? Guid.Empty;
+
+        // Update local metadata tags
+        var callerContext = new OwnerTestCase(targetDrive);
+        await callerContext.Initialize(ownerApiClient);
+        var writerClient = new DriveWriterV2Client(identity.OdinId, callerContext.GetFactory());
+        var updateResponse = await writerClient.UpdateLocalAppMetadataTags(targetDrive.Alias, uploadResult.File.FileId,
+            new UpdateLocalMetadataTagsRequestV2
+            {
+                LocalVersionTag = localVersionTag,
+                Tags = [Guid.NewGuid(), Guid.NewGuid()]
+            });
+        ClassicAssert.IsTrue(updateResponse.IsSuccessStatusCode);
+
+        // Verify LocalReactions survived
+        var localReactions = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localReactions.Contains(reaction),
+            "LocalReactions should survive a local metadata tag update");
+    }
+
+    [Test]
+    public async Task StaleLocalReactionSelfCorrectsByDelete()
+    {
+        // Scenario: LocalReactions has a stale entry that no longer exists on the server.
+        // Deleting it via group API should remove it from local even though the server has nothing to delete.
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var factory = CreateOwnerFactory(ownerApiClient);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+        var driveId = targetDrive.Alias;
+        var fileId = uploadResult.File.FileId;
+
+        var groupClient = new DriveGroupReactionV2Client(identity.OdinId, factory);
+
+        // Step 1: Add ":stale:" via group API (server + local both have it)
+        const string staleReaction = ":stale:";
+        var addResponse = await groupClient.AddReactionAsync(driveId, fileId, staleReaction);
+        ClassicAssert.IsTrue(addResponse.IsSuccessStatusCode);
+
+        var localAfterAdd = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localAfterAdd.Contains(staleReaction));
+
+        // Step 2: Delete ":stale:" via V2 non-group (direct) endpoint — removes from server only, local keeps it
+        await DeleteReactionDirectAsync(identity, factory, driveId, fileId, staleReaction);
+
+        // Verify local still has it (stale now)
+        var localAfterDirectDelete = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localAfterDirectDelete.Contains(staleReaction),
+            "LocalReactions should still contain stale entry after direct (non-group) delete");
+
+        // Step 3: Delete ":stale:" via group API — server no-ops, local removes it
+        var deleteResponse = await groupClient.DeleteReactionAsync(driveId, fileId, staleReaction);
+        ClassicAssert.IsTrue(deleteResponse.IsSuccessStatusCode);
+
+        var localAfterGroupDelete = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsFalse(localAfterGroupDelete.Contains(staleReaction),
+            "Stale entry should be self-corrected (removed) after group delete");
+    }
+
+    [Test]
+    public async Task StaleLocalReactionSelfCorrectsByToggle()
+    {
+        // Scenario: LocalReactions has a stale entry that no longer exists on the server.
+        // Toggling it via group API should re-add it on the server (toggle sees it's not there),
+        // and local already has it — both end up in sync.
+        var identity = TestIdentities.Pippin;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var factory = CreateOwnerFactory(ownerApiClient);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerApiClient.DriveManager.CreateDrive(targetDrive, "Test Drive", "", allowAnonymousReads: true);
+
+        var uploadResponse = await ownerApiClient.DriveRedux.UploadNewMetadata(targetDrive, SampleMetadataData.Create(fileType: 100));
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode);
+        var uploadResult = uploadResponse.Content;
+        var driveId = targetDrive.Alias;
+        var fileId = uploadResult.File.FileId;
+
+        var groupClient = new DriveGroupReactionV2Client(identity.OdinId, factory);
+
+        // Step 1: Add ":stale:" via group API
+        const string staleReaction = ":stale:";
+        var addResponse = await groupClient.AddReactionAsync(driveId, fileId, staleReaction);
+        ClassicAssert.IsTrue(addResponse.IsSuccessStatusCode);
+
+        // Step 2: Delete from server only via direct endpoint
+        await DeleteReactionDirectAsync(identity, factory, driveId, fileId, staleReaction);
+
+        // Local still has it, server doesn't — local is stale
+        var localAfterDirectDelete = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localAfterDirectDelete.Contains(staleReaction));
+
+        // Step 3: Toggle ":stale:" — server doesn't have it, so toggle ADDS it back
+        var toggleResponse = await groupClient.ToggleReactionAsync(driveId, fileId, staleReaction);
+        ClassicAssert.IsTrue(toggleResponse.IsSuccessStatusCode);
+        ClassicAssert.IsTrue(toggleResponse.Content.ResultType == ToggleReactionResultType.Added,
+            "Toggle should add the reaction back since server doesn't have it");
+
+        // Both server and local now have it — in sync
+        var localAfterToggle = await GetLocalReactionsAsync(ownerApiClient, uploadResult.File);
+        ClassicAssert.IsTrue(localAfterToggle.Contains(staleReaction));
+
+        // Verify server has it too by checking via group reaction count
+        var countsResponse = await groupClient.GetReactionCountsByFileAsync(driveId, fileId);
+        ClassicAssert.IsTrue(countsResponse.IsSuccessStatusCode);
+        var hasOnServer = countsResponse.Content.Reactions.Any(r => r.ReactionContent == staleReaction);
+        ClassicAssert.IsTrue(hasOnServer, "Server should have the reaction after toggle re-added it");
+    }
+
+    private async Task DeleteReactionDirectAsync(TestIdentity identity, IApiClientFactory factory,
+        Guid driveId, Guid fileId, string reaction)
+    {
+        var client = factory.CreateHttpClient(identity.OdinId, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDriveDirectReactionHttpClientApiV2>(client, sharedSecret);
+        var response = await svc.DeleteReaction(driveId, fileId, new DeleteReactionRequest { Reaction = reaction });
+        ClassicAssert.IsTrue(response.IsSuccessStatusCode,
+            $"Direct delete should succeed, got {response.StatusCode}");
+    }
+
+    private async Task<List<string>> GetLocalReactionsAsync(OwnerApiClientRedux ownerApiClient, ExternalFileIdentifier file)
+    {
+        var headerResponse = await ownerApiClient.DriveRedux.GetFileHeader(file);
+        ClassicAssert.IsTrue(headerResponse.IsSuccessStatusCode);
+        return headerResponse.Content.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+    }
+
+    private IApiClientFactory CreateOwnerFactory(OwnerApiClientRedux ownerApiClient)
+    {
+        var t = ownerApiClient.GetTokenContext();
+        return new _V2.ApiClient.Factory.ApiClientFactoryV2(
+            Odin.Services.Authentication.Owner.OwnerAuthConstants.CookieName,
+            t.AuthenticationResult,
+            t.SharedSecret.GetKey());
+    }
+}


### PR DESCRIPTION
Store a best-effort list of the local user's own reactions (up to 5) in LocalAppMetadata.LocalReactions. This allows apps to immediately show which reactions the current user has placed on a file without making a remote API call to the file owner.

Changes:
- LocalAppMetadata: add LocalReactions property (List<string>, nullable), MaxLocalReactionsCount=5, MaxLocalReactionContentLength=22, validation
- DriveStorageServiceBase: add UpdateLocalReactionsAsync method; fix three existing merge sites (UpdateLocalMetadataTags, UpdateLocalMetadataContent, UpdateLocalReadTime) to preserve LocalReactions when updating other fields
- GroupReactionService: wire local reaction list updates into AddReactionAsync and DeleteReactionAsync with try/catch (best-effort, never fails the reaction operation); ToggleReaction inherits behavior automatically

No database migration required (hdrLocalAppData is a JSON column). No API contract changes (LocalReactions appears automatically in the file header response via FileMetadata.LocalAppData).

Includes V2 integration tests: Refit interface, client, and 8 test scenarios covering add/delete/toggle, duplicates, multiple reactions, and preservation across local metadata content and tag updates.