### PR TITLE
Reactions/comments emit a single fileModified over WebSocket

### DIFF
--- a/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationHandler.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationHandler.cs
@@ -190,6 +190,11 @@ namespace Odin.Services.AppNotifications.WebSocket
         // Dst: PubSub queue (via the per-tenant dispatcher)
         public Task Handle(IDriveNotification notification, CancellationToken cancellationToken = default)
         {
+            if (notification.IgnoreWebSocketNotification)
+            {
+                return Task.CompletedTask;
+            }
+
             return _dispatcher.PublishDriveNotificationAsync(notification);
         }
 

--- a/src/services/Odin.Services/AppNotifications/WebSocket/PeerAppNotificationHandler.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/PeerAppNotificationHandler.cs
@@ -218,6 +218,11 @@ namespace Odin.Services.AppNotifications.WebSocket
         // Dst: PubSub queue (via the per-tenant dispatcher)
         public Task Handle(IDriveNotification notification, CancellationToken cancellationToken = default)
         {
+            if (notification.IgnoreWebSocketNotification)
+            {
+                return Task.CompletedTask;
+            }
+
             return _dispatcher.PublishDriveNotificationAsync(notification);
         }
 

--- a/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
@@ -1407,6 +1407,11 @@ namespace Odin.Services.Drives.FileSystem.Base
                         File = file,
                         ServerFileHeader = updatedHeader,
                         OdinContext = odinContext,
+                        // localReactions is only written in the group-reaction flow, which also raises
+                        // a ReactionPreviewUpdatedNotification (now a fileModified) carrying the full
+                        // fresh header. Suppress this redundant WS broadcast so a reaction sends the
+                        // header once; the MediatR event still fires for cache/feed handlers.
+                        IgnoreWebSocketNotification = true,
                     });
                 }
             }

--- a/src/services/Odin.Services/Mediator/DriveFileAddedNotification.cs
+++ b/src/services/Odin.Services/Mediator/DriveFileAddedNotification.cs
@@ -18,4 +18,5 @@ public class DriveFileAddedNotification : MediatorNotificationBase, IDriveNotifi
 
     public bool IgnoreFeedDistribution { get; set; }
     public bool IgnoreReactionPreviewCalculation { get; set; }
+    public bool IgnoreWebSocketNotification { get; set; }
 }

--- a/src/services/Odin.Services/Mediator/DriveFileChangedNotification.cs
+++ b/src/services/Odin.Services/Mediator/DriveFileChangedNotification.cs
@@ -21,5 +21,6 @@ namespace Odin.Services.Mediator
 
         public bool IgnoreFeedDistribution { get; set; }
         public bool IgnoreReactionPreviewCalculation { get; set; }
+        public bool IgnoreWebSocketNotification { get; set; }
     }
 }

--- a/src/services/Odin.Services/Mediator/DriveFileDeletedNotification.cs
+++ b/src/services/Odin.Services/Mediator/DriveFileDeletedNotification.cs
@@ -21,4 +21,5 @@ public class DriveFileDeletedNotification : MediatorNotificationBase, IDriveNoti
 
     public bool IgnoreFeedDistribution { get; set; }
     public bool IgnoreReactionPreviewCalculation { get; set; }
+    public bool IgnoreWebSocketNotification { get; set; }
 }

--- a/src/services/Odin.Services/Mediator/IDriveNotification.cs
+++ b/src/services/Odin.Services/Mediator/IDriveNotification.cs
@@ -21,8 +21,15 @@ public interface IDriveNotification : INotification
     /// Feed hack so I can ensure certain update events do not get distributed 
     /// </summary>
     public bool IgnoreFeedDistribution { get; set; }
-    
+
     public bool IgnoreReactionPreviewCalculation { get; set; }
+
+    /// <summary>
+    /// When true, this drive event is NOT broadcast to WebSocket clients. Other handlers
+    /// (cache invalidation, feed distribution, etc.) still run. Used to suppress the redundant
+    /// local-reactions fileModified so a reaction emits a single client notification.
+    /// </summary>
+    public bool IgnoreWebSocketNotification { get; set; }
 
 }
 

