### PR TITLE
Fix duplicate WebSocket notifications scaling with connected devices

### DIFF
--- a/src/apps/Odin.Hosting/TenantServices.cs
+++ b/src/apps/Odin.Hosting/TenantServices.cs
@@ -104,6 +104,14 @@ public static class TenantServices
 
         cb.RegisterGeneric(typeof(SharedDeviceSocketCollection<>)).SingleInstance();
 
+        // Per-tenant singletons that own the single WebSocket pub/sub subscription + fan-out.
+        // Must be singletons so the RefCountedSubscription is shared across all connections of a
+        // tenant (one broker subscription, ref-counted by connection count). Their only
+        // dependencies are singleton-safe; per-connection/DB-bound work stays in the scoped
+        // AppNotificationHandler / PeerAppNotificationHandler below.
+        cb.RegisterType<AppNotificationDispatcher>().AsSelf().SingleInstance();
+        cb.RegisterType<PeerAppNotificationDispatcher>().AsSelf().SingleInstance();
+
         cb.RegisterType<ClientRegistrationStorage>().InstancePerLifetimeScope();
 
         cb.RegisterType<DriveQuery>().InstancePerLifetimeScope();

--- a/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationDispatcher.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationDispatcher.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.Extensions.Logging;
+using Odin.Core;
+using Odin.Core.Exceptions;
+using Odin.Core.Json;
+using Odin.Core.Serialization;
+using Odin.Core.Storage;
+using Odin.Core.Storage.PubSub;
+using Odin.Services.AppNotifications.ClientNotifications;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Storage;
+using Odin.Services.Drives.FileSystem.Base;
+using Odin.Services.Drives.Management;
+using Odin.Services.Mediator;
+using Odin.Services.Peer;
+using Odin.Services.Peer.Incoming.Drive.Transfer;
+using Odin.Services.Tenant.Container;
+
+#nullable enable
+
+namespace Odin.Services.AppNotifications.WebSocket
+{
+    /// <summary>
+    /// Per-tenant singleton that owns the single pub/sub subscription and fans WebSocket
+    /// notifications out to all connected device sockets.
+    ///
+    /// Extracted from <see cref="AppNotificationHandler"/> so the <see cref="RefCountedSubscription"/>
+    /// is shared across every connection of a tenant: connection #1 registers the one broker
+    /// subscription, subsequent connections ref-count onto it, and the last to disconnect tears
+    /// it down. Previously each connection (its own request scope) created its own handler and
+    /// therefore its own subscription, so a single notification was delivered once PER connected
+    /// socket (N copies for N devices).
+    ///
+    /// Only singleton-safe dependencies are held here. Per-connection / DB-bound work (the command
+    /// loop, inbox processing) stays in the scoped <see cref="AppNotificationHandler"/>.
+    /// </summary>
+    public class AppNotificationDispatcher
+    {
+        public const string NotificationChannel = nameof(AppNotificationHandler);
+
+        private readonly ILogger<AppNotificationDispatcher> _logger;
+        private readonly ITenantRootScope _tenantRootScope;
+        private readonly ITenantPubSub _pubSub;
+        private readonly SharedDeviceSocketCollection<AppNotificationHandler> _deviceSocketCollection;
+        private readonly RefCountedSubscription _notificationSubscription;
+
+        // Per-drive coalescer for server-side inbox drains triggered by InboxItemReceived
+        // notifications. The cached gate (TableInboxCached.GetReadyCountAsync) keeps repeat
+        // drains cheap, but under arrival bursts we'd still do redundant DB work; this keeps
+        // it to one in-flight drain per drive per process. Lazy<Task> ensures GetOrAdd's
+        // value factory races never start more than one drain task.
+        private readonly ConcurrentDictionary<Guid, Lazy<Task>> _inFlightDrains = new();
+
+        public AppNotificationDispatcher(
+            ILogger<AppNotificationDispatcher> logger,
+            ITenantRootScope tenantRootScope,
+            ITenantPubSub pubSub,
+            SharedDeviceSocketCollection<AppNotificationHandler> deviceSocketCollection)
+        {
+            _logger = logger;
+            _tenantRootScope = tenantRootScope;
+            _pubSub = pubSub;
+            _deviceSocketCollection = deviceSocketCollection;
+            _notificationSubscription = new RefCountedSubscription(_pubSub, NotificationChannel, NotificationHandler);
+        }
+
+        //
+        // Connection lifecycle (called per-connection by AppNotificationHandler)
+        //
+
+        public void AddSocket(DeviceSocket deviceSocket) => _deviceSocketCollection.AddSocket(deviceSocket);
+
+        public Task RemoveSocket(Guid key) => _deviceSocketCollection.RemoveSocket(key);
+
+        public Task SubscribeAsync(CancellationToken cancellationToken = default) =>
+            _notificationSubscription.SubscribeAsync(cancellationToken);
+
+        public Task UnsubscribeAsync(CancellationToken cancellationToken = default) =>
+            _notificationSubscription.UnsubscribeAsync(cancellationToken);
+
+        //
+
+        private async Task NotificationHandler(JsonEnvelope envelope)
+        {
+            var message = envelope.DeserializeMessage();
+
+            switch (message)
+            {
+                case ClientNotificationMessage notification:
+                    await WsPublishAsync(notification);
+                    return;
+                case DriveNotificationMessage notification:
+                    await WsPublishAsync(notification);
+                    return;
+                case InboxItemReceivedNotificationMessage notification:
+                    await WsPublishAsync(notification);
+                    return;
+                case null:
+                    _logger.LogError("Received null message");
+                    return;
+                default:
+                    _logger.LogError("Unknown message type: {message}", message.GetType().Name);
+                    return;
+            }
+        }
+
+        //
+        // IClientNotification
+        //
+
+        // Src: MediatR
+        // Dst: PubSub queue
+        public async Task PublishClientNotificationAsync(IClientNotification notification)
+        {
+            var shouldEncrypt =
+                !(notification.NotificationType is ClientNotificationType.ConnectionRequestAccepted
+                    or ClientNotificationType.ConnectionRequestReceived);
+
+            var json = OdinSystemSerializer.Serialize(new
+            {
+                notification.NotificationType,
+                Data = notification.GetClientData()
+            });
+
+            var message = new ClientNotificationMessage
+            {
+                ShouldEncrypt = shouldEncrypt,
+                Json = json,
+            };
+
+            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
+        }
+
+        //
+
+        // Src: PubSub queue
+        // Dst: WebSocket
+        private async Task WsPublishAsync(ClientNotificationMessage notification)
+        {
+            var sockets = _deviceSocketCollection.GetAll().Values;
+            foreach (var deviceSocket in sockets)
+            {
+                await SendMessageAsync(
+                    deviceSocket,
+                    notification.Json,
+                    notification.ShouldEncrypt);
+            }
+        }
+
+        //
+        // IDriveNotification
+        //
+
+        // Src: MediatR
+        // Dst: PubSub queue
+        public async Task PublishDriveNotificationAsync(IDriveNotification notification)
+        {
+            var message = new DriveNotificationMessage
+            {
+                NotificationType = notification.NotificationType,
+                File = notification.File,
+                IsDeleteNotification = notification is DriveFileDeletedNotification,
+                ServerFileHeader = notification.ServerFileHeader,
+                PreviousServerFileHeader = (notification as DriveFileDeletedNotification)?.PreviousServerFileHeader
+            };
+
+            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
+        }
+
+        //
+
+        // Src: PubSub queue
+        // Dst: WebSocket
+        private async Task WsPublishAsync(DriveNotificationMessage notification)
+        {
+            var sockets = _deviceSocketCollection.GetAll().Values
+                .Where(ds => ds.Drives.Any(driveId => driveId == notification.File.DriveId))
+                .ToList();
+
+            if (sockets.Count == 0)
+            {
+                return;
+            }
+
+            await using var scope = _tenantRootScope.BeginLifetimeScope();
+            if (scope == null)
+            {
+                return;
+            }
+
+            var driveManager =  scope.Resolve<IDriveManager>();
+            var drive = await driveManager.GetDriveAsync(notification.File.DriveId);
+
+            foreach (var deviceSocket in sockets)
+            {
+                var deviceOdinContext = deviceSocket.DeviceOdinContext;
+                var hasSharedSecret = null != deviceOdinContext?.PermissionsContext?.SharedSecretKey;
+
+                var o = new ClientDriveNotification
+                {
+                    TargetDrive = drive?.TargetDriveInfo,
+                    Header = hasSharedSecret
+                        ? DriveFileUtility.CreateClientFileHeader(notification.ServerFileHeader, deviceOdinContext)
+                        : null,
+                    PreviousServerFileHeader = hasSharedSecret
+                        ? notification.IsDeleteNotification
+                            ? DriveFileUtility.CreateClientFileHeader(notification.PreviousServerFileHeader, deviceOdinContext!)
+                            : null
+                        : null
+                };
+
+                var json = OdinSystemSerializer.Serialize(new
+                {
+                    notification.NotificationType,
+                    Data = OdinSystemSerializer.Serialize(o)
+                });
+
+                await SendMessageAsync(deviceSocket, json, encrypt: true);
+            }
+        }
+
+        //
+        // InboxItemReceivedNotification
+        //
+
+        // TODO: This notification is largely redundant now. TryDrainInboxForDriveAsync runs
+        // synchronously before we send InboxItemReceived to clients, and any
+        // DriveFileAddedNotification it produces fans out as FileAdded over the same WS
+        // (via PublishDriveNotificationAsync) — carrying the actual file header. The bare
+        // "something arrived" ping is therefore useful only when no FileAdded will follow.
+        // Suppress per TransferFileType once clients have migrated: keep it for types that
+        // don't produce a FileAdded (e.g. read receipts, reactions) and drop it for the rest.
+
+        // Src: MediatR
+        // Dst: PubSub queue
+        public async Task PublishInboxItemReceivedAsync(InboxItemReceivedNotification notification)
+        {
+            var message = new InboxItemReceivedNotificationMessage
+            {
+                NotificationType = notification.NotificationType,
+                TargetDrive = notification.TargetDrive,
+                FileSystemType = notification.FileSystemType,
+                TransferFileType = notification.TransferFileType,
+            };
+
+            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
+        }
+
+        // Src: PubSub queue
+        // Dst: WebSocket
+        private async Task WsPublishAsync(InboxItemReceivedNotificationMessage notification)
+        {
+            var notificationDriveId = notification.TargetDrive.Alias;
+
+            // Opportunistic server-side inbox drain, mirroring the QueryBatch path.
+            // We use an owner-acting context already cached on a locally-subscribed
+            // DeviceSocket; any DriveFileAdded events the drain produces will fan out
+            // through PublishDriveNotificationAsync onto the same sockets.
+            await TryDrainInboxForDriveAsync(notificationDriveId);
+
+            var translated = new TranslatedClientNotification(notification.NotificationType,
+                OdinSystemSerializer.Serialize(new
+                {
+                    TargetDrive = notification.TargetDrive,
+                    notification.TransferFileType,
+                    notification.FileSystemType
+                }));
+
+            await SerializeSendToAllDevicesForDrive(notificationDriveId, translated, false);
+        }
+
+        //
+
+        private async Task TryDrainInboxForDriveAsync(Guid driveId)
+        {
+            var deviceOdinContext = _deviceSocketCollection.GetAll().Values
+                .Select(ds => ds.DeviceOdinContext)
+                .FirstOrDefault(ctx => ctx != null && PeerInboxDriveQueue.IsAuthorizedToDrain(driveId, ctx));
+
+            if (deviceOdinContext == null)
+            {
+                return;
+            }
+
+            var lazy = _inFlightDrains.GetOrAdd(driveId,
+                id => new Lazy<Task>(() => RunDrainAsync(id, deviceOdinContext)));
+
+            try
+            {
+                await lazy.Value;
+            }
+            catch (Exception e)
+            {
+                // InboxDrainOnQuery already swallows and logs internally; this is defensive
+                // so a drain failure can never break the WS notification fan-out.
+                _logger.LogInformation(e, "Inbox drain on WS notify failed: {error}", e.Message);
+            }
+        }
+
+        private async Task RunDrainAsync(Guid driveId, IOdinContext deviceOdinContext)
+        {
+            try
+            {
+                await using var scope = _tenantRootScope.BeginLifetimeScope();
+                if (scope == null)
+                {
+                    return;
+                }
+
+                var drain = scope.Resolve<InboxDrainOnQuery>();
+                await drain.DrainIfReadyAsync(driveId, deviceOdinContext);
+            }
+            finally
+            {
+                _inFlightDrains.TryRemove(driveId, out _);
+            }
+        }
+
+        //
+
+        private async Task SerializeSendToAllDevicesForDrive(
+            Guid targetDriveId,
+            IClientNotification notification,
+            bool encrypt,
+            CancellationToken cancellationToken = default)
+        {
+            var json = OdinSystemSerializer.Serialize(new
+            {
+                notification.NotificationType,
+                Data = notification.GetClientData()
+            });
+
+            var sockets = _deviceSocketCollection.GetAll().Values
+                .Where(ds => ds.Drives.Any(driveId => driveId == targetDriveId));
+
+            foreach (var deviceSocket in sockets)
+            {
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await SendMessageAsync(deviceSocket, json, encrypt, cancellationToken);
+                }
+            }
+        }
+
+        //
+
+        private static string JsonMessage(ClientNotificationType notificationType, string message)
+        {
+            return OdinSystemSerializer.Serialize(new
+            {
+                NotificationType = notificationType,
+                Data = message,
+            });
+        }
+
+        //
+
+        public async Task SendErrorMessageAsync(DeviceSocket deviceSocket, string errorText, CancellationToken cancellationToken = default)
+        {
+            var json = JsonMessage(ClientNotificationType.Error, errorText);
+            await SendMessageAsync(
+                deviceSocket,
+                json,
+                deviceSocket.DeviceOdinContext?.PermissionsContext?.SharedSecretKey != null,
+                cancellationToken);
+        }
+
+        //
+
+        public async Task SendMessageAsync(
+            DeviceSocket deviceSocket,
+            string message,
+            bool encrypt,
+            CancellationToken cancellationToken = default)
+        {
+            var socket = deviceSocket.Socket;
+
+            if (socket is not { State: WebSocketState.Open } || cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            try
+            {
+                if (encrypt)
+                {
+                    if (deviceSocket.DeviceOdinContext == null)
+                    {
+                        await _deviceSocketCollection.RemoveSocket(deviceSocket.Key);
+                        _logger.LogInformation("Invalid/Stale Device found; removing from list; closing socket");
+                        throw new WebSocketException("Missing device odin context");
+                    }
+
+                    if (deviceSocket.DeviceOdinContext.PermissionsContext?.SharedSecretKey == null)
+                    {
+                        throw new OdinSystemException("Cannot encrypt message without shared secret key");
+                    }
+
+                    var key = deviceSocket.DeviceOdinContext.PermissionsContext.SharedSecretKey;
+                    var encryptedPayload = SharedSecretEncryptedPayload.Encrypt(message.ToUtf8ByteArray(), key);
+                    message = OdinSystemSerializer.Serialize(encryptedPayload);
+                }
+
+                var payload = new ClientNotificationPayload()
+                {
+                    IsEncrypted = encrypt,
+                    Payload = message
+                };
+
+                var json = OdinSystemSerializer.Serialize(payload);
+                await deviceSocket.FireAndForgetAsync(json, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore, this exception is expected when the socket is closing behind the scenes
+            }
+            catch (WebSocketException e)
+            {
+                _logger.LogInformation("WebSocketException: {error}", e.Message);
+            }
+            catch (Exception e)
+            {
+                //HACK: need to find out what is trying to write when the response is complete
+                _logger.LogError(e, "SendMessageAsync: {error}", e.Message);
+            }
+        }
+
+        //
+
+        private class ClientNotificationMessage
+        {
+            public required bool ShouldEncrypt { get; init; }
+            public required string Json { get; init; }
+        }
+
+        private class DriveNotificationMessage
+        {
+            public required ClientNotificationType NotificationType { get; init; }
+            public required InternalDriveFileId File { get; init; }
+            public required bool IsDeleteNotification { get; init; }
+            public required ServerFileHeader ServerFileHeader { get; init; }
+            public required ServerFileHeader? PreviousServerFileHeader { get; init; }
+        }
+
+        private class InboxItemReceivedNotificationMessage
+        {
+            public required ClientNotificationType NotificationType { get; init; }
+            public required TargetDrive TargetDrive { get; init; }
+            public required FileSystemType FileSystemType { get; init; }
+            public required TransferFileType TransferFileType { get; init; }
+        }
+    }
+}

--- a/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationHandler.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationHandler.cs
@@ -1,82 +1,55 @@
-﻿using System;
-using System.Collections.Concurrent;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.WebSockets;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Odin.Core;
 using Odin.Core.Exceptions;
-using Odin.Core.Json;
 using Odin.Core.Serialization;
-using Odin.Core.Storage;
-using Odin.Core.Storage.PubSub;
 using Odin.Services.AppNotifications.ClientNotifications;
 using Odin.Services.Base;
 using Odin.Services.Drives;
-using Odin.Services.Drives.DriveCore.Storage;
-using Odin.Services.Drives.FileSystem.Base;
-using Odin.Services.Drives.Management;
 using Odin.Services.Mediator;
 using Odin.Services.Peer;
 using Odin.Services.Peer.Incoming.Drive.Transfer;
-using Odin.Services.Tenant.Container;
 
 #nullable enable
 
-// SEB:TODO this file needs to be combined with AppNotificationHandler.cs
-
-// SEB:TODO this file needs to be split up into different classes handling
-// - websocket incoming and outgoing messages
-// - client notifications (i.e. messages coming from the "inside" and going out to a websocket)
-
-// SEB:TODO cleanup SendMessageAsync params
-
 namespace Odin.Services.AppNotifications.WebSocket
 {
+    /// <summary>
+    /// Scoped MediatR handler and per-connection WebSocket command processor.
+    ///
+    /// The shared subscription and the fan-out of notifications to all connected sockets live
+    /// in the per-tenant singleton <see cref="AppNotificationDispatcher"/>; this class delegates
+    /// to it. Keeping this class scoped lets it use request/DB-bound services (e.g.
+    /// <see cref="PeerInboxProcessor"/>) for the per-connection command loop without making them
+    /// captive dependencies of a singleton.
+    /// </summary>
     public class AppNotificationHandler :
         INotificationHandler<IClientNotification>,
         INotificationHandler<IDriveNotification>,
         INotificationHandler<InboxItemReceivedNotification>
     {
-        private const string NotificationChannel = nameof(AppNotificationHandler);
-
         private readonly ILogger<AppNotificationHandler> _logger;
-        private readonly ITenantRootScope _tenantRootScope;
-        private readonly ITenantPubSub _pubSub;
+        private readonly AppNotificationDispatcher _dispatcher;
         private readonly PeerInboxProcessor _peerInboxProcessor;
-        private readonly SharedDeviceSocketCollection<AppNotificationHandler> _deviceSocketCollection;
-        private readonly RefCountedSubscription _notificationSubscription;
-
-        // Per-drive coalescer for server-side inbox drains triggered by InboxItemReceived
-        // notifications. The cached gate (TableInboxCached.GetReadyCountAsync) keeps repeat
-        // drains cheap, but under arrival bursts we'd still do redundant DB work; this keeps
-        // it to one in-flight drain per drive per process. Lazy<Task> ensures GetOrAdd's
-        // value factory races never start more than one drain task.
-        private readonly ConcurrentDictionary<Guid, Lazy<Task>> _inFlightDrains = new();
 
         public AppNotificationHandler(
             ILogger<AppNotificationHandler> logger,
-            ITenantRootScope tenantRootScope,
-            ITenantPubSub pubSub,
-            PeerInboxProcessor peerInboxProcessor,
-            SharedDeviceSocketCollection<AppNotificationHandler> deviceSocketCollection)
+            AppNotificationDispatcher dispatcher,
+            PeerInboxProcessor peerInboxProcessor)
         {
             _logger = logger;
-            _tenantRootScope = tenantRootScope;
-            _pubSub = pubSub;
+            _dispatcher = dispatcher;
             _peerInboxProcessor = peerInboxProcessor;
-            _deviceSocketCollection = deviceSocketCollection;
-            _notificationSubscription = new RefCountedSubscription(_pubSub, NotificationChannel, NotificationHandler);
         }
 
         //
-
 
         /// <summary>
         /// Awaits the configuration when establishing a new web socket connection
@@ -94,9 +67,9 @@ namespace Odin.Services.AppNotifications.WebSocket
                     Key = webSocketKey,
                     Socket = webSocket,
                 };
-                _deviceSocketCollection.AddSocket(deviceSocket);
+                _dispatcher.AddSocket(deviceSocket);
 
-                await _notificationSubscription.SubscribeAsync(cancellationToken);
+                await _dispatcher.SubscribeAsync(cancellationToken);
                 await AwaitCommands(deviceSocket, odinContext, cancellationToken);
             }
             catch (OperationCanceledException)
