### PR TITLE
Fix inbox staging leak when cleanup runs without descriptors

### DIFF
--- a/src/services/Odin.Services/Drives/DriveCore/Storage/InboxStorageManager.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/InboxStorageManager.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Odin.Services.Base;
@@ -44,64 +42,37 @@ namespace Odin.Services.Drives.DriveCore.Storage
             return await fileReaderWriter.WriteStreamAsync(path, stream);
         }
 
-        public Task CleanupInboxFiles(InternalDriveFileId file, List<PayloadDescriptor> descriptors)
+        // We used to take a List<PayloadDescriptor> and compute each .payload / .thumb path from
+        // it. That leaked staging files whenever the inbox processor caught an exception and
+        // returned an empty descriptor list (PeerInboxProcessor.ProcessInboxItemAsync's catch arms
+        // all return (DeleteFromInbox, [])): the row was MarkComplete'd and the metadata +
+        // transferkeyheader were deleted, but the .payload/.thumb files were left behind, surfacing
+        // later as inbox orphans. The drive inbox dir is a single-purpose staging area where every
+        // file is prefixed with "{fileId:N}." (see TenantPathManager.GetFilename), so a glob on that
+        // prefix is the authoritative way to remove everything for a given fileId — independent of
+        // whatever descriptors the in-flight processor managed to parse.
+        public Task CleanupInboxFiles(InternalDriveFileId file)
         {
             logger.LogDebug("CleanupInboxFiles called - file: {file}", file);
 
-            CleanupInboxFilesInternal(file, descriptors);
-
-            //TODO: the extensions should be centralized
-            string[] additionalFiles =
-            [
-                _tenantPathManager.GetDriveInboxFilePath(file.DriveId, file.FileId, TenantPathManager.MetadataExtension),
-                _tenantPathManager.GetDriveInboxFilePath(file.DriveId, file.FileId, TenantPathManager.TransferInstructionSetExtension)
-            ];
-
-            foreach (var f in additionalFiles)
-            {
-                logger.LogDebug("CleanupInboxFiles Deleting additional File: {file}", f);
-            }
-
-            // clean up the transfer header and metadata since we keep those in the inbox
-            fileReaderWriter.DeleteFiles(additionalFiles);
-
-            return Task.CompletedTask;
-        }
-
-        private void CleanupInboxFilesInternal(InternalDriveFileId file, List<PayloadDescriptor> descriptors)
-        {
             try
             {
-                if (descriptors == null || descriptors.Count == 0)
+                var dir = _tenantPathManager.GetDriveInboxPath(file.DriveId);
+                if (!Directory.Exists(dir))
                 {
-                    return;
+                    return Task.CompletedTask;
                 }
 
-                var targetFiles = new List<string>();
-
-                descriptors!.ForEach(descriptor =>
-                {
-                    var payloadExtension = TenantPathManager.GetBasePayloadFileNameAndExtension(descriptor.Key, descriptor.Uid);
-                    string payloadDirectoryAndFilename = _tenantPathManager.GetDriveInboxFilePath(file.DriveId, file.FileId, payloadExtension);
-                    targetFiles.Add(payloadDirectoryAndFilename);
-
-                    descriptor.Thumbnails?.ForEach(thumb =>
-                    {
-                        var thumbnailExtension = TenantPathManager.GetThumbnailFileNameAndExtension(descriptor.Key,
-                            descriptor.Uid,
-                            thumb.PixelWidth,
-                            thumb.PixelHeight);
-                        string thumbnailDirectoryAndFilename = _tenantPathManager.GetDriveInboxFilePath(file.DriveId, file.FileId, thumbnailExtension);
-                        targetFiles.Add(thumbnailDirectoryAndFilename);
-                    });
-                });
-
-                fileReaderWriter.DeleteFiles(targetFiles);
+                var prefix = TenantPathManager.GuidToPathSafeString(file.FileId);
+                var matches = Directory.GetFiles(dir, prefix + ".*");
+                fileReaderWriter.DeleteFiles(matches);
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Failure while cleaning up inbox files");
+                logger.LogError(e, "Failure while cleaning up inbox files for {file}", file);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
@@ -1415,13 +1415,12 @@ namespace Odin.Services.Drives.FileSystem.Base
             }
         }
 
-        public async Task CleanupInboxTemporaryFiles(InternalDriveFileId file, List<PayloadDescriptor> descriptors,
-            IOdinContext odinContext)
+        public async Task CleanupInboxTemporaryFiles(InternalDriveFileId file, IOdinContext odinContext)
         {
             await AssertDriveIsNotArchived(file.DriveId, odinContext);
             if (await CanWriteToDrive(file.DriveId, odinContext))
             {
-                await inboxStorageManager.CleanupInboxFiles(file, descriptors);
+                await inboxStorageManager.CleanupInboxFiles(file);
             }
         }
 

