### PR TITLE
ItShouldInvalidateInAndAfterTransaction: wip

### DIFF
--- a/src/core/Odin.Core.Storage/Database/AbstractTableCaching.cs
+++ b/src/core/Odin.Core.Storage/Database/AbstractTableCaching.cs
@@ -21,6 +21,7 @@ public abstract class AbstractTableCaching(ITransactionalCacheFactory cacheFacto
 
     public long Hits => Cache.Hits;
     public long Misses => Cache.Misses;
+    public bool InDatabaseTransaction => Cache.InDatabaseTransaction;
 
     public Task InvalidateAllAsync()
     {

--- a/src/core/Odin.Core.Storage/Database/Identity/Abstractions/MainIndexMetaCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Abstractions/MainIndexMetaCached.cs
@@ -9,11 +9,12 @@ namespace Odin.Core.Storage.Database.Identity.Abstractions;
 
 public class MainIndexMetaCached : AbstractTableCaching
 {
+    public const string RootInvalidationTag = TableDriveMainIndexCacheKeys.RootInvalidationTag;
     private readonly MainIndexMeta _meta;
     private readonly TableDriveMainIndexCacheKeys _cacheKeys;
 
     public MainIndexMetaCached(MainIndexMeta meta, IIdentityTransactionalCacheFactory cacheFactory)
-        : base(cacheFactory, meta.GetType().Name, TableDriveMainIndexCacheKeys.RootInvalidationTag)
+        : base(cacheFactory, meta.GetType().Name, RootInvalidationTag)
     {
         _meta = meta;
         _cacheKeys = new TableDriveMainIndexCacheKeys(Cache);

--- a/src/core/Odin.Core.Storage/Database/Identity/Abstractions/QueryBatchCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Abstractions/QueryBatchCached.cs
@@ -11,11 +11,12 @@ namespace Odin.Core.Storage.Database.Identity.Abstractions;
 
 public class QueryBatchCached : AbstractTableCaching
 {
+    public const string RootInvalidationTag = TableDriveMainIndexCacheKeys.RootInvalidationTag;
     private readonly QueryBatch _meta;
     private readonly TableDriveMainIndexCacheKeys _cacheKeys;
 
     public QueryBatchCached(QueryBatch meta, IIdentityTransactionalCacheFactory cacheFactory)
-        : base(cacheFactory, meta.GetType().Name, TableDriveMainIndexCacheKeys.RootInvalidationTag)
+        : base(cacheFactory, meta.GetType().Name, RootInvalidationTag)
     {
         _meta = meta;
         _cacheKeys = new TableDriveMainIndexCacheKeys(Cache);

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppGrantsCached.cs
@@ -7,8 +7,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableAppGrantsCached(TableAppGrants table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableAppGrants);
+
     private const string CacheKeyAll = "all:all:all";
 
     //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCached.cs
@@ -7,8 +7,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableAppNotificationsCached(TableAppNotifications table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableAppNotifications);
+
     private static readonly List<string> PagingByCreateTags = ["PagingByCreate"];
 
     //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleCached.cs
@@ -7,8 +7,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableCircleCached(TableCircle table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableCircle);
+
     private static readonly List<string> PagingByCircleIdTags = ["PagingByCircleId"];
 
     //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableCircleMemberCached.cs
@@ -7,8 +7,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableCircleMemberCached(TableCircleMember table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableCircleMember);
+
     private const string CacheKeyAll = "all:all:all";
 
     //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableConnectionsCached.cs
@@ -8,8 +8,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableConnectionsCached(TableConnections table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableConnections);
+
     private static readonly List<string> PagingByTags = ["PagingBy"];
 
     //

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCached.cs
@@ -8,11 +8,12 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 
 public class TableDriveMainIndexCached : AbstractTableCaching
 {
+    public const string RootInvalidationTag = TableDriveMainIndexCacheKeys.RootInvalidationTag;
     private readonly TableDriveMainIndex _table;
     private readonly TableDriveMainIndexCacheKeys _cacheKeys;
 
     public TableDriveMainIndexCached(TableDriveMainIndex table, IIdentityTransactionalCacheFactory cacheFactory) :
-        base(cacheFactory, table.GetType().Name, TableDriveMainIndexCacheKeys.RootInvalidationTag)
+        base(cacheFactory, table.GetType().Name, RootInvalidationTag)
     {
         _table = table;
         _cacheKeys = new TableDriveMainIndexCacheKeys(Cache);

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableFollowsMeCached.cs
@@ -8,8 +8,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableFollowsMeCached(TableFollowsMe table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableFollowsMe);
+
     // SEB:NOTE some advanced queries are used in this table, so instead of trying to remove specific keys,
     // we use Cache.InvalidateAllAsync() to clear the cache whenever data changes are made
 

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableImFollowingCached.cs
@@ -8,8 +8,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableImFollowingCached(TableImFollowing table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableImFollowing);
+
     // SEB:NOTE some advanced queries are used in this table, so instead of trying to remove specific keys,
     // we use Cache.InvalidateAllAsync() to clear the cache whenever data changes are made
 

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableInboxCached.cs
@@ -21,9 +21,11 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 /// is invalidated on every mutation (insert, pop, commit, cancel, recover) so it never serves stale
 /// data that would cause items to be missed.
 /// </summary>
-public class TableInboxCached(TableInbox table, IIdentityTransactionalCacheFactory cacheFactory)
-    : AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+public class TableInboxCached(TableInbox table, IIdentityTransactionalCacheFactory cacheFactory) :
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableInbox);
+
     //
 
     private static string GetCacheKey(Guid boxId)

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyThreeValueCached.cs
@@ -7,8 +7,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableKeyThreeValueCached(TableKeyThreeValue table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableKeyThreeValue);
+
     // SEB:NOTE some funky cache keys here. We'll invalidate everything on any change. Might be worth refining later.
 
     private static string GetCacheKey1(byte[] key1)

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyTwoValueCached.cs
@@ -7,8 +7,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableKeyTwoValueCached(TableKeyTwoValue table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableKeyTwoValue);
+
     // SEB:NOTE some funky cache keys here. We'll invalidate everything on any change. Might be worth refining later.
 
     private static string GetCacheKey1(byte[] key1)

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableKeyValueCached.cs
@@ -8,8 +8,10 @@ namespace Odin.Core.Storage.Database.Identity.Table;
 #nullable enable
 
 public class TableKeyValueCached(TableKeyValue table, IIdentityTransactionalCacheFactory cacheFactory) :
-    AbstractTableCaching(cacheFactory, table.GetType().Name, table.GetType().Name)
+    AbstractTableCaching(cacheFactory, table.GetType().Name, RootInvalidationTag)
 {
+    public const string RootInvalidationTag = nameof(TableKeyValue);
+
     //
 
     private static string GetCacheKey(byte[] key)

--- a/src/core/Odin.Core.Storage/Database/TransactionalCache.cs
+++ b/src/core/Odin.Core.Storage/Database/TransactionalCache.cs
@@ -39,6 +39,8 @@ public sealed class TransactionalCache
     private long _misses;
     public long Misses => Interlocked.Read(ref _misses);
 
+    public bool InDatabaseTransaction => _scopedConnectionFactory.HasTransaction;
+
     private readonly ILevel2Cache _cache;
     private readonly ITransactionalCacheStats _cacheStats;
     private readonly IScopedConnectionFactory _scopedConnectionFactory;
@@ -46,8 +48,6 @@ public sealed class TransactionalCache
 
     private readonly List<string> _rootTag;
     private string RootTag { get; }
-
-    private bool InDatabaseTransaction => _scopedConnectionFactory.HasTransaction;
 
     //
 
@@ -268,14 +268,18 @@ public sealed class TransactionalCache
 
     public async Task InvalidateAllAsync()
     {
+        // SEB:NOTE we have to invalidate both immediately and after a transaction so the change will be visible to:
+        // - Cache instances aware of the transaction (everything implementing AbstractTableCaching).
+        // - Cache instances running within a transaction but not aware of it,
+        //   e.g. instances of ITenantLevel2Cache using the same invalidation tags as AbstractTableCaching,
+        //   but not aware of the transaction themselves
+
+        await _cache.RemoveByTagAsync(_rootTag);
+
         if (InDatabaseTransaction)
         {
             _scopedConnectionFactory.AddPostCommitAction(async () => await _cache.RemoveByTagAsync(_rootTag));
             _scopedConnectionFactory.AddPostRollbackAction(async () => await _cache.RemoveByTagAsync(_rootTag));
-        }
-        else
-        {
-            await _cache.RemoveByTagAsync(_rootTag);
         }
     }
 
@@ -290,14 +294,18 @@ public sealed class TransactionalCache
             return;
         }
 
+        // SEB:NOTE we have to invalidate both immediately and after a transaction so the change will be visible to:
+        // - Cache instances aware of the transaction (everything implementing AbstractTableCaching).
+        // - Cache instances running within a transaction but not aware of it,
+        //   e.g. instances of ITenantLevel2Cache using the same invalidation tags as AbstractTableCaching,
+        //   but not aware of the transaction themselves
+
+        await Task.WhenAll(actionsArray.Select(a => a()));
+
         if (InDatabaseTransaction)
         {
             _scopedConnectionFactory.AddPostCommitAction(async () => await Task.WhenAll(actionsArray.Select(a => a())));
             _scopedConnectionFactory.AddPostRollbackAction(async () => await Task.WhenAll(actionsArray.Select(a => a())));
-        }
-        else
-        {
-            await Task.WhenAll(actionsArray.Select(a => a()));
         }
     }
 

--- a/tests/core/Odin.Core.Storage.Tests/Database/AbstractTableCachingTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/AbstractTableCachingTests.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Autofac;
 using NUnit.Framework;
+using Odin.Core.Storage.Cache;
+using Odin.Core.Storage.Database.Identity;
 using Odin.Core.Storage.Database.Identity.Connection;
 using Odin.Core.Storage.Database.Identity.Table;
 using Odin.Core.Storage.Factory;
@@ -39,6 +42,126 @@ public class AbstractTableCachingTests : IocTestBase
     }
 
     //
+
+    [Test]
+    public async Task ItShouldInvalidateInAndAfterTransaction()
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite);
+        await using var scope = Services.BeginLifetimeScope();
+        var db = scope.Resolve<IdentityDatabase>();
+
+        var outerCache =  scope.Resolve<ITenantLevel2Cache>();
+        var outerCacheInvalidationTag = new List<string> { TableKeyValueCached.RootInvalidationTag };
+        var outerHit = false;
+
+        var itemKey = Guid.NewGuid();
+        var item = new KeyValueRecord { key = itemKey.ToByteArray(), data = Guid.NewGuid().ToByteArray() };
+
+        var cacheKey = itemKey.ToString();
+
+        {
+            await using var tx = await db.BeginStackedTransactionAsync();
+
+            // Outer cache MISS
+            {
+                outerHit = true;
+                var data = await outerCache.GetOrSetAsync(
+                    cacheKey,
+                    _ =>
+                    {
+                        outerHit = false;
+                        return db.KeyValueCached.GetAsync(item.key, TimeSpan.FromMilliseconds(1000));
+                    },
+                    TimeSpan.FromMilliseconds(500),
+                    EntrySize.Medium,
+                    outerCacheInvalidationTag);
+
+                Assert.That(data, Is.Null);
+                Assert.That(outerHit, Is.False);
+            }
+
+            // Outer cache HIT
+            {
+                outerHit = true;
+                var data = await outerCache.GetOrSetAsync(
+                    cacheKey,
+                    _ =>
+                    {
+                        outerHit = false;
+                        return db.KeyValueCached.GetAsync(item.key, TimeSpan.FromMilliseconds(1000));
+                    },
+                    TimeSpan.FromMilliseconds(500),
+                    EntrySize.Medium,
+                    outerCacheInvalidationTag);
+
+                Assert.That(data, Is.Null);
+                Assert.That(outerHit, Is.True);
+            }
+
+            // Insert data, invalidate outerCacheInvalidationTag
+            await db.KeyValueCached.InsertAsync(item);
+
+            // Outer cache MISS (because of invalidation when inserting)
+            {
+                outerHit = true;
+                var data = await outerCache.GetOrSetAsync(
+                    cacheKey,
+                    _ =>
+                    {
+                        outerHit = false;
+                        return db.KeyValueCached.GetAsync(item.key, TimeSpan.FromMilliseconds(1000));
+                    },
+                    TimeSpan.FromMilliseconds(500),
+                    EntrySize.Medium,
+                    outerCacheInvalidationTag);
+
+                // SEB:NOTE this fails because the cache key generated in ITenantLevel2Cache is not the same as the one
+                // generated in TableKeyValueCached (bug)
+                Assert.That(data, Is.Not.Null);
+                Assert.That(outerHit, Is.True);
+            }
+
+
+            //
+            // {
+            //     // We're in a transaction, so cache was not updated in above INSERT
+            //     var r = await db.KeyValueCached.GetAsync(item.key, TimeSpan.FromMilliseconds(100));
+            //     Assert.That(r, Is.Not.Null);
+            //     Assert.That(db.KeyValueCached.Hits, Is.EqualTo(0));
+            //     Assert.That(db.KeyValueCached.Misses, Is.EqualTo(0));
+            // }
+            //
+            // {
+            //     // We're in still a transaction, so cache was not updated in above INSERT
+            //     var r = await db.KeyValueCached.GetAsync(item.key, TimeSpan.FromMilliseconds(100));
+            //     Assert.That(r, Is.Not.Null);
+            //     Assert.That(db.KeyValueCached.Hits, Is.EqualTo(0));
+            //     Assert.That(db.KeyValueCached.Misses, Is.EqualTo(0));
+            // }
+            //
+            // tx.Commit();
+
+            // NOTE: technically we're still in the transaction until leaving this scope
+        }
+
+        // {
+        //     // MISS: we're not in a transaction, so cache is now accessed
+        //     var r = await db.KeyValueCached.GetAsync(item.key, TimeSpan.FromMilliseconds(100));
+        //     Assert.That(r, Is.Not.Null);
+        //     Assert.That(db.KeyValueCached.Hits, Is.EqualTo(0));
+        //     Assert.That(db.KeyValueCached.Misses, Is.EqualTo(1));
+        // }
+        //
+        // {
+        //     // HIT: we're not in a transaction, so cache is now accessed
+        //     var r = await db.KeyValueCached.GetAsync(item.key, TimeSpan.FromMilliseconds(100));
+        //     Assert.That(r, Is.Not.Null);
+        //     Assert.That(db.KeyValueCached.Hits, Is.EqualTo(1));
+        //     Assert.That(db.KeyValueCached.Misses, Is.EqualTo(1));
+        // }
+
+    }
+
 
 }
 


### PR DESCRIPTION
We have to invalidate both immediately and after a transaction so the change will be visible to:
 - Cache instances aware of the transaction (everything implementing AbstractTableCaching).
 - Cache instances running within a transaction but not aware of it,
   e.g. instances of ITenantLevel2Cache using the same invalidation tags as AbstractTableCaching,
   but not aware of the transaction themselves