--- a/src/services/Odin.Services/Mediator/ReactionPreviewUpdatedNotification.cs
+++ b/src/services/Odin.Services/Mediator/ReactionPreviewUpdatedNotification.cs
@@ -7,7 +7,10 @@ namespace Odin.Services.Mediator;
 
 public class ReactionPreviewUpdatedNotification : MediatorNotificationBase, IDriveNotification
 {
-    public ClientNotificationType NotificationType { get; } = ClientNotificationType.StatisticsChanged;
+    // A reaction/comment summary change is surfaced to clients as a fileModified (the file's header
+    // changed). Previously this was StatisticsChanged; clients now handle a single fileModified for
+    // reactions, comments, and peer reactions. StatisticsChanged is no longer emitted on the wire.
+    public ClientNotificationType NotificationType { get; } = ClientNotificationType.FileModified;
 
     public DriveNotificationType DriveNotificationType { get; } = DriveNotificationType.FileModified;
 
@@ -18,4 +21,5 @@ public class ReactionPreviewUpdatedNotification : MediatorNotificationBase, IDri
 
     public bool IgnoreFeedDistribution { get; set; }
     public bool IgnoreReactionPreviewCalculation { get; set; }
+    public bool IgnoreWebSocketNotification { get; set; }
 }

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationConsistencyTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationConsistencyTests.cs
@@ -112,6 +112,36 @@ public class ReactionNotificationConsistencyTests
     }
 
     [Test]