@@ -114,8 +87,8 @@ namespace Odin.Services.AppNotifications.WebSocket
             }
             finally
             {
-                await _notificationSubscription.UnsubscribeAsync(CancellationToken.None);
-                await _deviceSocketCollection.RemoveSocket(webSocketKey);
+                await _dispatcher.UnsubscribeAsync(CancellationToken.None);
+                await _dispatcher.RemoveSocket(webSocketKey);
                 _logger.LogTrace("WebSocket closed");
             }
         }
@@ -199,72 +172,14 @@ namespace Odin.Services.AppNotifications.WebSocket
         }
 
         //
-
-        private async Task NotificationHandler(JsonEnvelope envelope)
-        {
-            var message = envelope.DeserializeMessage();
-
-            switch (message)
-            {
-                case ClientNotificationMessage notification:
-                    await WsPublishAsync(notification);
-                    return;
-                case DriveNotificationMessage notification:
-                    await WsPublishAsync(notification);
-                    return;
-                case InboxItemReceivedNotificationMessage notification:
-                    await WsPublishAsync(notification);
-                    return;
-                case null:
-                    _logger.LogError("Received null message");
-                    return;
-                default:
-                    _logger.LogError("Unknown message type: {message}", message.GetType().Name);
-                    return;
-            }
-        }
-
-        //
         // IClientNotification
         //
 
         // Src: MediatR
