### PR TITLE
Fix v2 ws-token reconnect 401 by cloning cached auth context

### DIFF
--- a/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2NotificationSocketController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2NotificationSocketController.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -17,6 +18,8 @@ using Odin.Services.Authorization.ExchangeGrants;
 using Odin.Services.Base;
 using Odin.Services.Configuration.VersionUpgrade;
 using Odin.Services.Peer.AppNotification;
+
+[assembly: InternalsVisibleTo("Odin.Hosting.Tests")]
 
 namespace Odin.Hosting.UnifiedV2.Notifications
 {
@@ -97,6 +100,21 @@ namespace Odin.Hosting.UnifiedV2.Notifications
 
             if (bearerProtocol == null)
             {
+                // Diagnostics for the intermittent native-client 401: log the wire
+                // protocol (HTTP/1.1 vs HTTP/2 Extended CONNECT — reveals a proxy
+                // forwarding the upgrade over h2) and the requested subprotocols
+                // MINUS the bearer (so we never log the credential). If this shows
+                // protocols=[odin.notify.v1] with the bearer absent, the bearer was
+                // stripped/reordered before reaching the controller (proxy/engine),
+                // not a client encoding bug.
+                _logger.LogWarning(
+                    "V2 WS upgrade rejected (401): no '{prefix}*' subprotocol present. " +
+                    "httpProtocol={protocol} isWebSocketRequest={isWs} nonBearerProtocols=[{protocols}]",
+                    BearerProtocolPrefix,
+                    HttpContext.Request.Protocol,
+                    HttpContext.WebSockets.IsWebSocketRequest,
+                    string.Join(", ", HttpContext.WebSockets.WebSocketRequestedProtocols
+                        .Where(p => !p.StartsWith(BearerProtocolPrefix, StringComparison.Ordinal))));
                 HttpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
                 return;
             }
@@ -113,13 +131,16 @@ namespace Odin.Hosting.UnifiedV2.Notifications
             }
             catch (OdinSecurityException e)
             {
-                _logger.LogInformation("WS upgrade rejected: {error}", e.Message);
+                _logger.LogWarning("V2 WS upgrade rejected (401): token parsed but security check failed: {error} " +
+                                   "httpProtocol={protocol}", e.Message, HttpContext.Request.Protocol);
                 HttpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
                 return;
             }
 
             if (authenticatedContext == null)
             {
+                _logger.LogWarning("V2 WS upgrade rejected (401): app permission context resolved to null for a " +
+                                   "parsed token. httpProtocol={protocol}", HttpContext.Request.Protocol);
                 HttpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
                 return;
             }
@@ -171,11 +192,18 @@ namespace Odin.Hosting.UnifiedV2.Notifications
                     throw new OdinSecurityException("Invalid Client Token Type");
             }
 
-            ctx?.SetAuthContext(authContextName);
-            return ctx;
+            // GetAppPermissionContextAsync returns a token-keyed CACHED IOdinContext that is
+            // shared across requests. Calling SetAuthContext on it mutates that shared instance:
+            // the first WS upgrade for a token sets AuthContext, and every subsequent upgrade for
+            // the same token then throws OdinSecurityException("Cannot reset auth context") -> 401
+            // until the cache entry expires. That is the intermittent reconnect-401 flap. Clone
+            // first so the per-connection auth context never touches the cached entry.
+            var resolved = ctx?.Clone();
+            resolved?.SetAuthContext(authContextName);
+            return resolved;
         }
 