+    public async Task ReactionAdd_FileModified_CarriesUpdatedReactionSummary()
+    {
+        // The single fileModified must carry the UPDATED reactionSummary (statistics) including the
+        // new reaction, not the pre-reaction summary. The notification is built from a header
+        // re-read AFTER the summary is persisted (UpdateReactionSummary).
+        var f = await SetupFileAsync();
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+
+            var fileModified = await handler.WaitForNotification(ClientNotificationType.FileModified, f.Gtid, WaitTimeout);
+            ClassicAssert.IsNotNull(fileModified, "No fileModified notification arrived for the reaction add.");
+
+            var preview = fileModified.Header.FileMetadata.ReactionPreview;
+            ClassicAssert.IsNotNull(preview, "fileModified header is missing the reactionSummary.");
+
+            var match = preview.Reactions.Values.SingleOrDefault(r => r.ReactionContent == Reaction1);
+            ClassicAssert.IsNotNull(match, "fileModified must carry the updated reactionSummary including the new reaction.");
+            ClassicAssert.AreEqual(1, match.Count, "The updated reactionSummary should reflect the new reaction's count.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
     public async Task ReactionAdd_FileModified_UpdatedReflectsItsOwnWrite()
     {
         var f = await SetupFileAsync();

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationConsistencyTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationConsistencyTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using Odin.Core;
+using Odin.Core.Storage;
 using Odin.Hosting.Controllers.Base.Drive.GroupReactions;
 using Odin.Hosting.Tests._Universal.ApiClient.Owner;
 using Odin.Hosting.Tests._Universal.DriveTests;
@@ -14,19 +15,15 @@ using Odin.Services.Drives;
 
 namespace Odin.Hosting.Tests._Universal.AppNotifications;
 
-// Verifies the server emits a CONSISTENT view of a file's reactions over the WebSocket.
-//
-// Adding/removing a reaction via the group reaction path (/drive/files/group/reactions ->
-// GroupReactionService) emits TWO notifications for one reaction, sharing the same versionTag:
-//   - statisticsChanged (ClientNotificationType.StatisticsChanged) from UpdateReactionSummary
-//   - fileModified      (ClientNotificationType.FileModified)      from UpdateLocalReactionsAsync
-//
-// The contract (decided): the SERVER is the source of truth for localReactions across devices,
-// so every emitted notification must carry a localReactions/updated snapshot consistent with the
-// server state at that event. Today statisticsChanged is built from a header read BEFORE the
-// local-reactions write and BEFORE the in-memory `updated` is refreshed, so it lags. Tests 1-4
-// pin that and FAIL until the server emits a consistent snapshot. Tests 5-8 are regression
-// guards for current/intended behavior and pass today.
+// A reaction (and a comment) emits a SINGLE full-header WebSocket notification, of type
+// fileModified. Mechanics:
+//   - The reaction summary update (ReactionPreviewUpdatedNotification) is surfaced to clients as
+//     fileModified (formerly statisticsChanged) and carries the fresh full header
+//     (reactionSummary + localReactions + updated).
+//   - The local-reactions DriveFileChangedNotification (also fileModified) is suppressed from the
+//     WS broadcast (IgnoreWebSocketNotification) so the header isn't sent twice; its MediatR event
+//     still fires for cache/feed.
+// So for a reaction the client receives exactly one fileModified and zero statisticsChanged.
 public class ReactionNotificationConsistencyTests
 {
     private WebScaffold _scaffold;
@@ -61,11 +58,11 @@ public class ReactionNotificationConsistencyTests
     public void TearDown() => _scaffold.AssertLogEvents();
 
     //
-    // Tests 1-4: pin the server inconsistency (statisticsChanged lags). RED until the fix.
+    // The single full-header fileModified per reaction, and its consistency.
     //
 
     [Test]
-    public async Task ReactionAdd_StatisticsChanged_AnnouncesItsOwnReaction()
+    public async Task ReactionAdd_EmitsExactlyOneFileModified_AndNoStatisticsChanged()
     {
         var f = await SetupFileAsync();
         var handler = new ReactionNotificationSocketHandler();
@@ -75,14 +72,14 @@ public class ReactionNotificationConsistencyTests
         {
             await AddReactionAsync(f, Reaction1);
 
-            var statisticsChanged = await handler.WaitForNotification(
-                ClientNotificationType.StatisticsChanged, f.Gtid, WaitTimeout);
-            ClassicAssert.IsNotNull(statisticsChanged, "No statisticsChanged notification arrived for the reaction add.");
+            var fileModified = await handler.WaitForNotification(ClientNotificationType.FileModified, f.Gtid, WaitTimeout);
+            ClassicAssert.IsNotNull(fileModified, "No fileModified notification arrived for the reaction add.");
+            await Task.Delay(SettleDelay);
 
-            var localReactions = statisticsChanged.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
-            CollectionAssert.Contains(localReactions, Reaction1,
-                "statisticsChanged must announce its own reaction in localReactions, but it carries a stale snapshot " +
-                "(written before the local-reactions update). Server is the source of truth; the snapshot must be consistent.");
+            ClassicAssert.AreEqual(1, handler.CountByType(ClientNotificationType.FileModified, f.Gtid),
+                "A reaction should send the full header exactly once (one fileModified).");
+            ClassicAssert.AreEqual(0, handler.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
+                "statisticsChanged is retired; a reaction must not send it.");
         }
         finally
         {
@@ -91,7 +88,31 @@ public class ReactionNotificationConsistencyTests
     }
 
     [Test]
-    public async Task ReactionAdd_StatisticsChanged_UpdatedReflectsItsOwnWrite()
+    public async Task ReactionAdd_FileModified_AnnouncesItsOwnReaction()
+    {
+        var f = await SetupFileAsync();
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            await AddReactionAsync(f, Reaction1);
+
+            var fileModified = await handler.WaitForNotification(ClientNotificationType.FileModified, f.Gtid, WaitTimeout);
+            ClassicAssert.IsNotNull(fileModified, "No fileModified notification arrived for the reaction add.");
+
+            var localReactions = fileModified.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+            CollectionAssert.Contains(localReactions, Reaction1,
+                "The reaction's fileModified must carry localReactions including the reaction it announces.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task ReactionAdd_FileModified_UpdatedReflectsItsOwnWrite()
     {
         var f = await SetupFileAsync();
 
@@ -105,26 +126,11 @@ public class ReactionNotificationConsistencyTests
         {
             await AddReactionAsync(f, Reaction1);
 
-            ClassicAssert.IsTrue(await handler.WaitForBoth(f.Gtid, WaitTimeout),
-                "Expected both statisticsChanged and fileModified for the reaction add.");
-
-            var statisticsChanged = handler.EventsFor(ClientNotificationType.StatisticsChanged, f.Gtid).Last();
-            var fileModified = handler.EventsFor(ClientNotificationType.FileModified, f.Gtid).Last();
-
-            ClassicAssert.Greater(statisticsChanged.Header.FileMetadata.Updated.milliseconds, beforeUpdated.milliseconds,
-                "statisticsChanged.updated must reflect its own write (advance past the pre-reaction timestamp), " +
-                "not carry the prior state's `updated`.");
+            var fileModified = await handler.WaitForNotification(ClientNotificationType.FileModified, f.Gtid, WaitTimeout);
+            ClassicAssert.IsNotNull(fileModified, "No fileModified notification arrived for the reaction add.");
 
             ClassicAssert.Greater(fileModified.Header.FileMetadata.Updated.milliseconds, beforeUpdated.milliseconds,
-                "fileModified.updated must also advance past the pre-reaction timestamp.");
-
-            // The two notifications share a versionTag, so the client cannot order them; they must
-            // therefore carry the SAME localReactions snapshot. A divergence here is what caused the
-            // client 'blink' (a stale statisticsChanged overwriting a fresh fileModified).
-            var scLocal = statisticsChanged.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
-            var fmLocal = fileModified.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
-            CollectionAssert.AreEquivalent(fmLocal, scLocal,
-                "statisticsChanged and fileModified must carry the same localReactions snapshot.");
+                "The reaction's fileModified must carry an `updated` that advanced past the pre-reaction timestamp.");
         }
         finally
         {
@@ -133,7 +139,7 @@ public class ReactionNotificationConsistencyTests
     }
 
     [Test]
-    public async Task SecondReaction_StatisticsChanged_IncludesBothReactions()
+    public async Task SecondReaction_FileModified_IncludesBothReactions()
     {
         var f = await SetupFileAsync();
         var handler = new ReactionNotificationSocketHandler();
@@ -142,18 +148,21 @@ public class ReactionNotificationConsistencyTests
         try
         {
             await AddReactionAsync(f, Reaction1);
-            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 1, WaitTimeout));
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.FileModified, f.Gtid, 1, WaitTimeout));
 
             await AddReactionAsync(f, Reaction2);
-            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 2, WaitTimeout),
-                "Expected a second statisticsChanged for the second reaction.");
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.FileModified, f.Gtid, 2, WaitTimeout),
+                "Expected a second fileModified for the second reaction.");
 
-            var second = handler.EventsFor(ClientNotificationType.StatisticsChanged, f.Gtid).Last();
+            var second = handler.EventsFor(ClientNotificationType.FileModified, f.Gtid).Last();
             var localReactions = second.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
 
-            CollectionAssert.Contains(localReactions, Reaction1, "second statisticsChanged is missing the first reaction.");
+            CollectionAssert.Contains(localReactions, Reaction1, "second fileModified is missing the first reaction.");
             CollectionAssert.Contains(localReactions, Reaction2,
-                "second statisticsChanged must include the reaction it announces; it carries a stale localReactions snapshot.");
+                "second fileModified must include the reaction it announces.");
+
+            ClassicAssert.AreEqual(0, handler.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
+                "statisticsChanged is retired; reactions must not send it.");
         }
         finally
         {
@@ -162,7 +171,7 @@ public class ReactionNotificationConsistencyTests
     }
 
     [Test]
