### PR TITLE
Fix "Parallelism detected" in introduction preflight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,18 @@ One tenant = one identity (domain). Tenant resolution happens from the HTTP host
 
 No ORM. Raw SQL with a code-first table definition pattern. Tables are classes with CRUD methods (e.g., `TableAppNotificationsCRUD.cs`). Database factories: `SqliteIdentityDbConnectionFactory` or `PgsqlIdentityDbConnectionFactory`. Migrations use `AbstractMigrator`. Both SQLite and PostgreSQL are tested in CI.
 
+**Scoped connections and parallelism.** `ScopedConnectionFactory` is registered per IOC lifetime scope and holds a single connection/transaction for that scope. It is **not** safe for concurrent use: if two tasks touch the DB through the same scope at once, it throws `OdinDatabaseException: "Parallelism detected (CreateScopedConnectionAsync)"`. The request scope is one such scope, so you cannot fan out DB work across `Task.WhenAll` / `Parallel.ForEach` / `Task.Run` while sharing the ambient services.
+
+When running DB work in parallel, give each parallel branch its own child scope and resolve the DB-touching services from it:
+
+```csharp
+await using var childScope = _lifetimeScope.BeginLifetimeScope($"MyWork:{Guid.NewGuid()}");
+var svc = childScope.Resolve<SomeDbService>();
+await svc.DoWorkAsync(...);
+```
+
+Inject `ILifetimeScope` to get the owning scope (Autofac supplies it automatically). Reference patterns: `PeerOutboxProcessorBackgroundService.ProcessItemThread` and `CircleNetworkIntroductionService.ProbeRecipientAsync`. `IOdinContext` is plain data and is safe to pass into a child scope; only resolved services are scope-bound. If parallelism isn't worth the scope plumbing, run the work sequentially instead.
+
 ### Authentication & API Versions
 
 Four auth schemes, each with its own controller directory:

--- a/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
+++ b/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Autofac;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Odin.Core;
@@ -18,6 +19,7 @@ using Odin.Services.AppNotifications.ClientNotifications;
 using Odin.Services.AppNotifications.Push;
 using Odin.Services.AppNotifications.SystemNotifications;
 using Odin.Services.Apps;
+using Odin.Services.Authorization.ExchangeGrants;
 using Odin.Services.Authorization.Permissions;
 using Odin.Services.Base;
 using Odin.Services.Configuration;
@@ -52,6 +54,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
     private readonly IDriveManager _driveManager;
     private readonly TenantConfigService _tenantConfigService;
     private readonly VersionUpgradeScheduler _versionUpgradeScheduler;
+    private readonly ILifetimeScope _lifetimeScope;
 
     /// <summary>
     /// Enables introducing identities to each other
@@ -69,7 +72,8 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         TenantContext tenantContext,
         TenantConfigService tenantConfigService,
         VersionUpgradeScheduler versionUpgradeScheduler,
-        IdentityDatabase db)
+        IdentityDatabase db,
+        ILifetimeScope lifetimeScope)
         : base(odinHttpClientFactory, circleNetworkService, fileSystemResolver, odinConfiguration)
     {
         _circleNetworkRequestService = circleNetworkRequestService;
@@ -82,6 +86,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         _tenantContext = tenantContext;
         _tenantConfigService = tenantConfigService;
         _versionUpgradeScheduler = versionUpgradeScheduler;
+        _lifetimeScope = lifetimeScope;
     }
 
     private const string ReceivedIntroductionContextKey = "f2f5c94c-c299-4122-8aa2-744d91f3b12f";
@@ -260,7 +265,12 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
 
         try
         {
-            var clientAuthToken = await ResolveClientAccessTokenAsync(recipient, odinContext, failIfNotConnected: false);
+            // Each probe runs in parallel (see PreflightIntroductionsAsync), so it must use its own IOC
+            // scope. Resolving DB-touching services from the shared request scope would have multiple
+            // probes contend on the same ScopedConnectionFactory and trip its parallelism guard.
+            await using var childScope = _lifetimeScope.BeginLifetimeScope($"ProbeRecipient:{Guid.NewGuid()}");
+
+            var clientAuthToken = await ResolveClientAccessTokenScopedAsync(childScope, recipient, odinContext);
             if (clientAuthToken == null)
             {
                 status.Status = IntroductionPreflightStatus.NotConnected;
@@ -340,6 +350,30 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             status.Detail = ex.Message;
             return status;
         }
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="PeerServiceBase.ResolveClientAccessTokenAsync"/> but resolves the
+    /// <see cref="CircleNetworkService"/> from the supplied child scope so parallel probes each
+    /// use their own ScopedConnectionFactory. Returns null when the recipient is not connected.
+    /// </summary>
+    private async Task<ClientAccessToken> ResolveClientAccessTokenScopedAsync(
+        ILifetimeScope childScope, OdinId recipient, IOdinContext odinContext)
+    {
+        odinContext.PermissionsContext.AssertHasAtLeastOnePermission(
+            PermissionKeys.UseTransitWrite,
+            PermissionKeys.UseTransitRead);
+
+        var circleNetworkService = childScope.Resolve<CircleNetworkService>();
+
+        // overrideHack: we already asserted UseTransitWrite or UseTransitRead above
+        var icr = await circleNetworkService.GetIcrAsync(recipient, odinContext, overrideHack: true);
+        if (icr.IsConnected() == false)
+        {
+            return null;
+        }
+
+        return icr.CreateClientAccessToken(odinContext.PermissionsContext.GetIcrKey());
     }
 
     /// <summary>


### PR DESCRIPTION
PreflightIntroductionsAsync fans out ProbeRecipientAsync across all recipients with Task.WhenAll, but every probe shared the request-scoped ScopedConnectionFactory. Concurrent ICR lookups (GetIcrAsync -> TableConnections) tripped the factory's parallelism guard, failing the preflight with OdinDatabaseException.

Each probe now opens its own child ILifetimeScope and resolves CircleNetworkService from it, so parallel branches get independent connection factories. Mirrors PeerOutboxProcessorBackgroundService's ProcessItemThread pattern.

Also document the scoped-connection/parallelism rule in CLAUDE.md.