-        // Dst: PubSub queue
-        public async Task Handle(IClientNotification notification, CancellationToken cancellationToken = default)
+        // Dst: PubSub queue (via the per-tenant dispatcher)
+        public Task Handle(IClientNotification notification, CancellationToken cancellationToken = default)
         {
-            var shouldEncrypt =
-                !(notification.NotificationType is ClientNotificationType.ConnectionRequestAccepted
-                    or ClientNotificationType.ConnectionRequestReceived);
-
-            var json = OdinSystemSerializer.Serialize(new
-            {
-                notification.NotificationType,
-                Data = notification.GetClientData()
-            });
-
-            var message = new ClientNotificationMessage
-            {
-                ShouldEncrypt = shouldEncrypt,
-                Json = json,
-            };
-
-            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
-        }
-
-        //
-
-        // Src: PubSub queue
-        // Dst: WebSocket
-        private async Task WsPublishAsync(ClientNotificationMessage notification)
-        {
-            var sockets = _deviceSocketCollection.GetAll().Values;
-            foreach (var deviceSocket in sockets)
-            {
-                await SendMessageAsync(
-                    deviceSocket,
-                    notification.Json,
-                    notification.ShouldEncrypt);
-            }
+            return _dispatcher.PublishClientNotificationAsync(notification);
         }
 
         //
@@ -272,281 +187,39 @@ namespace Odin.Services.AppNotifications.WebSocket
         //
 
         // Src: MediatR
-        // Dst: PubSub queue
-        public async Task Handle(IDriveNotification notification, CancellationToken cancellationToken = default)
+        // Dst: PubSub queue (via the per-tenant dispatcher)
+        public Task Handle(IDriveNotification notification, CancellationToken cancellationToken = default)
         {
-            var message = new DriveNotificationMessage
-            {
-                NotificationType = notification.NotificationType,
-                File = notification.File,
-                IsDeleteNotification = notification is DriveFileDeletedNotification,
-                ServerFileHeader = notification.ServerFileHeader,
-                PreviousServerFileHeader = (notification as DriveFileDeletedNotification)?.PreviousServerFileHeader
-            };
-
-            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
-        }
-
-        //
-
-        // Src: PubSub queue
-        // Dst: WebSocket
-        private async Task WsPublishAsync(DriveNotificationMessage notification)
-        {
-            var sockets = _deviceSocketCollection.GetAll().Values
-                .Where(ds => ds.Drives.Any(driveId => driveId == notification.File.DriveId))
-                .ToList();
-
-            if (sockets.Count == 0)
-            {
-                return;
-            }
-
-            await using var scope = _tenantRootScope.BeginLifetimeScope();
-            if (scope == null)
-            {
-                return;
-            }
-
-            var driveManager =  scope.Resolve<IDriveManager>();
-            var drive = await driveManager.GetDriveAsync(notification.File.DriveId);
-
-            foreach (var deviceSocket in sockets)
-            {
-                var deviceOdinContext = deviceSocket.DeviceOdinContext;
-                var hasSharedSecret = null != deviceOdinContext?.PermissionsContext?.SharedSecretKey;
-
-                var o = new ClientDriveNotification
-                {
-                    TargetDrive = drive?.TargetDriveInfo,
-                    Header = hasSharedSecret
-                        ? DriveFileUtility.CreateClientFileHeader(notification.ServerFileHeader, deviceOdinContext)
-                        : null,
-                    PreviousServerFileHeader = hasSharedSecret
-                        ? notification.IsDeleteNotification
-                            ? DriveFileUtility.CreateClientFileHeader(notification.PreviousServerFileHeader, deviceOdinContext!)
-                            : null
-                        : null
-                };
-
-                var json = OdinSystemSerializer.Serialize(new
-                {
-                    notification.NotificationType,
-                    Data = OdinSystemSerializer.Serialize(o)
-                });
-
-                await SendMessageAsync(deviceSocket, json, encrypt: true);
-            }
+            return _dispatcher.PublishDriveNotificationAsync(notification);
         }
 
         //
         // InboxItemReceivedNotification
         //
 
-        // TODO: This notification is largely redundant now. TryDrainInboxForDriveAsync runs
-        // synchronously before we send InboxItemReceived to clients, and any
-        // DriveFileAddedNotification it produces fans out as FileAdded over the same WS
-        // (via Handle(IDriveNotification)) — carrying the actual file header. The bare
-        // "something arrived" ping is therefore useful only when no FileAdded will follow.
-        // Suppress per TransferFileType once clients have migrated: keep it for types that
-        // don't produce a FileAdded (e.g. read receipts, reactions) and drop it for the rest.
-        // Note: empirical testing showed InboxItemReceived does not currently reach the
-        // owner WS in the peer-file-arrival scenario at all — there is little owner-WS
-        // back-compat surface to preserve. The peer-app WS path (PeerAppNotificationHandler)
-        // may differ; verify before removing.
-
         // Src: MediatR
-        // Dst: PubSub queue
-        public async Task Handle(InboxItemReceivedNotification notification, CancellationToken cancellationToken = default)
+        // Dst: PubSub queue (via the per-tenant dispatcher)
+        public Task Handle(InboxItemReceivedNotification notification, CancellationToken cancellationToken = default)
         {
-            var message = new InboxItemReceivedNotificationMessage
-            {
-                NotificationType = notification.NotificationType,
-                TargetDrive = notification.TargetDrive,
-                FileSystemType = notification.FileSystemType,
-                TransferFileType = notification.TransferFileType,
-            };
-
-            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
-        }
-
-        // Src: PubSub queue
-        // Dst: WebSocket
-        private async Task WsPublishAsync(InboxItemReceivedNotificationMessage notification)
-        {
-            var notificationDriveId = notification.TargetDrive.Alias;
-
-            // Opportunistic server-side inbox drain, mirroring the QueryBatch path.
-            // We use an owner-acting context already cached on a locally-subscribed
-            // DeviceSocket; any DriveFileAdded events the drain produces will fan out
-            // through Handle(IDriveNotification) onto the same sockets.
-            await TryDrainInboxForDriveAsync(notificationDriveId);
-
-            var translated = new TranslatedClientNotification(notification.NotificationType,
-                OdinSystemSerializer.Serialize(new
-                {
-                    TargetDrive = notification.TargetDrive,
-                    notification.TransferFileType,
-                    notification.FileSystemType
-                }));
-
-            await SerializeSendToAllDevicesForDrive(notificationDriveId, translated, false);
+            return _dispatcher.PublishInboxItemReceivedAsync(notification);
         }
 
         //
 
-        private async Task TryDrainInboxForDriveAsync(Guid driveId)
+        private Task SendErrorMessageAsync(DeviceSocket deviceSocket, string errorText, CancellationToken cancellationToken = default)
         {
-            var deviceOdinContext = _deviceSocketCollection.GetAll().Values
-                .Select(ds => ds.DeviceOdinContext)
-                .FirstOrDefault(ctx => ctx != null && PeerInboxDriveQueue.IsAuthorizedToDrain(driveId, ctx));
-
-            if (deviceOdinContext == null)
-            {
-                return;
-            }
-
-            var lazy = _inFlightDrains.GetOrAdd(driveId,
-                id => new Lazy<Task>(() => RunDrainAsync(id, deviceOdinContext)));
-
-            try
-            {
-                await lazy.Value;
-            }
-            catch (Exception e)
-            {
-                // InboxDrainOnQuery already swallows and logs internally; this is defensive
-                // so a drain failure can never break the WS notification fan-out.
-                _logger.LogInformation(e, "Inbox drain on WS notify failed: {error}", e.Message);
-            }
-        }
-
-        private async Task RunDrainAsync(Guid driveId, IOdinContext deviceOdinContext)
-        {
-            try
-            {
-                await using var scope = _tenantRootScope.BeginLifetimeScope();
-                if (scope == null)
-                {
-                    return;
-                }
-
-                var drain = scope.Resolve<InboxDrainOnQuery>();
-                await drain.DrainIfReadyAsync(driveId, deviceOdinContext);
-            }
-            finally
-            {
-                _inFlightDrains.TryRemove(driveId, out _);
-            }
+            return _dispatcher.SendErrorMessageAsync(deviceSocket, errorText, cancellationToken);
         }
 
         //
 