-    public async Task LastStatisticsChanged_LocalReactions_MatchAuthoritativeStore_AcrossAddAddDelete()
+    public async Task LastFileModified_LocalReactions_MatchAuthoritativeStore_AcrossAddAddDelete()
     {
         var f = await SetupFileAsync();
         var handler = new ReactionNotificationSocketHandler();
@@ -171,13 +180,12 @@ public class ReactionNotificationConsistencyTests
         try
         {
             await AddReactionAsync(f, Reaction1);
-            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 1, WaitTimeout));
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.FileModified, f.Gtid, 1, WaitTimeout));
 
             await AddReactionAsync(f, Reaction2);
-            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 2, WaitTimeout));
+            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.FileModified, f.Gtid, 2, WaitTimeout));
 
             await DeleteReactionAsync(f, Reaction1);
-            ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.StatisticsChanged, f.Gtid, 3, WaitTimeout));
             ClassicAssert.IsTrue(await handler.WaitForCount(ClientNotificationType.FileModified, f.Gtid, 3, WaitTimeout));
             await Task.Delay(SettleDelay);
 
@@ -186,54 +194,19 @@ public class ReactionNotificationConsistencyTests
             CollectionAssert.AreEquivalent(new[] { Reaction2 }, authoritative,
                 "Sanity: after add r1, add r2, delete r1 the authoritative store should be exactly {r2}.");
 