-        private static string Base64UrlToBase64(string base64Url)
+        internal static string Base64UrlToBase64(string base64Url)
         {
             var s = base64Url.Replace('-', '+').Replace('_', '/');
             var padLen = (4 - s.Length % 4) % 4;

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/Notifications/V2NotificationBearerEncodingTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/Notifications/V2NotificationBearerEncodingTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Odin.Hosting.UnifiedV2.Notifications;
+using Odin.Services.Authorization.ExchangeGrants;
+
+namespace Odin.Hosting.Tests._V2.Tests.Notifications;
+
+/// <summary>
+/// Pure-function coverage for the bearer-subprotocol decode path used by the v2
+/// cookie-less WebSocket route (<see cref="V2NotificationSocketController"/>).
+///
+/// Motivation: the Kotlin (KMP) desktop/native client builds the bearer as
+/// <c>odin.bearer.{Convert.ToBase64String(token.ToPortableBytes())}</c> — i.e.
+/// STANDARD base64 (alphabet '+' '/', '=' padding), NOT base64url. The browser
+/// client sends base64url (the subprotocol token grammar forbids '/'). Both must
+/// resolve to the identical <see cref="ClientAuthenticationToken"/> after the
+/// controller normalizes with <see cref="V2NotificationSocketController.Base64UrlToBase64"/>.
+///
+/// These tests pin that contract so a future "fix" to the normalizer can't
+/// silently break native clients (whose tokens contain '/'/'+' ~half the time).
+/// </summary>
+[TestFixture]
+public class V2NotificationBearerEncodingTests
+{
+    private const string BearerProtocolPrefix = "odin.bearer.";
+
+    // ClientAuthenticationToken.ToPortableBytes() == Id(16) + AccessTokenHalfKey(16) + type(1)
+    private const int PortableTokenLength = 33;
+
+    private static string ToBase64Url(byte[] bytes)
+        => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] BuildPortableToken(Random rng, byte tokenType)
+    {
+        var bytes = new byte[PortableTokenLength];
+        rng.NextBytes(bytes);
+        bytes[PortableTokenLength - 1] = tokenType; // last byte = ClientTokenType
+        return bytes;
+    }
+
+    [Test]
+    public void Base64UrlToBase64_IsIdentityOnAlreadyStandardBase64_For33ByteTokens()
+    {
+        // A 33-byte token base64-encodes to exactly 44 chars with no '=' padding,
+        // so the normalizer must leave standard base64 untouched (no '-'/'_' to
+        // swap, length already a multiple of 4). This is the property that lets
+        // native standard-base64 bearers authenticate at all.
+        var rng = new Random(1);
+        for (var i = 0; i < 5000; i++)
+        {
+            var bytes = BuildPortableToken(rng, (byte)ClientTokenType.App);
+            var std = Convert.ToBase64String(bytes);
+            ClassicAssert.AreEqual(44, std.Length, "33-byte token must encode to 44 base64 chars");
+            ClassicAssert.IsFalse(std.Contains('='), "33-byte token base64 must not be padded");
+
+            ClassicAssert.AreEqual(std, V2NotificationSocketController.Base64UrlToBase64(std),
+                $"Normalizer must be identity on standard base64 of a 33-byte token (input={std})");
+        }
+    }
+
+    [Test]
+    public void Bearer_StandardBase64_And_Base64Url_BothResolveToSameToken()
+    {
+        var rng = new Random(42);
+        var sawSlash = 0;
+        var sawPlus = 0;
+
+        for (var i = 0; i < 20000; i++)
+        {
+            var bytes = BuildPortableToken(rng, (byte)ClientTokenType.App);
+
+            var expectedId = new Guid(bytes.Take(16).ToArray());
+            var expectedHalfKey = bytes.Skip(16).Take(16).ToArray();
+            var expectedType = (ClientTokenType)bytes[32];
+
+            // What the KMP desktop/native client puts after "odin.bearer." (standard base64).
+            var nativeBearerValue = Convert.ToBase64String(bytes);
+            // What the browser client puts after "odin.bearer." (base64url, no padding).
+            var browserBearerValue = ToBase64Url(bytes);
+
+            if (nativeBearerValue.Contains('/')) sawSlash++;
+            if (nativeBearerValue.Contains('+')) sawPlus++;
+
+            AssertBearerResolves($"{BearerProtocolPrefix}{nativeBearerValue}", expectedId, expectedHalfKey, expectedType,
+                "native/standard-base64");
+            AssertBearerResolves($"{BearerProtocolPrefix}{browserBearerValue}", expectedId, expectedHalfKey, expectedType,
+                "browser/base64url");
+        }
+
+        // Guard: ensure the random corpus actually exercised the '+' and '/'
+        // characters that distinguish standard base64 from base64url — otherwise
+        // the test would be vacuously green.
+        ClassicAssert.Greater(sawSlash, 0, "expected some tokens whose standard base64 contains '/'");
+        ClassicAssert.Greater(sawPlus, 0, "expected some tokens whose standard base64 contains '+'");
+    }
+
+    private static void AssertBearerResolves(string requestedSubProtocol, Guid expectedId, byte[] expectedHalfKey,
+        ClientTokenType expectedType, string label)
+    {
+        // Mirror the controller's two steps exactly:
+        //   token64 = Base64UrlToBase64(value.Substring(prefix.Length));
+        //   ClientAuthenticationToken.TryParse(token64, out var cat);
+        var raw = requestedSubProtocol.Substring(BearerProtocolPrefix.Length);
+        var token64 = V2NotificationSocketController.Base64UrlToBase64(raw);
+
+        var ok = ClientAuthenticationToken.TryParse(token64, out var cat);
+        ClassicAssert.IsTrue(ok, $"[{label}] TryParse must succeed for bearer={requestedSubProtocol}");
+        ClassicAssert.AreEqual(expectedId, cat.Id, $"[{label}] token Id mismatch");
+        ClassicAssert.AreEqual(expectedType, cat.ClientTokenType, $"[{label}] token type mismatch");
+        CollectionAssert.AreEqual(expectedHalfKey, cat.AccessTokenHalfKey.GetKey(),
+            $"[{label}] access-token half key mismatch");
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/Notifications/V2NotificationSocketControllerTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/Notifications/V2NotificationSocketControllerTests.cs
@@ -96,6 +96,37 @@ public class V2NotificationSocketControllerTests
         await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
     }
 
+    // Regression for the intermittent reconnect 401 ("Cannot reset auth context").
+    // GetAppPermissionContextAsync returns a token-keyed CACHED IOdinContext; the controller
+    // mutated it via SetAuthContext on each upgrade. The first connect set AuthContext on the
+    // cached instance; every subsequent connect for the same token (the reconnect path) then
+    // threw OdinSecurityException("Cannot reset auth context") -> 401, until the cache entry
+    // expired. A single-connect test never catches this — you must connect twice with the
+    // same token.
+    [Test]
+    public async Task Connect_TwiceWithSameAppToken_SecondUpgradeStillSucceeds()
+    {
+        var (testAppContext, deviceClientAuthToken, deviceSharedSecret) = await SetupAppAndDeviceAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        // First connect — cache miss; works even with the bug present.
+        using (var socket1 = await ConnectAuthenticatedAsync(deviceClientAuthToken, cts.Token))
+        {
+            var r1 = await DoHandshakeAsync(socket1, deviceSharedSecret, [testAppContext.TargetDrive], cts.Token);
+            ClassicAssert.AreEqual(ClientNotificationType.DeviceHandshakeSuccess, r1.NotificationType);
+            await socket1.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+        }
+
+        // Second connect with the SAME token (cache hit) — the reconnect scenario that 401'd.
+        using var socket2 = await ConnectAuthenticatedAsync(deviceClientAuthToken, cts.Token);
+        ClassicAssert.AreEqual(NegotiatedSubProtocol, socket2.SubProtocol,
+            $"Reconnect upgrade must succeed; got HTTP {(int)socket2.HttpStatusCode}.");
+        var r2 = await DoHandshakeAsync(socket2, deviceSharedSecret, [testAppContext.TargetDrive], cts.Token);
+        ClassicAssert.AreEqual(ClientNotificationType.DeviceHandshakeSuccess, r2.NotificationType);
+        await socket2.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+    }
+
     [Test]
     public async Task Connect_WithValidAppToken_ReceivesFileAddedNotification()
     {
@@ -186,6 +217,39 @@ public class V2NotificationSocketControllerTests
 
     private static Uri BuildSocketUri(TestIdentity identity)
         => new($"wss://{identity.OdinId}:{WebScaffold.HttpsPort}{UnifiedApiRouteConstants.NotifySocket}");
+
+    private static Uri BuildSocketUriWasm(TestIdentity identity)
+        => new($"wss://{identity.OdinId}:{WebScaffold.HttpsPort}{UnifiedApiRouteConstants.NotifySocketWasm}");
+
+    // Reproduction probe for the intermittent native-client 401. The controller's own
+    // comment claims the [AcceptVerbs("GET","CONNECT")] route (ws-token-wasm now; and
+    // ws-token itself on pre-#1526 builds) "drops the bearer subprotocol value before
+    // the controller runs" for native HTTP/1.1 engines, yielding 401. A .NET
+    // ClientWebSocket performs an HTTP/1.1 GET+Upgrade just like Ktor CIO/OkHttp/Darwin,
+    // so if that claim is true in-process this test fails with 401. If it PASSES, the
+    // AcceptVerbs route is fine in-process and the production 401 is environmental
+    // (proxy/CDN mangling the upgrade, or a mixed/rolling deploy), not this code path.
+    [Test]
+    public async Task Connect_NativeHttp11_ToAcceptVerbsWasmRoute_WithValidAppToken_StillFindsBearerAndHandshakes()
+    {
+        var (testAppContext, deviceClientAuthToken, deviceSharedSecret) = await SetupAppAndDeviceAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        using var socket = new ClientWebSocket();
+        socket.Options.CollectHttpResponseDetails = true;
+        socket.Options.AddSubProtocol(NegotiatedSubProtocol);
+        socket.Options.AddSubProtocol(BearerProtocolPrefix + ToBase64Url(deviceClientAuthToken.ToPortableBytes()));
+        await socket.ConnectAsync(BuildSocketUriWasm(TestIdentities.Samwise), cts.Token);
+
+        ClassicAssert.AreEqual(NegotiatedSubProtocol, socket.SubProtocol,
+            $"AcceptVerbs route must echo {NegotiatedSubProtocol}; got HTTP {(int)socket.HttpStatusCode}.");
+
+        var response = await DoHandshakeAsync(socket, deviceSharedSecret, [testAppContext.TargetDrive], cts.Token);
+        ClassicAssert.AreEqual(ClientNotificationType.DeviceHandshakeSuccess, response.NotificationType);
+
+        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+    }
 
     private async Task<ClientWebSocket> ConnectAuthenticatedAsync(
         Odin.Services.Authorization.ExchangeGrants.ClientAuthenticationToken deviceClientAuthToken,


### PR DESCRIPTION
## Problem

Native clients (KMP desktop/Android/iOS) on the v2 cookie-less WebSocket
(`/api/v2/notify/ws-token`) showed an intermittent red connection dot: the socket
would connect once, then **401 on every reconnect** for minutes at a time, while all
REST calls with the same token kept working.

## Root cause

`V2NotificationSocketController.ResolveContextAsync` authenticated each upgrade by calling
`SetAuthContext()` on the `IOdinContext` returned by
`AppRegistrationService.GetAppPermissionContextAsync()`. That context is **cached, keyed by
the client auth token**, and therefore shared across requests. `OdinContext.SetAuthContext`
throws when `AuthContext` is already set:

```csharp
public void SetAuthContext(string authContext) {
    if (null != AuthContext) throw new OdinSecurityException("Cannot reset auth context");
    AuthContext = authContext;
}
```

So:

- **1st** upgrade for a token → cache miss → succeeds, **but mutates the cached context** (AuthContext now set).
- **Every reconnect** (same token, cache hit) → returns the poisoned context → `SetAuthContext` throws → **401** — until the cache entry expires, at which point it works once and re-poisons. Hence the flapping.
- **REST is unaffected** because `AppAuthPathHandler` copies `Caller`/`PermissionsContext` onto the per-request context instead of mutating the cached instance.

This is engine- and transport-independent — not a proxy/CDN or client problem. It was reproduced live against a local odin-core with no proxy in front, and the server-side log (added here) named it exactly: `token parsed but security check failed: Cannot reset auth context  httpProtocol=HTTP/1.1`.

## Fix

Clone the cached context before setting the per-connection auth context, so the shared cache entry is never mutated:

```csharp
var resolved = ctx?.Clone();
resolved?.SetAuthContext(authContextName);
return resolved;
```

## Tests

- **`Connect_TwiceWithSameAppToken_SecondUpgradeStillSucceeds`** — reproduces the reconnect path; **red** before this change (2nd upgrade returns 401), **green** after. The pre-existing single-connect test passed for the same reason the bug shipped — it never reconnected, so always test reconnect for cache-poisoning bugs.
- **`V2NotificationBearerEncodingTests`** — pins the bearer decode contract: native standard-base64 and browser base64url resolve to the identical token, including tokens whose base64 contains `+`/`/`.
- A native-HTTP/1.1-to-`[AcceptVerbs]`-route handshake test.

All 8 v2 notification tests pass.

## Also

The two previously-silent 401 branches in the controller now `LogWarning` with the request HTTP protocol and the non-bearer requested subprotocols (no credential logged) — this is what pinpointed the root cause and will make any future WS-upgrade 401 self-explanatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