-        private async Task SerializeSendToAllDevicesForDrive(
-            Guid targetDriveId,
-            IClientNotification notification,
-            bool encrypt,
-            CancellationToken cancellationToken = default)
-        {
-            var json = OdinSystemSerializer.Serialize(new
-            {
-                notification.NotificationType,
-                Data = notification.GetClientData()
-            });
-
-            var sockets = _deviceSocketCollection.GetAll().Values
-                .Where(ds => ds.Drives.Any(driveId => driveId == targetDriveId));
-
-            foreach (var deviceSocket in sockets)
-            {
-                if (!cancellationToken.IsCancellationRequested)
-                {
-                    await SendMessageAsync(deviceSocket, json, encrypt, cancellationToken);
-                }
-            }
-        }
-
-        //
-
-        private static string JsonMessage(ClientNotificationType notificationType, string message)
-        {
-            return OdinSystemSerializer.Serialize(new
-            {
-                NotificationType = notificationType,
-                Data = message,
-            });
-        }
-
-        //
-
-        private async Task SendErrorMessageAsync(DeviceSocket deviceSocket, string errorText, CancellationToken cancellationToken = default)
-        {
-            var json = JsonMessage(ClientNotificationType.Error, errorText);
-            await SendMessageAsync(
-                deviceSocket,
-                json,
-                deviceSocket.DeviceOdinContext?.PermissionsContext?.SharedSecretKey != null,
-                cancellationToken);
-        }
-
-        //
-
-        private async Task SendMessageAsync(
+        private Task SendMessageAsync(
             DeviceSocket deviceSocket,
             string message,
             bool encrypt,
             CancellationToken cancellationToken = default)
         {
-            var socket = deviceSocket.Socket;
-
-            if (socket is not { State: WebSocketState.Open } || cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
-
-            try
-            {
-                if (encrypt)
-                {
-                    if (deviceSocket.DeviceOdinContext == null)
-                    {
-                        await _deviceSocketCollection.RemoveSocket(deviceSocket.Key);
-                        _logger.LogInformation("Invalid/Stale Device found; removing from list; closing socket");
-                        throw new WebSocketException("Missing device odin context");
-                    }
-
-                    if (deviceSocket.DeviceOdinContext.PermissionsContext?.SharedSecretKey == null)
-                    {
-                        throw new OdinSystemException("Cannot encrypt message without shared secret key");
-                    }
-
-                    var key = deviceSocket.DeviceOdinContext.PermissionsContext.SharedSecretKey;
-                    var encryptedPayload = SharedSecretEncryptedPayload.Encrypt(message.ToUtf8ByteArray(), key);
-                    message = OdinSystemSerializer.Serialize(encryptedPayload);
-                }
-
-                var payload = new ClientNotificationPayload()
-                {
-                    IsEncrypted = encrypt,
-                    Payload = message
-                };
-
-                var json = OdinSystemSerializer.Serialize(payload);
-                await deviceSocket.FireAndForgetAsync(json, cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                // ignore, this exception is expected when the socket is closing behind the scenes
-            }
-            catch (WebSocketException e)
-            {
-                _logger.LogInformation("WebSocketException: {error}", e.Message);
-            }
-            catch (Exception e)
-            {
-                //HACK: need to find out what is trying to write when the response is complete
-                _logger.LogError(e, "SendMessageAsync: {error}", e.Message);
-            }
+            return _dispatcher.SendMessageAsync(deviceSocket, message, encrypt, cancellationToken);
         }
 
         //
@@ -629,27 +302,13 @@ namespace Odin.Services.AppNotifications.WebSocket
 
         //
 
-        private class ClientNotificationMessage
+        private static string JsonMessage(ClientNotificationType notificationType, string message)
         {
-            public required bool ShouldEncrypt { get; init; }
-            public required string Json { get; init; }
-        }
-
-        private class DriveNotificationMessage
-        {
-            public required ClientNotificationType NotificationType { get; init; }
-            public required InternalDriveFileId File { get; init; }
-            public required bool IsDeleteNotification { get; init; }
-            public required ServerFileHeader ServerFileHeader { get; init; }
-            public required ServerFileHeader? PreviousServerFileHeader { get; init; }
-        }
-
-        private class InboxItemReceivedNotificationMessage
-        {
-            public required ClientNotificationType NotificationType { get; init; }
-            public required TargetDrive TargetDrive { get; init; }
-            public required FileSystemType FileSystemType { get; init; }
-            public required TransferFileType TransferFileType { get; init; }
+            return OdinSystemSerializer.Serialize(new
+            {
+                NotificationType = notificationType,
+                Data = message,
+            });
         }
     }
 }

--- a/src/services/Odin.Services/AppNotifications/WebSocket/PeerAppNotificationDispatcher.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/PeerAppNotificationDispatcher.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.Extensions.Logging;
+using Odin.Core;
+using Odin.Core.Exceptions;
+using Odin.Core.Json;
+using Odin.Core.Serialization;
+using Odin.Core.Storage;
+using Odin.Core.Storage.PubSub;
+using Odin.Services.AppNotifications.ClientNotifications;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Storage;
+using Odin.Services.Drives.FileSystem.Base;
+using Odin.Services.Drives.Management;
+using Odin.Services.Mediator;
+using Odin.Services.Tenant.Container;
+
+#nullable enable
+
+namespace Odin.Services.AppNotifications.WebSocket
+{
+    /// <summary>
+    /// Per-tenant singleton owning the single pub/sub subscription and WebSocket fan-out for the
+    /// peer-app notification pipeline. Counterpart of <see cref="AppNotificationDispatcher"/>;
+    /// see that class for why the subscription must be shared across all connections of a tenant.
+    /// Uses a distinct channel and a distinct <see cref="SharedDeviceSocketCollection{T}"/> from
+    /// the app pipeline, so the two never cross-contaminate.
+    /// </summary>
+    public class PeerAppNotificationDispatcher
+    {
+        public const string NotificationChannel = nameof(PeerAppNotificationHandler);
+
+        private readonly ILogger<PeerAppNotificationDispatcher> _logger;
+        private readonly ITenantRootScope _tenantRootScope;
+        private readonly ITenantPubSub _pubSub;
+        private readonly SharedDeviceSocketCollection<PeerAppNotificationHandler> _deviceSocketCollection;
+        private readonly RefCountedSubscription _notificationSubscription;
+
+        public PeerAppNotificationDispatcher(
+            ILogger<PeerAppNotificationDispatcher> logger,
+            ITenantRootScope tenantRootScope,
+            ITenantPubSub pubSub,
+            SharedDeviceSocketCollection<PeerAppNotificationHandler> deviceSocketCollection)
+        {
+            _logger = logger;
+            _tenantRootScope = tenantRootScope;
+            _pubSub = pubSub;
+            _deviceSocketCollection = deviceSocketCollection;
+            _notificationSubscription = new RefCountedSubscription(_pubSub, NotificationChannel, NotificationHandler);
+        }
+
+        //
+        // Connection lifecycle (called per-connection by PeerAppNotificationHandler)
+        //
+
+        public void AddSocket(DeviceSocket deviceSocket) => _deviceSocketCollection.AddSocket(deviceSocket);
+
+        public Task RemoveSocket(Guid key) => _deviceSocketCollection.RemoveSocket(key);
+
+        public Task SubscribeAsync(CancellationToken cancellationToken = default) =>
+            _notificationSubscription.SubscribeAsync(cancellationToken);
+
+        public Task UnsubscribeAsync(CancellationToken cancellationToken = default) =>
+            _notificationSubscription.UnsubscribeAsync(cancellationToken);
+
+        //
+
+        private async Task NotificationHandler(JsonEnvelope envelope)
+        {
+            var message = envelope.DeserializeMessage();
+
+            switch (message)
+            {
+                case ClientNotificationMessage notification:
+                    await WsPublishAsync(notification);
+                    return;
+                case DriveNotificationMessage notification:
+                    await WsPublishAsync(notification);
+                    return;
+                case null:
+                    _logger.LogError("Received null message");
+                    return;
+                default:
+                    _logger.LogError("Unknown message type: {message}", message.GetType().Name);
+                    return;
+            }
+        }
+
+        //
+        // IClientNotification
+        //
+
+        // Src: MediatR
+        // Dst: PubSub queue
+        public async Task PublishClientNotificationAsync(IClientNotification notification)
+        {
+            var json = OdinSystemSerializer.Serialize(new
+            {
+                notification.NotificationType,
+                Data = notification.GetClientData()
+            });
+
+            var message = new ClientNotificationMessage
+            {
+                Json = json,
+            };
+
+            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
+        }
+
+        //
+
+        // Src: PubSub queue
+        // Dst: WebSocket
+        private async Task WsPublishAsync(ClientNotificationMessage notification)
+        {
+            var sockets = _deviceSocketCollection.GetAll().Values;
+            foreach (var deviceSocket in sockets)
+            {
+                await SendMessageAsync(deviceSocket, notification.Json, true);
+            }
+        }
+
+        //
+        // IDriveNotification
+        //
+
+        // Src: MediatR
+        // Dst: PubSub queue
+        public async Task PublishDriveNotificationAsync(IDriveNotification notification)
+        {
+            var message = new DriveNotificationMessage
+            {
+                NotificationType  = notification.NotificationType,
+                File = notification.File,
+                IsDeleteNotification = notification is DriveFileDeletedNotification,
+                ServerFileHeader = notification.ServerFileHeader,
+                PreviousServerFileHeader = (notification as DriveFileDeletedNotification)?.PreviousServerFileHeader
+            };
+
+            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
+        }
+
+        //
+
+        // Src: PubSub queue
+        // Dst: WebSocket
+        private async Task WsPublishAsync(DriveNotificationMessage notification)
+        {
+            var sockets = _deviceSocketCollection.GetAll().Values
+                .Where(ds => ds.Drives.Any(driveId => driveId == notification.File.DriveId))
+                .ToList();
+
+            if (sockets.Count == 0)
+            {
+                return;
+            }
+
+            await using var scope = _tenantRootScope.BeginLifetimeScope();
+            if (scope == null)
+            {
+                return;
+            }
+
+            var driveManager =  scope.Resolve<IDriveManager>();
+            var drive = await driveManager.GetDriveAsync(notification.File.DriveId);
+
+            foreach (var deviceSocket in sockets)
+            {
+                var deviceOdinContext = deviceSocket.DeviceOdinContext;
+                var hasSharedSecret = null != deviceOdinContext?.PermissionsContext?.SharedSecretKey;
+
+                var o = new ClientDriveNotification
+                {
+                    TargetDrive = drive?.TargetDriveInfo,
+                    Header = hasSharedSecret
+                        ? DriveFileUtility.CreateClientFileHeader(notification.ServerFileHeader, deviceOdinContext)
+                        : null,
+                    PreviousServerFileHeader = hasSharedSecret
+                        ? notification.IsDeleteNotification
+                            ? DriveFileUtility.CreateClientFileHeader(notification.PreviousServerFileHeader, deviceOdinContext!)
+                            : null
+                        : null
+                };
+
+                var json = OdinSystemSerializer.Serialize(new
+                {
+                    notification.NotificationType,
+                    Data = OdinSystemSerializer.Serialize(o)
+                });
+
+                await SendMessageAsync(
+                    deviceSocket,
+                    json,
+                    encrypt: true);
+            }
+        }
+
+        //
+
+        public async Task SendErrorMessageAsync(DeviceSocket deviceSocket, string errorText, CancellationToken cancellationToken = default)
+        {
+            await SendMessageAsync(deviceSocket, OdinSystemSerializer.Serialize(new
+                {
+                    NotificationType = ClientNotificationType.Error,
+                    Data = errorText,
+                }),
+                deviceSocket.DeviceOdinContext?.PermissionsContext?.SharedSecretKey != null,
+                sendEvenIfNoDeviceOdinContext: false,
+                cancellationToken);
+        }
+
+        //
+
+        public async Task SendMessageAsync(
+            DeviceSocket deviceSocket,
+            string message,
+            bool encrypt,
+            bool sendEvenIfNoDeviceOdinContext = false,
+            CancellationToken cancellationToken = default)
+        {
+            var socket = deviceSocket.Socket;
+
+            if (socket is not { State: WebSocketState.Open } || cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (deviceSocket.DeviceOdinContext == null)
+            {
+                await _deviceSocketCollection.RemoveSocket(deviceSocket.Key);
+                _logger.LogInformation("Invalid/Stale Device found; removing from list");
+                if (sendEvenIfNoDeviceOdinContext)
+                {
+                    var payload = new ClientNotificationPayload()
+                    {
+                        IsEncrypted = false,
+                        Payload = message
+                    };
+
+                    var json = OdinSystemSerializer.Serialize(payload);
+                    await deviceSocket.FireAndForgetAsync(json, cancellationToken);
+                }
+
+                return;
+            }
+
+            try
+            {
+                if (encrypt)
+                {
+                    if (deviceSocket.DeviceOdinContext.PermissionsContext?.SharedSecretKey == null)
+                    {
+                        throw new OdinSystemException("Cannot encrypt message without shared secret key");
+                    }
+
+                    var key = deviceSocket.DeviceOdinContext.PermissionsContext.SharedSecretKey;
+                    var encryptedPayload = SharedSecretEncryptedPayload.Encrypt(message.ToUtf8ByteArray(), key);
+                    message = OdinSystemSerializer.Serialize(encryptedPayload);
+                }
+
+                var payload = new ClientNotificationPayload()
+                {
+                    IsEncrypted = encrypt,
+                    Payload = message
+                };
+
+                var json = OdinSystemSerializer.Serialize(payload);
+                await deviceSocket.FireAndForgetAsync(json, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore, this exception is expected when the socket is closing behind the scenes
+            }
+            catch (WebSocketException e)
+            {
+                _logger.LogWarning("WebSocketException: {error}", e.Message);
+            }
+            catch (Exception e)
+            {
+                //HACK: need to find out what is trying to write when the response is complete
+                _logger.LogError(e, "SendMessageAsync: {error}", e.Message);
+            }
+        }
+
+        //
+
+        private class ClientNotificationMessage
+        {
+            public required string Json { get; init; }
+        }
+
+        private class DriveNotificationMessage
+        {
+            public required ClientNotificationType NotificationType { get; init; }
+            public required InternalDriveFileId File { get; init; }
+            public required bool IsDeleteNotification { get; init; }
+            public required ServerFileHeader ServerFileHeader { get; init; }
+            public required ServerFileHeader? PreviousServerFileHeader { get; init; }
+        }
+    }
+}

--- a/src/services/Odin.Services/AppNotifications/WebSocket/PeerAppNotificationHandler.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/PeerAppNotificationHandler.cs
@@ -1,69 +1,49 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.WebSockets;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Odin.Core;
 using Odin.Core.Exceptions;
-using Odin.Core.Json;
 using Odin.Core.Serialization;
-using Odin.Core.Storage.PubSub;
 using Odin.Services.AppNotifications.ClientNotifications;
 using Odin.Services.Authorization.ExchangeGrants;
 using Odin.Services.Base;
 using Odin.Services.Drives;
-using Odin.Services.Drives.DriveCore.Storage;
-using Odin.Services.Drives.FileSystem.Base;
-using Odin.Services.Drives.Management;
 using Odin.Services.Mediator;
 using Odin.Services.Peer.AppNotification;
-using Odin.Services.Tenant.Container;
 using Odin.Services.Util;
 
 #nullable enable
 
-// SEB:TODO this file needs to be combined with PeerAppNotificationHandler.cs
-
-// SEB:TODO this file needs to be split up into different classes handling
-// - websocket incoming and outgoing messages
-// - client notifications (i.e. messages coming from the "inside" and going out to a websocket)
-
-// SEB:TODO cleanup SendMessageAsync params
-
 namespace Odin.Services.AppNotifications.WebSocket
 {
+    /// <summary>
+    /// Scoped MediatR handler and per-connection WebSocket command processor for the peer-app
+    /// notification pipeline. The shared subscription and notification fan-out live in the
+    /// per-tenant singleton <see cref="PeerAppNotificationDispatcher"/>; this class delegates to
+    /// it. Kept scoped so it can use the request/DB-bound <see cref="PeerAppNotificationService"/>
+    /// for connection authentication without making it a captive dependency of a singleton.
+    /// </summary>
     public class PeerAppNotificationHandler :
         INotificationHandler<IClientNotification>,
         INotificationHandler<IDriveNotification>
     {
-        private const string NotificationChannel = nameof(PeerAppNotificationHandler);
-
         private readonly ILogger<PeerAppNotificationHandler> _logger;
-        private readonly ITenantRootScope _tenantRootScope;
-        private readonly ITenantPubSub _pubSub;
+        private readonly PeerAppNotificationDispatcher _dispatcher;
         private readonly PeerAppNotificationService _peerAppNotificationService;
-        private readonly SharedDeviceSocketCollection<PeerAppNotificationHandler> _deviceSocketCollection;
-        private readonly RefCountedSubscription _notificationSubscription;
 
-        public PeerAppNotificationHandler(ILogger<PeerAppNotificationHandler> logger,
-            ITenantPubSub pubSub,
-            PeerAppNotificationService peerAppNotificationService,
-            SharedDeviceSocketCollection<PeerAppNotificationHandler> deviceSocketCollection,
-            ITenantRootScope tenantRootScope)
+        public PeerAppNotificationHandler(
+            ILogger<PeerAppNotificationHandler> logger,
+            PeerAppNotificationDispatcher dispatcher,
+            PeerAppNotificationService peerAppNotificationService)
         {
             _logger = logger;
-            _tenantRootScope = tenantRootScope;
+            _dispatcher = dispatcher;
             _peerAppNotificationService = peerAppNotificationService;
-            _deviceSocketCollection = deviceSocketCollection;
-            _pubSub = pubSub;
-            _notificationSubscription =
-                new RefCountedSubscription(_pubSub, NotificationChannel, NotificationHandler);
         }
 
         //
@@ -84,9 +64,9 @@ namespace Odin.Services.AppNotifications.WebSocket
                     Key = webSocketKey,
                     Socket = webSocket,
                 };
-                _deviceSocketCollection.AddSocket(deviceSocket);
+                _dispatcher.AddSocket(deviceSocket);
 
-                await _notificationSubscription.SubscribeAsync(cancellationToken);
+                await _dispatcher.SubscribeAsync(cancellationToken);
                 await AwaitCommands(deviceSocket, odinContext, cancellationToken);
             }
             catch (OperationCanceledException)
@@ -104,8 +84,8 @@ namespace Odin.Services.AppNotifications.WebSocket
             }
             finally
             {
-                await _notificationSubscription.UnsubscribeAsync(CancellationToken.None);
-                await _deviceSocketCollection.RemoveSocket(webSocketKey);
+                await _dispatcher.UnsubscribeAsync(CancellationToken.None);
+                await _dispatcher.RemoveSocket(webSocketKey);
                 _logger.LogTrace("WebSocket closed");
             }
         }
@@ -220,61 +200,14 @@ namespace Odin.Services.AppNotifications.WebSocket
         }
 
         //