-            // The persisted header agrees with the authoritative store (this is correct today).
+            // The persisted header agrees with the authoritative store.
             var persisted = await f.Owner.DriveRedux.GetFileHeader(f.File);
             var persistedLocal = persisted.Content.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
             CollectionAssert.AreEquivalent(authoritative, persistedLocal, "Persisted header localReactions diverged from authoritative store.");
 
-            // The last fileModified is consistent (re-read after persisting) — correct today.
+            // The last fileModified must carry the consistent, current localReactions.
             var lastFileModified = handler.EventsFor(ClientNotificationType.FileModified, f.Gtid).Last();
-            var fmLocal = lastFileModified.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
-            CollectionAssert.AreEquivalent(authoritative, fmLocal, "fileModified localReactions diverged from authoritative store.");
+            var lastLocal = lastFileModified.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
+            CollectionAssert.AreEquivalent(authoritative, lastLocal,
+                "The last fileModified must carry localReactions consistent with the server's authoritative state.");
 
-            // The last statisticsChanged (for the delete) must also be consistent. It lags today.
-            var lastStatisticsChanged = handler.EventsFor(ClientNotificationType.StatisticsChanged, f.Gtid).Last();
-            var scLocal = lastStatisticsChanged.Header.FileMetadata.LocalAppData?.LocalReactions ?? new List<string>();
-            CollectionAssert.AreEquivalent(authoritative, scLocal,
-                "statisticsChanged must carry localReactions consistent with the server's authoritative state at emit time; " +
-                "today it carries a stale snapshot taken before the local-reactions write.");
-        }
-        finally
-        {
-            await handler.DisconnectAsync();
-        }
-    }
-
-    //
-    // Tests 5-8: regression guards for current/intended behavior. GREEN today.
-    //
-
-    [Test]
-    public async Task SingleReaction_OneSocket_EmitsExactlyOneStatisticsChanged_AndOneFileModified()
-    {
-        var f = await SetupFileAsync();
-        var handler = new ReactionNotificationSocketHandler();
-        await handler.ConnectAsync(f.Owner, f.TargetDrive);
-
-        try
-        {
-            await AddReactionAsync(f, Reaction1);
-
-            ClassicAssert.IsTrue(await handler.WaitForBoth(f.Gtid, WaitTimeout),
-                "Expected both statisticsChanged and fileModified for the reaction add.");
-            await Task.Delay(SettleDelay);
-
-            // Two DISTINCT events (one of each type) is the current design; the bug we already fixed
-            // was the same fileId being delivered once-per-connected-socket. Guard against that regressing.
-            ClassicAssert.AreEqual(1, handler.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
-                "Exactly one statisticsChanged expected per reaction on a single socket.");
-            ClassicAssert.AreEqual(1, handler.CountByType(ClientNotificationType.FileModified, f.Gtid),
-                "Exactly one fileModified expected per reaction on a single socket.");
+            ClassicAssert.AreEqual(0, handler.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
+                "statisticsChanged is retired; reactions must not send it.");
         }
         finally
         {
@@ -242,7 +215,7 @@ public class ReactionNotificationConsistencyTests
     }
 
     [Test]
-    public async Task ReactionAdd_BumpsFileModifiedTimestamp()
+    public async Task ReactionAdd_BumpsUpdatedTimestamp()
     {
         // Characterization: a reaction (a non-content change) bumps the file's `updated`/modified
         // timestamp. Documented so any future change to this behavior is deliberate.
@@ -297,10 +270,10 @@ public class ReactionNotificationConsistencyTests
     }
 
     [Test]
-    public async Task Reaction_TwoSockets_EachSocketGetsOneOfEachType()
+    public async Task Reaction_TwoSockets_EachSocketGetsOneFileModified_AndNoStatisticsChanged()
     {
-        // Guards the per-connection subscription fix: with two sockets on one identity, a single
-        // reaction must deliver exactly one statisticsChanged and one fileModified to EACH socket.
+        // Each connected socket on the identity receives exactly one fileModified (and no
+        // statisticsChanged) for a single reaction. Also guards the per-connection subscription fix.
         var f = await SetupFileAsync();
 
         var socketA = new ReactionNotificationSocketHandler();
@@ -312,22 +285,57 @@ public class ReactionNotificationConsistencyTests
         {
             await AddReactionAsync(f, Reaction1);
 
-            ClassicAssert.IsTrue(await socketA.WaitForBoth(f.Gtid, WaitTimeout), "Socket A did not receive both notifications.");
-            ClassicAssert.IsTrue(await socketB.WaitForBoth(f.Gtid, WaitTimeout), "Socket B did not receive both notifications.");
+            ClassicAssert.IsNotNull(await socketA.WaitForNotification(ClientNotificationType.FileModified, f.Gtid, WaitTimeout),
+                "Socket A did not receive a fileModified.");
+            ClassicAssert.IsNotNull(await socketB.WaitForNotification(ClientNotificationType.FileModified, f.Gtid, WaitTimeout),
+                "Socket B did not receive a fileModified.");
             await Task.Delay(SettleDelay);
 
             foreach (var (name, socket) in new[] { ("A", socketA), ("B", socketB) })
             {
-                ClassicAssert.AreEqual(1, socket.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
-                    $"Socket {name} should receive exactly one statisticsChanged.");
                 ClassicAssert.AreEqual(1, socket.CountByType(ClientNotificationType.FileModified, f.Gtid),
                     $"Socket {name} should receive exactly one fileModified.");
+                ClassicAssert.AreEqual(0, socket.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
+                    $"Socket {name} should receive zero statisticsChanged.");
             }
         }
         finally
         {
             await socketA.DisconnectAsync();
             await socketB.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task Comment_EmitsFileModified_OnTargetFile_AndNoStatisticsChanged()
+    {
+        // A comment referencing a file updates the target's reaction preview, which the target file's
+        // owner receives as a single fileModified (was statisticsChanged) with no extra fileModified
+        // (comments never write localReactions).
+        var f = await SetupFileAsync();
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(f.Owner, f.TargetDrive);
+
+        try
+        {
+            var commentMetadata = SampleMetadataData.Create(fileType: 1111);
+            commentMetadata.ReferencedFile = f.ReferencedFile;
+
+            var commentUpload = await f.Owner.DriveRedux.UploadNewMetadata(f.TargetDrive, commentMetadata, FileSystemType.Comment);
+            ClassicAssert.IsTrue(commentUpload.IsSuccessStatusCode, $"comment upload failed: {commentUpload.StatusCode}");
+
+            var fileModified = await handler.WaitForNotification(ClientNotificationType.FileModified, f.Gtid, WaitTimeout);
+            ClassicAssert.IsNotNull(fileModified, "Target file did not receive fileModified after a comment.");
+            await Task.Delay(SettleDelay);
+
+            ClassicAssert.AreEqual(1, handler.CountByType(ClientNotificationType.FileModified, f.Gtid),
+                "A comment should produce exactly one fileModified on the target file.");
+            ClassicAssert.AreEqual(0, handler.CountByType(ClientNotificationType.StatisticsChanged, f.Gtid),
+                "statisticsChanged is retired; a comment must not send it.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
         }
     }
 
@@ -340,7 +348,8 @@ public class ReactionNotificationConsistencyTests
         TargetDrive TargetDrive,
         Guid Gtid,
         ExternalFileIdentifier File,
-        FileIdentifier GroupFile);
+        FileIdentifier GroupFile,
+        GlobalTransitIdFileIdentifier ReferencedFile);
 
     private async Task<ReactionTestFile> SetupFileAsync()
     {
@@ -358,7 +367,8 @@ public class ReactionNotificationConsistencyTests
             targetDrive,
             uploadResult.GlobalTransitIdFileIdentifier.GlobalTransitId,
             uploadResult.File,
-            uploadResult.GlobalTransitIdFileIdentifier.ToFileIdentifier());
+            uploadResult.GlobalTransitIdFileIdentifier.ToFileIdentifier(),
+            uploadResult.GlobalTransitIdFileIdentifier);
     }
 
     private static async Task AddReactionAsync(ReactionTestFile f, string reaction)

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationPeerTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ReactionNotificationPeerTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Odin.Core;
+using Odin.Core.Identity;
+using Odin.Hosting.Controllers.Base.Drive.GroupReactions;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+using Odin.Services.Drives.FileSystem.Base.Upload;
+using Odin.Services.Drives.Reactions.Redux.Group;
+using Odin.Services.Peer;
+using Odin.Services.Peer.Outgoing.Drive;
+
+namespace Odin.Hosting.Tests._Universal.AppNotifications;
+
+// Verifies the peer-incoming reaction path: when a connected identity distributes a reaction to us,
+// our owner WebSocket receives a single fileModified (the reaction summary update, formerly
+// statisticsChanged) and no second notification (peer reactions never write localReactions).
+public class ReactionNotificationPeerTests
+{
+    private WebScaffold _scaffold;
+
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan SettleDelay = TimeSpan.FromSeconds(2);
+    private const string Reaction1 = ":thumbsup:";
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = GetType().Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: new List<TestIdentity> { TestIdentities.Frodo, TestIdentities.Samwise });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _scaffold.RunAfterAnyTests();
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [TearDown]
+    public void TearDown() => _scaffold.AssertLogEvents();
+
+    [Test]
+    public async Task PeerIncomingReaction_RecipientReceivesExactlyOneFileModified_AndNoStatisticsChanged()
+    {
+        var sender = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+        var recipient = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Samwise);
+
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await PrepareScenario(sender, recipient, targetDrive, DrivePermission.Write | DrivePermission.React);
+
+        // Distribute a file to the recipient so the reaction has a local target there.
+        var upload = await SendFileToRecipient(sender, recipient, targetDrive, fileType: 7001);
+        await sender.DriveRedux.WaitForEmptyOutbox(targetDrive);
+        await recipient.DriveRedux.ProcessInbox(targetDrive);
+
+        var gtid = upload.GlobalTransitIdFileIdentifier.GlobalTransitId;
+
+        var handler = new ReactionNotificationSocketHandler();
+        await handler.ConnectAsync(recipient, targetDrive);
+
+        try
+        {
+            // Sender reacts and distributes the reaction to the recipient (peer-incoming on recipient).
+            var addReaction = await sender.Reactions.AddReaction(new AddReactionRequestRedux
+            {
+                File = upload.GlobalTransitIdFileIdentifier.ToFileIdentifier(),
+                Reaction = Reaction1,
+                TransitOptions = new ReactionTransitOptions { Recipients = new List<OdinId> { recipient.Identity.OdinId } }
+            });
+            ClassicAssert.IsTrue(addReaction.IsSuccessStatusCode, $"AddReaction failed: {addReaction.StatusCode}");
+
+            await sender.DriveRedux.WaitForEmptyOutbox(targetDrive);
+            await recipient.DriveRedux.ProcessInbox(targetDrive);
+
+            var fileModified = await handler.WaitForNotification(ClientNotificationType.FileModified, gtid, WaitTimeout);
+            ClassicAssert.IsNotNull(fileModified, "Recipient did not receive fileModified for the peer reaction.");
+            await Task.Delay(SettleDelay);
+
+            ClassicAssert.AreEqual(1, handler.CountByType(ClientNotificationType.FileModified, gtid),
+                "A peer-incoming reaction should produce exactly one fileModified on the recipient.");
+            ClassicAssert.AreEqual(0, handler.CountByType(ClientNotificationType.StatisticsChanged, gtid),
+                "statisticsChanged is retired; a peer-incoming reaction must not send it.");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+            await DeleteScenario(sender, recipient);
+        }
+    }
+
+    //
+    // Helpers (adapted from WebSocketInboxDrainTests)
+    //
+
+    private async Task<UploadResult> SendFileToRecipient(
+        OwnerApiClientRedux sender, OwnerApiClientRedux recipient, TargetDrive targetDrive, int fileType)
+    {
+        var metadata = SampleMetadataData.Create(fileType: fileType);
+        metadata.AllowDistribution = true;
+
+        var transitOptions = new TransitOptions { Recipients = [recipient.Identity.OdinId] };
+        var response = await sender.DriveRedux.UploadNewMetadata(targetDrive, metadata, transitOptions);
+        ClassicAssert.IsTrue(response.IsSuccessStatusCode, $"upload failed: {response.StatusCode}");
+        return response.Content;
+    }
+
+    private async Task PrepareScenario(
+        OwnerApiClientRedux senderOwnerClient, OwnerApiClientRedux recipientOwnerClient,
+        TargetDrive targetDrive, DrivePermission drivePermissions)
+    {
+        await recipientOwnerClient.DriveManager.CreateDrive(targetDrive, "Target drive on recipient", "",
+            allowAnonymousReads: false, allowSubscriptions: false, ownerOnly: false);
+        await senderOwnerClient.DriveManager.CreateDrive(targetDrive, "Target drive on sender", "",
+            allowAnonymousReads: false, allowSubscriptions: false, ownerOnly: false);
+
+        var permissionedDrive = new PermissionedDrive { Drive = targetDrive, Permission = drivePermissions };
+        var circleId = Guid.NewGuid();
+        await recipientOwnerClient.Network.CreateCircle(circleId, "Circle with drive access",
+            new PermissionSetGrantRequest
+            {
+                Drives = new List<DriveGrantRequest> { new() { PermissionedDrive = permissionedDrive } }
+            });
+
+        await senderOwnerClient.Connections.SendConnectionRequest(recipientOwnerClient.Identity.OdinId, new List<GuidId>());
+        await recipientOwnerClient.Connections.AcceptConnectionRequest(senderOwnerClient.Identity.OdinId, new List<GuidId> { circleId });
+    }
+
+    private async Task DeleteScenario(OwnerApiClientRedux senderOwnerClient, OwnerApiClientRedux recipientOwnerClient)
+    {
+        await _scaffold.OldOwnerApi.DisconnectIdentities(senderOwnerClient.Identity.OdinId, recipientOwnerClient.Identity.OdinId);
+    }
+}