--- a/src/services/Odin.Services/Peer/Incoming/Drive/Transfer/PeerFileWriter.cs
+++ b/src/services/Odin.Services/Peer/Incoming/Drive/Transfer/PeerFileWriter.cs
@@ -427,10 +427,5 @@ namespace Odin.Services.Peer.Incoming.Drive.Transfer
             return existingFile;
         }
 
-        public async Task CleanupInboxFiles(InternalDriveFileId file, List<PayloadDescriptor> payloads, IOdinContext odinContext)
-        {
-            var fs = fileSystemResolver.ResolveFileSystem(FileSystemType.Standard);
-            await fs.Storage.CleanupInboxTemporaryFiles(file, payloads, odinContext);
-        }
     }
 }

--- a/src/services/Odin.Services/Peer/Incoming/Drive/Transfer/PeerInboxProcessor.cs
+++ b/src/services/Odin.Services/Peer/Incoming/Drive/Transfer/PeerInboxProcessor.cs
@@ -99,14 +99,13 @@ namespace Odin.Services.Peer.Incoming.Drive.Transfer
 
                 PeerFileWriter writer = new PeerFileWriter(logger, fileSystemResolver, driveManager, feedWriter);
                 var markComplete = new MarkInboxComplete(transitInboxBoxStorage, file, inboxItem.Marker);
-                var payloads = new List<PayloadDescriptor>();
                 var success = InboxReturnTypes.DeleteFromInbox;
 
                 try
                 {
                     // This function will have marked the inbox item as complete if successful
                     // Otherwise if it returns false, it's a failure
-                    (success, payloads) = await ProcessInboxItemAsync(file, inboxItem, writer, odinContext, markComplete);
+                    (success, _) = await ProcessInboxItemAsync(file, inboxItem, writer, odinContext, markComplete);
 
                     logger.LogDebug("Item with file ({fileId}) Processed.  success: {s}", file.FileId, success);
                 }
@@ -126,7 +125,7 @@ namespace Odin.Services.Peer.Incoming.Drive.Transfer
                         if (n == 1)
                         {
                             var fs = fileSystemResolver.ResolveFileSystem(inboxItem.FileSystemType);
-                            await fs.Storage.CleanupInboxTemporaryFiles(file, payloads, odinContext);
+                            await fs.Storage.CleanupInboxTemporaryFiles(file, odinContext);
                         }
                         else
                         {
@@ -136,7 +135,7 @@ namespace Odin.Services.Peer.Incoming.Drive.Transfer
                     else if (success == InboxReturnTypes.HasBeenMarkedComplete)
                     {
                         var fs = fileSystemResolver.ResolveFileSystem(inboxItem.FileSystemType);
-                        await fs.Storage.CleanupInboxTemporaryFiles(file, payloads, odinContext);
+                        await fs.Storage.CleanupInboxTemporaryFiles(file, odinContext);
                     }
                 }
             }