-
-        private async Task NotificationHandler(JsonEnvelope envelope)
-        {
-            var message = envelope.DeserializeMessage();
-
-            switch (message)
-            {
-                case ClientNotificationMessage notification:
-                    await WsPublishAsync(notification);
-                    return;
-                case DriveNotificationMessage notification:
-                    await WsPublishAsync(notification);
-                    return;
-                case null:
-                    _logger.LogError("Received null message");
-                    return;
-                default:
-                    _logger.LogError("Unknown message type: {message}", message.GetType().Name);
-                    return;
-            }
-        }
-
-        //
         // IClientNotification
         //
 
         // Src: MediatR
-        // Dst: PubSub queue
-        public async Task Handle(IClientNotification notification, CancellationToken cancellationToken = default)
+        // Dst: PubSub queue (via the per-tenant dispatcher)
+        public Task Handle(IClientNotification notification, CancellationToken cancellationToken = default)
         {
-            var json = OdinSystemSerializer.Serialize(new
-            {
-                notification.NotificationType,
-                Data = notification.GetClientData()
-            });
-
-            var message = new ClientNotificationMessage
-            {
-                Json = json,
-            };
-
-            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
-        }
-
-        //
-
-        // Src: PubSub queue
-        // Dst: WebSocket
-        private async Task WsPublishAsync(ClientNotificationMessage notification)
-        {
-            var sockets = _deviceSocketCollection.GetAll().Values;
-            foreach (var deviceSocket in sockets)
-            {
-                await SendMessageAsync(deviceSocket, notification.Json, true);
-            }
+            return _dispatcher.PublishClientNotificationAsync(notification);
         }
 
         //
@@ -282,161 +215,29 @@ namespace Odin.Services.AppNotifications.WebSocket
         //
 
         // Src: MediatR
-        // Dst: PubSub queue
-        public async Task Handle(IDriveNotification notification, CancellationToken cancellationToken = default)
+        // Dst: PubSub queue (via the per-tenant dispatcher)
+        public Task Handle(IDriveNotification notification, CancellationToken cancellationToken = default)
         {
-            var message = new DriveNotificationMessage
-            {
-                NotificationType  = notification.NotificationType,
-                File = notification.File,
-                IsDeleteNotification = notification is DriveFileDeletedNotification,
-                ServerFileHeader = notification.ServerFileHeader,
-                PreviousServerFileHeader = (notification as DriveFileDeletedNotification)?.PreviousServerFileHeader
-            };
-
-            await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
+            return _dispatcher.PublishDriveNotificationAsync(notification);
         }
 
         //
 
-        // Src: PubSub queue
-        // Dst: WebSocket
-        private async Task WsPublishAsync(DriveNotificationMessage notification)
+        private Task SendErrorMessageAsync(DeviceSocket deviceSocket, string errorText, CancellationToken cancellationToken = default)
         {
-            var sockets = _deviceSocketCollection.GetAll().Values
-                .Where(ds => ds.Drives.Any(driveId => driveId == notification.File.DriveId))
-                .ToList();
-
-            if (sockets.Count == 0)
-            {
-                return;
-            }
-
-            await using var scope = _tenantRootScope.BeginLifetimeScope();
-            if (scope == null)
-            {
-                return;
-            }
-
-            var driveManager =  scope.Resolve<IDriveManager>();
-            var drive = await driveManager.GetDriveAsync(notification.File.DriveId);
-
-            foreach (var deviceSocket in sockets)
-            {
-                var deviceOdinContext = deviceSocket.DeviceOdinContext;
-                var hasSharedSecret = null != deviceOdinContext?.PermissionsContext?.SharedSecretKey;
-
-                var o = new ClientDriveNotification
-                {
-                    TargetDrive = drive?.TargetDriveInfo,
-                    Header = hasSharedSecret
-                        ? DriveFileUtility.CreateClientFileHeader(notification.ServerFileHeader, deviceOdinContext)
-                        : null,
-                    PreviousServerFileHeader = hasSharedSecret
-                        ? notification.IsDeleteNotification
-                            ? DriveFileUtility.CreateClientFileHeader(notification.PreviousServerFileHeader, deviceOdinContext!)
-                            : null
-                        : null
-                };
-
-                var json = OdinSystemSerializer.Serialize(new
-                {
-                    notification.NotificationType,
-                    Data = OdinSystemSerializer.Serialize(o)
-                });
-
-                await SendMessageAsync(
-                    deviceSocket,
-                    json,
-                    encrypt: true);
-            }
+            return _dispatcher.SendErrorMessageAsync(deviceSocket, errorText, cancellationToken);
         }
 
         //
 