### PR DESCRIPTION
A local-owner reaction sent the client two full-header WS notifications with the same versionTag: fileModified (from the localReactions write in UpdateLocalReactionsAsync) and statisticsChanged (from the reaction-summary update in UpdateReactionSummary). Sending the full header twice is wasteful.

This makes a reaction (and a comment, and a peer-incoming reaction) deliver a single full-header notification, of type fileModified:

- Retire StatisticsChanged on the wire: ReactionPreviewUpdatedNotification's client NotificationType is now FileModified (it was the only producer of StatisticsChanged). It already carries the fresh full header (reactionSummary
  + localReactions + updated). Reactions, comments, and peer reactions therefore all arrive as one fileModified.
- Suppress the now-redundant local-reactions fileModified from the WS broadcast via a new IDriveNotification.IgnoreWebSocketNotification flag, set on the DriveFileChangedNotification published by UpdateLocalReactionsAsync. The MediatR event still fires, so HomeCachingService (cache invalidation) and FeedDriveDistributionRouter (feed/peer distribution) are unaffected; only the client WS broadcast is skipped. The two WS handlers honor the flag.

Scope/safety: the double notification only ever occurred on the local-owner reaction path (the only writer of localReactions). Peer-incoming reactions and comments already emitted a single statisticsChanged with no fileModified; the rename simply relabels that single event to fileModified.

Tests (written first to characterize current behavior, then flipped):
- ReactionNotificationConsistencyTests: a reaction/comment now yields exactly one fileModified and zero statisticsChanged; the header carries fresh localReactions/summary/updated; matches the authoritative store across add/add/delete; two sockets each get exactly one fileModified.
- ReactionNotificationPeerTests (new): a peer-incoming reaction delivers exactly one fileModified to the recipient and zero statisticsChanged.

Verified: reaction (10), reaction+websocket (65), and feed (19) suites pass.