--- a/tests/services/Odin.Services.Tests/Drives/DriveCore/Storage/InboxStorageManagerTests.cs
+++ b/tests/services/Odin.Services.Tests/Drives/DriveCore/Storage/InboxStorageManagerTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Odin.Core.Identity;
+using Odin.Services.Base;
+using Odin.Services.Configuration;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Storage;
+using Odin.Services.Drives.FileSystem.Base;
+
+namespace Odin.Services.Tests.Drives.DriveCore.Storage;
+
+public class InboxStorageManagerTests : PayloadReaderWriterBaseTestFixture
+{
+    private OdinConfiguration _config = null!;
+    private TenantContext _tenantContext = null!;
+    private TenantPathManager _tenantPathManager = null!;
+    private FileReaderWriter _fileReaderWriter = null!;
+    private InboxStorageManager _sut = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        BaseSetup();
+
+        _config = new OdinConfiguration
+        {
+            Host = new OdinConfiguration.HostSection
+            {
+                TenantDataRootPath = Path.Combine(TestRootPath, "tenants"),
+                FileOperationRetryAttempts = 1,
+                FileOperationRetryDelayMs = TimeSpan.FromMilliseconds(1),
+            }
+        };
+
+        var tenantId = Guid.NewGuid();
+        _tenantContext = new TenantContext(
+            tenantId,
+            new OdinId("frodo.me"),
+            new TenantPathManager(_config, tenantId),
+            firstRunToken: null,
+            isPreconfigured: true,
+            markedForDeletionDate: null,
+            email: null);
+        _tenantPathManager = _tenantContext.TenantPathManager;
+
+        _fileReaderWriter = new FileReaderWriter(_config, new Mock<ILogger<FileReaderWriter>>().Object);
+        _sut = new InboxStorageManager(_fileReaderWriter, new Mock<ILogger<InboxStorageManager>>().Object, _tenantContext);
+    }
+
+    [TearDown]
+    public void TearDown() => BaseTearDown();
+
+    [Test]
+    public async Task CleanupInboxFiles_DeletesAllStagingFilesForFileId()
+    {
+        // Repro: PeerInboxProcessor catches exceptions during inbox processing and used to call
+        // CleanupInboxFiles with an empty descriptor list, which short-circuited and left
+        // .payload/.thumb files behind (e.g. yossi.silberberg.dk leaked 4 convo_img staging
+        // files). The glob-based cleanup deletes every {fileId:N}.* entry in the drive inbox dir,
+        // independent of whatever descriptors the in-flight processor managed to parse.
+        var file = new InternalDriveFileId { DriveId = Guid.NewGuid(), FileId = Guid.NewGuid() };
+        var driveInboxDir = _tenantPathManager.GetDriveInboxPath(file.DriveId);
+        Directory.CreateDirectory(driveInboxDir);
+
+        var metadata = _tenantPathManager.GetDriveInboxFilePath(file.DriveId, file.FileId, TenantPathManager.MetadataExtension);
+        var keyHeader = _tenantPathManager.GetDriveInboxFilePath(file.DriveId, file.FileId, TenantPathManager.TransferInstructionSetExtension);
+        var payload  = Path.Combine(driveInboxDir, $"{file.FileId:N}.convo_img-116589220245667840.payload");
+        var thumb320 = Path.Combine(driveInboxDir, $"{file.FileId:N}.convo_img-116589220245667840-320x320.thumb");
+        var thumb640 = Path.Combine(driveInboxDir, $"{file.FileId:N}.convo_img-116589220245667840-640x640.thumb");
+
+        foreach (var p in new[] { metadata, keyHeader, payload, thumb320, thumb640 })
+            File.WriteAllText(p, "x");
+
+        await _sut.CleanupInboxFiles(file);
+
+        Assert.That(File.Exists(metadata), Is.False);
+        Assert.That(File.Exists(keyHeader), Is.False);
+        Assert.That(File.Exists(payload),  Is.False);
+        Assert.That(File.Exists(thumb320), Is.False);
+        Assert.That(File.Exists(thumb640), Is.False);
+    }
+
+    [Test]
+    public async Task CleanupInboxFiles_LeavesOtherFileIdsAlone()
+    {
+        // The cleanup is scoped to one fileId. Files for a different fileId in the same drive
+        // inbox dir must not be touched.
+        var driveId = Guid.NewGuid();
+        var targetFile = new InternalDriveFileId { DriveId = driveId, FileId = Guid.NewGuid() };
+        var otherFileId = Guid.NewGuid();
+
+        var driveInboxDir = _tenantPathManager.GetDriveInboxPath(driveId);
+        Directory.CreateDirectory(driveInboxDir);
+
+        var targetPayload = Path.Combine(driveInboxDir, $"{targetFile.FileId:N}.convo_img-1.payload");
+        var otherPayload  = Path.Combine(driveInboxDir, $"{otherFileId:N}.convo_img-2.payload");
+        File.WriteAllText(targetPayload, "x");
+        File.WriteAllText(otherPayload, "x");
+
+        await _sut.CleanupInboxFiles(targetFile);
+
+        Assert.That(File.Exists(targetPayload), Is.False);
+        Assert.That(File.Exists(otherPayload),  Is.True, "Files for a different fileId must not be deleted");
+    }
+
+    [Test]
+    public async Task CleanupInboxFiles_NoThrow_WhenDriveInboxDirMissing()
+    {
+        // No staging dir at all (no transfers ever staged) — must be a no-op, not a throw.
+        var file = new InternalDriveFileId { DriveId = Guid.NewGuid(), FileId = Guid.NewGuid() };
+        Assert.That(Directory.Exists(_tenantPathManager.GetDriveInboxPath(file.DriveId)), Is.False);
+
+        await _sut.CleanupInboxFiles(file);
+    }
+}


### PR DESCRIPTION
PeerInboxProcessor's exception catch arms return (DeleteFromInbox, []), which made the descriptor-based CleanupInboxFiles short-circuit on Count==0 and leave .payload/.thumb files behind. Those surface later as inbox orphans (e.g. yossi.silberberg.dk's 4 convo_img staging files flagged by InboxOrphanScanBackgroundService).

Switch CleanupInboxFiles to glob {fileId:N}.* in the drive inbox dir. The inbox dir is single-purpose staging where every file uses the fileId prefix, and PeerDriveIncomingTransferService.InitializeIncoming Transfer mints a fresh SequentialGuid per receive, so the glob is scoped to one transfer's lifetime and cannot collide with another in-flight transfer.

Drops the now-redundant List<PayloadDescriptor> parameter from CleanupInboxFiles and CleanupInboxTemporaryFiles, and removes the unused PeerFileWriter.CleanupInboxFiles wrapper.