-        private async Task SendErrorMessageAsync(DeviceSocket deviceSocket, string errorText, CancellationToken cancellationToken = default)
-        {
-            await SendMessageAsync(deviceSocket, OdinSystemSerializer.Serialize(new
-                {
-                    NotificationType = ClientNotificationType.Error,
-                    Data = errorText,
-                }),
-                deviceSocket.DeviceOdinContext?.PermissionsContext?.SharedSecretKey != null,
-                sendEvenIfNoDeviceOdinContext: false,
-                cancellationToken);
-        }
-
-        //
-
-        private async Task SendMessageAsync(
+        private Task SendMessageAsync(
             DeviceSocket deviceSocket,
             string message,
             bool encrypt,
             bool sendEvenIfNoDeviceOdinContext = false,
             CancellationToken cancellationToken = default)
         {
-            var socket = deviceSocket.Socket;
-
-            if (socket is not { State: WebSocketState.Open } || cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
-
-            if (deviceSocket.DeviceOdinContext == null)
-            {
-                await _deviceSocketCollection.RemoveSocket(deviceSocket.Key);
-                _logger.LogInformation("Invalid/Stale Device found; removing from list");
-                if (sendEvenIfNoDeviceOdinContext)
-                {
-                    var payload = new ClientNotificationPayload()
-                    {
-                        IsEncrypted = false,
-                        Payload = message
-                    };
-
-                    var json = OdinSystemSerializer.Serialize(payload);
-                    await deviceSocket.FireAndForgetAsync(json, cancellationToken);
-                }
-
-                return;
-            }
-
-            try
-            {
-                if (encrypt)
-                {
-                    if (deviceSocket.DeviceOdinContext.PermissionsContext?.SharedSecretKey == null)
-                    {
-                        throw new OdinSystemException("Cannot encrypt message without shared secret key");
-                    }
-
-                    var key = deviceSocket.DeviceOdinContext.PermissionsContext.SharedSecretKey;
-                    var encryptedPayload = SharedSecretEncryptedPayload.Encrypt(message.ToUtf8ByteArray(), key);
-                    message = OdinSystemSerializer.Serialize(encryptedPayload);
-                }
-
-                var payload = new ClientNotificationPayload()
-                {
-                    IsEncrypted = encrypt,
-                    Payload = message
-                };
-
-                var json = OdinSystemSerializer.Serialize(payload);
-                await deviceSocket.FireAndForgetAsync(json, cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                // ignore, this exception is expected when the socket is closing behind the scenes
-            }
-            catch (WebSocketException e)
-            {
-                _logger.LogWarning("WebSocketException: {error}", e.Message);
-            }
-            catch (Exception e)
-            {
-                //HACK: need to find out what is trying to write when the response is complete
-                _logger.LogError(e, "SendMessageAsync: {error}", e.Message);
-            }
+            return _dispatcher.SendMessageAsync(deviceSocket, message, encrypt, sendEvenIfNoDeviceOdinContext, cancellationToken);
         }
 
         //
@@ -526,22 +327,5 @@ namespace Odin.Services.AppNotifications.WebSocket
 
             throw new OdinSecurityException("No token provided");
         }
-
-        //
-
-        private class ClientNotificationMessage
-        {
-            public required string Json { get; init; }
-        }
-
-        private class DriveNotificationMessage
-        {
-            public required ClientNotificationType NotificationType { get; init; }
-            public required InternalDriveFileId File { get; init; }
-            public required bool IsDeleteNotification { get; init; }
-            public required ServerFileHeader ServerFileHeader { get; init; }
-            public required ServerFileHeader? PreviousServerFileHeader { get; init; }
-        }
-
     }
 }

--- a/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
@@ -834,11 +834,20 @@ namespace Odin.Services.Drives.FileSystem.Base
 
             if (await TryShouldRaiseDriveEventAsync(targetFile))
             {
+                // Re-read so the notification carries a snapshot consistent with what was just
+                // persisted: the bumped `modified`/updated timestamp and the current localReactions
+                // (the group reaction flow updates localReactions before this runs). Publishing the
+                // pre-write `existingHeader` previously emitted a stale statisticsChanged (old
+                // `updated` and missing the reaction it announces).
+                var refreshedHeader =
+                    await longTermStorageManager.GetServerFileHeader(drive, targetFile.FileId, GetFileSystemType())
+                    ?? existingHeader;
+
                 await TryPublishAsync(new ReactionPreviewUpdatedNotification
                 {
                     File = targetFile,
-                    ServerFileHeader = existingHeader,
-                    SharedSecretEncryptedFileHeader = DriveFileUtility.CreateClientFileHeader(existingHeader, odinContext),
+                    ServerFileHeader = refreshedHeader,
+                    SharedSecretEncryptedFileHeader = DriveFileUtility.CreateClientFileHeader(refreshedHeader, odinContext),
                     OdinContext = odinContext,
                 });
             }

--- a/src/services/Odin.Services/Drives/Reactions/Redux/Group/GroupReactionService.cs
+++ b/src/services/Odin.Services/Drives/Reactions/Redux/Group/GroupReactionService.cs
@@ -46,16 +46,22 @@ public class GroupReactionService(
 
         var result = new AddReactionResult();
 
-        await reactionContentService.AddReactionAsync(localFile, reaction, odinContext.GetCallerOdinIdOrFail(), odinContext, null);
-
+        // Update the local-reactions cache BEFORE adding the reaction content. The reaction-content
+        // add raises statisticsChanged (via ReactionPreviewCalculator -> UpdateReactionSummary),
+        // whose header snapshot must already include this reaction in localReactions. The server is
+        // the source of truth for localReactions, so every emitted notification must be consistent;
+        // doing this after the add is what made statisticsChanged announce a reaction its own
+        // snapshot was missing.
         try
         {
             await UpdateLocalReactionListAsync(localFile, reaction, added: true, odinContext, fileSystemType);
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to update local reaction list after adding reaction");
+            logger.LogWarning(ex, "Failed to update local reaction list before adding reaction");
         }
+
+        await reactionContentService.AddReactionAsync(localFile, reaction, odinContext.GetCallerOdinIdOrFail(), odinContext, null);
 
         if (options?.Recipients?.Any() ?? false)
         {
@@ -84,17 +90,20 @@ public class GroupReactionService(
         odinContext.PermissionsContext.AssertHasDrivePermission(localFile.DriveId, DrivePermission.React);
 
         var result = new DeleteReactionResult();
-        await reactionContentService.DeleteReactionAsync(localFile, reaction, odinContext.GetCallerOdinIdOrFail(), odinContext,
-            markComplete: null);
 
+        // See AddReactionAsync: update the local-reactions cache before removing the reaction content
+        // so the statisticsChanged notification reflects the removal in its localReactions snapshot.
         try
         {
             await UpdateLocalReactionListAsync(localFile, reaction, added: false, odinContext, fileSystemType);
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to update local reaction list after deleting reaction");
+            logger.LogWarning(ex, "Failed to update local reaction list before deleting reaction");
         }
+
+        await reactionContentService.DeleteReactionAsync(localFile, reaction, odinContext.GetCallerOdinIdOrFail(), odinContext,
+            markComplete: null);
 
         if (options?.Recipients?.Any() ?? false)
         {

--- a/tests/apps/Odin.Hosting.Tests/_Universal/ApiClient/TestOwnerWebSocketListener.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/ApiClient/TestOwnerWebSocketListener.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net;
 using System.Net.WebSockets;
 using System.Threading;
@@ -114,7 +115,22 @@ public sealed class TestOwnerWebSocketListener
                 while (_clientWebSocket.State == WebSocketState.Open)
                 {
                     var receiveBuffer = new ArraySegment<byte>(new byte[1024 * 4]);
-                    var receiveResult = await _clientWebSocket.ReceiveAsync(receiveBuffer, _cancellationTokenSource.Token);
+
+                    // A single logical message can span multiple frames / multiple ReceiveAsync
+                    // calls (payloads larger than the buffer). Accumulate until EndOfMessage,
+                    // otherwise large notifications get truncated and fail to deserialize.
+                    using var ms = new MemoryStream();
+                    WebSocketReceiveResult receiveResult;
+                    do
+                    {
+                        receiveResult = await _clientWebSocket.ReceiveAsync(receiveBuffer, _cancellationTokenSource.Token);
+                        if (receiveResult.MessageType == WebSocketMessageType.Close)
+                        {
+                            break;
+                        }
+
+                        ms.Write(receiveBuffer.Array!, receiveBuffer.Offset, receiveResult.Count);
+                    } while (!receiveResult.EndOfMessage);
 
                     if (receiveResult.MessageType == WebSocketMessageType.Close)
                     {
@@ -122,9 +138,7 @@ public sealed class TestOwnerWebSocketListener
                     }
                     else
                     {
-                        var array = receiveBuffer.Array;
-                        Array.Resize(ref array, receiveResult.Count);
-                        await OnNotificationReceived(DecryptClientNotificationPayload<TestClientNotification>(array));
+                        await OnNotificationReceived(DecryptClientNotificationPayload<TestClientNotification>(ms.ToArray()));
                     }
                 }
             }

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationConsistencyTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationConsistencyTests.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Odin.Core;
+using Odin.Hosting.Controllers.Base.Drive.GroupReactions;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+
+namespace Odin.Hosting.Tests._Universal.AppNotifications;
+
+// Verifies the server emits a CONSISTENT view of a file's reactions over the WebSocket.
+//
+// Adding/removing a reaction via the group reaction path (/drive/files/group/reactions ->
+// GroupReactionService) emits TWO notifications for one reaction, sharing the same versionTag:
+//   - statisticsChanged (ClientNotificationType.StatisticsChanged) from UpdateReactionSummary
+//   - fileModified      (ClientNotificationType.FileModified)      from UpdateLocalReactionsAsync
+//
+// The contract (decided): the SERVER is the source of truth for localReactions across devices,
+// so every emitted notification must carry a localReactions/updated snapshot consistent with the
+// server state at that event. Today statisticsChanged is built from a header read BEFORE the
+// local-reactions write and BEFORE the in-memory `updated` is refreshed, so it lags. Tests 1-4
+// pin that and FAIL until the server emits a consistent snapshot. Tests 5-8 are regression
+// guards for current/intended behavior and pass today.
+public class ReactionNotificationConsistencyTests
+{
+    private WebScaffold _scaffold;
+
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
+
+    // Time to let any late/duplicate notifications land before counting.
+    private static readonly TimeSpan SettleDelay = TimeSpan.FromSeconds(2);
+
+    private const string Reaction1 = ":thumbsup:";
+    private const string Reaction2 = ":open_mouth:";
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = GetType().Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: new List<TestIdentity> { TestIdentities.Pippin });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _scaffold.RunAfterAnyTests();
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [TearDown]
+    public void TearDown() => _scaffold.AssertLogEvents();
+
+    //
+    // Tests 1-4: pin the server inconsistency (statisticsChanged lags). RED until the fix.
+    //
+
+    [Test]
+    public async Task ReactionAdd_StatisticsChanged_AnnouncesItsOwnReaction()
+    {
+        var f = await SetupFileAsync();
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+
+            var statisticsChanged = await handler.WaitForNotification(
+                ClientNotificationType.StatisticsChanged, f.Gtid, WaitTimeout);
+            ClassicAssert.IsNotNull(statisticsChanged, "No statisticsChanged notification arrived for the reaction add.");
+
+            var localReactions = statisticsChanged.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+            CollectionAssert.Contains(localReactions, Reaction1,
+                "statisticsChanged must announce its own reaction in localReactions, but it carries a stale snapshot " +
+                "(written before the local-reactions update). Server is the source of truth; the snapshot must be consistent.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task ReactionAdd_StatisticsChanged_UpdatedReflectsItsOwnWrite()
+    {
+        var f = await SetupFileAsync();
+
+        var before = await f.Owner.DriveRedux.GetFileHeader(f.File);
+        var beforeUpdated = before.Content.FileMetadata.Updated;
+
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+
+            ClassicAssert.IsTrue(await handler.WaitForBoth(f.Gtid, WaitTimeout),
+                "Expected both statisticsChanged and fileModified for the reaction add.");
+
+            var statisticsChanged = handler.EventsFor(ClientNotificationType.StatisticsChanged, f.Gtid).Last();
+            var fileModified = handler.EventsFor(ClientNotificationType.FileModified, f.Gtid).Last();
+
+            ClassicAssert.Greater(statisticsChanged.Header.FileMetadata.Updated.milliseconds, beforeUpdated.milliseconds,
+                "statisticsChanged.updated must reflect its own write (advance past the pre-reaction timestamp), " +
+                "not carry the prior state's `updated`.");
+
+            ClassicAssert.Greater(fileModified.Header.FileMetadata.Updated.milliseconds, beforeUpdated.milliseconds,
+                "fileModified.updated must also advance past the pre-reaction timestamp.");
+
+            // The two notifications share a versionTag, so the client cannot order them; they must
+            // therefore carry the SAME localReactions snapshot. A divergence here is what caused the
+            // client 'blink' (a stale statisticsChanged overwriting a fresh fileModified).
+            var scLocal = statisticsChanged.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+            var fmLocal = fileModified.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+            CollectionAssert.AreEquivalent(fmLocal, scLocal,
+                "statisticsChanged and fileModified must carry the same localReactions snapshot.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task SecondReaction_StatisticsChanged_IncludesBothReactions()
+    {
+        var f = await SetupFileAsync();
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 1, WaitTimeout));
+
+            await AddReactionAsync(f, Reaction2);
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 2, WaitTimeout),
+                "Expected a second statisticsChanged for the second reaction.");
+
+            var second = handler.EventsFor(ClientNotificationType.StatisticsChanged, f.Gtid).Last();
+            var localReactions = second.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+
+            CollectionAssert.Contains(localReactions, Reaction1, "second statisticsChanged is missing the first reaction.");
+            CollectionAssert.Contains(localReactions, Reaction2,
+                "second statisticsChanged must include the reaction it announces; it carries a stale localReactions snapshot.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task LastStatisticsChanged_LocalReactions_MatchAuthoritativeStore_AcrossAddAddDelete()
+    {
+        var f = await SetupFileAsync();
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 1, WaitTimeout));
+
+            await AddReactionAsync(f, Reaction2);
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 2, WaitTimeout));
+
+            await DeleteReactionAsync(f, Reaction1);
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 3, WaitTimeout));
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.FileModified, f.Gtid, 3, WaitTimeout));
+            await Task.Delay(SettleDelay);
+
+            // Authoritative store (driveReactions table) for the acting identity == final truth.
+            var authoritative = await GetAuthoritativeReactionsAsync(f);
+            CollectionAssert.AreEquivalent(new[] { Reaction2 }, authoritative,
+                "Sanity: after add r1, add r2, delete r1 the authoritative store should be exactly {r2}.");
+
+            // The persisted header agrees with the authoritative store (this is correct today).
+            var persisted = await f.Owner.DriveRedux.GetFileHeader(f.File);
+            var persistedLocal = persisted.Content.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+            CollectionAssert.AreEquivalent(authoritative, persistedLocal, "Persisted header localReactions diverged from authoritative store.");
+
+            // The last fileModified is consistent (re-read after persisting) — correct today.
+            var lastFileModified = handler.EventsFor(ClientNotificationType.FileModified, f.Gtid).Last();
+            var fmLocal = lastFileModified.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+            CollectionAssert.AreEquivalent(authoritative, fmLocal, "fileModified localReactions diverged from authoritative store.");
+
+            // The last statisticsChanged (for the delete) must also be consistent. It lags today.
+            var lastStatisticsChanged = handler.EventsFor(ClientNotificationType.StatisticsChanged, f.Gtid).Last();
+            var scLocal = lastStatisticsChanged.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+            CollectionAssert.AreEquivalent(authoritative, scLocal,
+                "statisticsChanged must carry localReactions consistent with the server's authoritative state at emit time; " +
+                "today it carries a stale snapshot taken before the local-reactions write.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    //
+    // Tests 5-8: regression guards for current/intended behavior. GREEN today.
+    //
+
+    [Test]
+    public async Task SingleReaction_OneSocket_EmitsExactlyOneStatisticsChanged_AndOneFileModified()
+    {
+        var f = await SetupFileAsync();
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+
+            ClassicAssert.IsTrue(await handler.WaitForBoth(f.Gtid, WaitTimeout),
+                "Expected both statisticsChanged and fileModified for the reaction add.");
+            await Task.Delay(SettleDelay);
+
+            // Two DISTINCT events (one of each type) is the current design; the bug we already fixed
+            // was the same fileId being delivered once-per-connected-socket. Guard against that regressing.
+            ClassicAssert.AreEqual(1, handler.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
+                "Exactly one statisticsChanged expected per reaction on a single socket.");
+            ClassicAssert.AreEqual(1, handler.CountByType(ClientNotificationType.FileModified, f.Gtid),
+                "Exactly one fileModified expected per reaction on a single socket.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task ReactionAdd_BumpsFileModifiedTimestamp()
+    {
+        // Characterization: a reaction (a non-content change) bumps the file's `updated`/modified
+        // timestamp. Documented so any future change to this behavior is deliberate.
+        var f = await SetupFileAsync();
+
+        var before = await f.Owner.DriveRedux.GetFileHeader(f.File);
+        var beforeUpdated = before.Content.FileMetadata.Updated;
+
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+
+            var fileModified = await handler.WaitForNotification(ClientNotificationType.FileModified, f.Gtid, WaitTimeout);
+            ClassicAssert.IsNotNull(fileModified, "No fileModified notification arrived for the reaction add.");
+
+            ClassicAssert.Greater(fileModified.Header.FileMetadata.Updated.milliseconds, beforeUpdated.milliseconds,
+                "A reaction is expected to bump the file's `updated` timestamp.");
+
+            var after = await f.Owner.DriveRedux.GetFileHeader(f.File);
+            ClassicAssert.Greater(after.Content.FileMetadata.Updated.milliseconds, beforeUpdated.milliseconds,
+                "The persisted file `updated` should advance after a reaction.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task ReactionPreview_DictionaryKey_IsSha256OfReactionContent()
+    {
+        // Documents the server's reaction-preview map key format (a SHA256-reduced GUID of the
+        // reaction content), which differs from the client's key format. Harmless today because
+        // rendering reads ReactionContent, not the key.
+        var f = await SetupFileAsync();
+
+        await AddReactionAsync(f, Reaction1);
+
+        var header = await f.Owner.DriveRedux.GetFileHeader(f.File);
+        var reactions = header.Content.FileMetadata.ReactionPreview.Reactions;
+
+        var expectedKey = ByteArrayUtil.ReduceSHA256Hash(Reaction1);
+        ClassicAssert.IsTrue(reactions.ContainsKey(expectedKey),
+            "ReactionPreview should be keyed by ReduceSHA256Hash(reactionContent).");
+
+        var preview = reactions[expectedKey];
+        ClassicAssert.AreEqual(Reaction1, preview.ReactionContent);
+        ClassicAssert.AreEqual(expectedKey, preview.Key);
+    }
+
+    [Test]
+    public async Task Reaction_TwoSockets_EachSocketGetsOneOfEachType()
+    {
+        // Guards the per-connection subscription fix: with two sockets on one identity, a single
+        // reaction must deliver exactly one statisticsChanged and one fileModified to EACH socket.
+        var f = await SetupFileAsync();
+
+        var socketA = new ReactionNotificationSocketHandler();
+        var socketB = new ReactionNotificationSocketHandler();
+        await socketA.ConnectAsync(f.Owner, f.TargetDrive);
+        await socketB.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+
+            ClassicAssert.IsTrue(await socketA.WaitForBoth(f.Gtid, WaitTimeout), "Socket A did not receive both notifications.");
+            ClassicAssert.IsTrue(await socketB.WaitForBoth(f.Gtid, WaitTimeout), "Socket B did not receive both notifications.");
+            await Task.Delay(SettleDelay);
+
+            foreach (var (name, socket) in new[] { ("A", socketA), ("B", socketB) })
+            {
+                ClassicAssert.AreEqual(1, socket.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
+                    $"Socket {name} should receive exactly one statisticsChanged.");
+                ClassicAssert.AreEqual(1, socket.CountByType(ClientNotificationType.FileModified, f.Gtid),
+                    $"Socket {name} should receive exactly one fileModified.");
+            }
+        }
+        finally
+        {
+            await socketA.DisconnectAsync();
+            await socketB.DisconnectAsync();
+        }
+    }
+
+    //
+    // Helpers
+    //
+
+    private sealed record ReactionTestFile(
+        OwnerApiClientRedux Owner,
+        TargetDrive TargetDrive,
+        Guid Gtid,
+        ExternalFileIdentifier File,
+        FileIdentifier GroupFile);
+
+    private async Task<ReactionTestFile> SetupFileAsync()
+    {
+        var owner = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Pippin);
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await owner.DriveManager.CreateDrive(targetDrive, "Reaction notification test drive", "", allowAnonymousReads: true);
+
+        var metadata = SampleMetadataData.Create(fileType: 100);
+        var uploadResponse = await owner.DriveRedux.UploadNewMetadata(targetDrive, metadata);
+        ClassicAssert.IsTrue(uploadResponse.IsSuccessStatusCode, $"upload failed: {uploadResponse.StatusCode}");
+
+        var uploadResult = uploadResponse.Content;
+        return new ReactionTestFile(
+            owner,
+            targetDrive,
+            uploadResult.GlobalTransitIdFileIdentifier.GlobalTransitId,
+            uploadResult.File,
+            uploadResult.GlobalTransitIdFileIdentifier.ToFileIdentifier());
+    }
+
+    private static async Task AddReactionAsync(ReactionTestFile f, string reaction)
+    {
+        var response = await f.Owner.Reactions.AddReaction(new AddReactionRequestRedux
+        {
+            File = f.GroupFile,
+            Reaction = reaction,
+            TransitOptions = null
+        });
+        ClassicAssert.IsTrue(response.IsSuccessStatusCode, $"AddReaction failed: {response.StatusCode}");
+    }
+
+    private static async Task DeleteReactionAsync(ReactionTestFile f, string reaction)
+    {
+        var response = await f.Owner.Reactions.DeleteReaction(new DeleteReactionRequestRedux
+        {
+            File = f.GroupFile,
+            Reaction = reaction,
+            TransitOptions = null
+        });
+        ClassicAssert.IsTrue(response.IsSuccessStatusCode, $"DeleteReaction failed: {response.StatusCode}");
+    }
+
+    private static async Task<List<string>> GetAuthoritativeReactionsAsync(ReactionTestFile f)
+    {
+        var response = await f.Owner.Reactions.GetReactionsByIdentity(new GetReactionsByIdentityRequestRedux
+        {
+            Identity = f.Owner.Identity.OdinId,
+            File = f.GroupFile
+        });
+        ClassicAssert.IsTrue(response.IsSuccessStatusCode, $"GetReactionsByIdentity failed: {response.StatusCode}");
+        return response.Content ?? new List<string>();
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationSocketHandler.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationSocketHandler.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Odin.Core.Serialization;
+using Odin.Hosting.Tests._Universal.ApiClient;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Apps;
+using Odin.Services.Drives;
+
+namespace Odin.Hosting.Tests._Universal.AppNotifications;
+
+// Passive owner WebSocket listener that captures the two reaction-related notifications
+// (StatisticsChanged and FileModified) together with their full headers. Unlike
+// WebSocketDrainTestSocketHandler it records EVERY occurrence (no de-duplication) so tests can
+// inspect snapshot consistency (localReactions, updated, versionTag, reactionPreview) and count
+// how many notifications of each type a single reaction produces.
+public sealed class ReactionNotificationSocketHandler
+{
+    public sealed record CapturedNotification(
+        ClientNotificationType Type,
+        TargetDrive Drive,
+        SharedSecretEncryptedFileHeader Header);
+
+    private readonly TestOwnerWebSocketListener _socketListener = new();
+    private readonly ConcurrentQueue<CapturedNotification> _events = new();
+
+    public IReadOnlyList<CapturedNotification> Events => _events.ToArray();
+
+    public async Task ConnectAsync(OwnerApiClientRedux client, TargetDrive targetDrive)
+    {
+        _socketListener.NotificationReceived += OnNotificationReceived;
+        await _socketListener.ConnectAsync(
+            client.Identity.OdinId,
+            client.GetTokenContext(),
+            new EstablishConnectionOptions { Drives = [targetDrive] });
+    }
+
+    public Task DisconnectAsync() => _socketListener.DisconnectAsync();
+
+    private Task OnNotificationReceived(TestClientNotification notification)
+    {
+        if (notification.NotificationType is ClientNotificationType.StatisticsChanged
+            or ClientNotificationType.FileModified)
+        {
+            var driveNotification = OdinSystemSerializer.Deserialize<ClientDriveNotification>(notification.Data);
+            if (driveNotification?.Header != null && driveNotification.TargetDrive != null)
+            {
+                _events.Enqueue(new CapturedNotification(
+                    notification.NotificationType,
+                    driveNotification.TargetDrive,
+                    driveNotification.Header));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    //
+
+    public CapturedNotification[] EventsFor(ClientNotificationType type, Guid globalTransitId) =>
+        Events
+            .Where(e => e.Type == type && e.Header.FileMetadata?.GlobalTransitId == globalTransitId)
+            .ToArray();
+
+    public int CountByType(ClientNotificationType type, Guid globalTransitId) =>
+        EventsFor(type, globalTransitId).Length;
+
+    /// <summary>Returns the most recent notification of <paramref name="type"/> for the file, or null on timeout.</summary>
+    public async Task<CapturedNotification> WaitForNotification(
+        ClientNotificationType type, Guid globalTransitId, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = EventsFor(type, globalTransitId).LastOrDefault();
+            if (hit != null)
+            {
+                return hit;
+            }
+
+            await Task.Delay(50);
+        }
+
+        return null;
+    }
+
+    /// <summary>Waits until at least <paramref name="count"/> notifications of <paramref name="type"/> have arrived for the file.</summary>
+    public async Task<bool> WaitForCount(
+        ClientNotificationType type, Guid globalTransitId, int count, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (CountByType(type, globalTransitId) >= count)
+            {
+                return true;
+            }
+
+            await Task.Delay(50);
+        }
+
+        return false;
+    }
+
+    /// <summary>Waits until BOTH a StatisticsChanged and a FileModified for the file have arrived.</summary>
+    public async Task<bool> WaitForBoth(Guid globalTransitId, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (EventsFor(ClientNotificationType.StatisticsChanged, globalTransitId).Any()
+                && EventsFor(ClientNotificationType.FileModified, globalTransitId).Any())
+            {
+                return true;
+            }
+
+            await Task.Delay(50);
+        }
+
+        return false;
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/WebSocketDuplicateFanoutTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/WebSocketDuplicateFanoutTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Services.Drives;
+
+namespace Odin.Hosting.Tests._Universal.AppNotifications;
+
+// Reproduces the duplicate WebSocket fan-out bug: a single logical notification is
+// delivered to a connected device once PER currently-connected socket on the same
+// identity. The cause is that each WebSocket connection (its own request scope) gets
+// its own AppNotificationHandler instance and therefore its own RefCountedSubscription,
+// so N connections register N broker subscriptions on the shared channel. One publish
+// then fans out N times, and each fan-out iterates the shared socket collection, so
+// every socket receives N copies.
+//
+// With the bug present, a single local upload with two sockets connected delivers
+// TWO FileAdded notifications to EACH socket. The fix must make it exactly one.
+public class WebSocketDuplicateFanoutTests
+{
+    private WebScaffold _scaffold;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = GetType().Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: new List<TestIdentity> { TestIdentities.Samwise });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _scaffold.RunAfterAnyTests();
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [TearDown]
+    public void TearDown() => _scaffold.AssertLogEvents();
+
+    [Test]
+    public async Task LocalUpload_WithTwoSocketsOnSameIdentity_EachSocketReceivesFileAddedExactlyOnce()
+    {
+        var owner = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Samwise);
+
+        var targetDrive = TargetDrive.NewTargetDrive();
+        var createDrive = await owner.DriveManager.CreateDrive(
+            targetDrive: targetDrive,
+            name: "ws duplicate fan-out test drive",
+            metadata: "",
+            allowAnonymousReads: false,
+            allowSubscriptions: false,
+            ownerOnly: false);
+        ClassicAssert.IsTrue(createDrive.IsSuccessStatusCode);
+
+        // Two independent WebSocket connections for the SAME identity, both subscribed
+        // to the same drive. These reuse WebSocketDrainTestSocketHandler, which records
+        // EVERY FileAdded it sees (no de-duplication), so duplicates are observable.
+        var socketA = new WebSocketDrainTestSocketHandler();
+        var socketB = new WebSocketDrainTestSocketHandler();
+        await socketA.ConnectAsync(owner, targetDrive);
+        await socketB.ConnectAsync(owner, targetDrive);
+
+        try
+        {
+            // Exactly one local upload -> exactly one DriveFileAddedNotification.
+            var metadata = SampleMetadataData.Create(fileType: 9911);
+            var upload = await owner.DriveRedux.UploadNewMetadata(targetDrive, metadata);
+            ClassicAssert.IsTrue(upload.IsSuccessStatusCode, $"upload failed: {upload.StatusCode}");
+
+            var gtid = upload.Content.GlobalTransitIdFileIdentifier.GlobalTransitId;
+
+            // Wait until each socket has seen the FileAdded at least once...
+            ClassicAssert.IsTrue(await socketA.WaitForFileAdded(gtid, TimeSpan.FromSeconds(15)),
+                "Socket A never received FileAdded for the uploaded file.");
+            ClassicAssert.IsTrue(await socketB.WaitForFileAdded(gtid, TimeSpan.FromSeconds(15)),
+                "Socket B never received FileAdded for the uploaded file.");
+
+            // ...then settle. Duplicates originate from the same publish and arrive
+            // back-to-back, so a short window is plenty to catch them before counting.
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            var countA = socketA.FileAddedEvents.Count(e => e.Header.FileMetadata?.GlobalTransitId == gtid);
+            var countB = socketB.FileAddedEvents.Count(e => e.Header.FileMetadata?.GlobalTransitId == gtid);
+
+            ClassicAssert.AreEqual(1, countA,
+                $"Socket A received {countA} copies of the single FileAdded (expected 1). " +
+                "Duplicate WebSocket fan-out: each connection registers its own pub/sub subscription.");
+            ClassicAssert.AreEqual(1, countB,
+                $"Socket B received {countB} copies of the single FileAdded (expected 1). " +
+                "Duplicate WebSocket fan-out: each connection registers its own pub/sub subscription.");
+        }
+        finally
+        {
+            await socketA.DisconnectAsync();
+            await socketB.DisconnectAsync();
+        }
+    }
+}


### PR DESCRIPTION
A WebSocket client received N identical copies of every notification, where N is the number of concurrently connected sockets/devices for the identity (2 devices -> 2 copies, 3 devices -> 3 copies).

Root cause: AppNotificationHandler and PeerAppNotificationHandler were registered InstancePerLifetimeScope, so each WebSocket connection (its own request scope) got its own handler instance and therefore its own RefCountedSubscription. EstablishConnection then registered one broker subscription per connection on the shared pub/sub channel. The broker fans each published message out to all subscriptions, and each subscription's fan-out iterates the shared singleton DeviceSocketCollection and sends to every socket. Net: 1 notification -> 1 publish -> N subscription callbacks -> each loops N sockets -> every device receives N copies.

RefCountedSubscription was designed to be one shared, ref-counted subscription per tenant, but living at per-connection scope defeated that.

Fix: extract the subscription + notification fan-out (which depend only on singleton-safe services) into per-tenant singletons AppNotificationDispatcher and PeerAppNotificationDispatcher. Each owns the single RefCountedSubscription, so connection #1 registers the one broker subscription and the rest ref-count onto it; the last to disconnect tears it down. The handlers stay scoped (unchanged MediatR lifetime) and keep the per-connection command loop, which needs request/DB-bound services (PeerInboxProcessor, PeerAppNotificationService); they now delegate add-socket/subscribe/unsubscribe/remove-socket/send/publish to the dispatcher. The in-flight inbox-drain coalescer also moves to the singleton, so it now coalesces per drive per tenant rather than per connection.

Adds WebSocketDuplicateFanoutTests: opens two sockets on one identity, does a single local upload, and asserts each socket receives the FileAdded exactly once (failed with 2 before the fix, passes after).