### PR TITLE
Add V2 peer/over-peer transport API

### DIFF
--- a/src/apps/Odin.Hosting/Controllers/Base/OdinControllerBase.cs
+++ b/src/apps/Odin.Hosting/Controllers/Base/OdinControllerBase.cs
@@ -1,16 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Odin.Core.Exceptions;
 using Odin.Core.Identity;
+using Odin.Core.Time;
 using Odin.Services.Base;
 using Odin.Services.Drives;
 using Odin.Services.Drives.FileSystem.Base;
+using Odin.Services.Peer.Encryption;
 using Odin.Services.Util;
 using Odin.Hosting.Authentication.YouAuth;
 using Odin.Hosting.Controllers.Base.Drive;
@@ -134,6 +138,50 @@ public abstract class OdinControllerBase : ControllerBase
     protected void AssertIsValidOdinId(string odinId, out OdinId id)
     {
         OdinValidationUtils.AssertIsValidOdinId(odinId, out id);
+    }
+
+    /// <summary>
+    /// Renders a payload stream retrieved from a peer identity as an HTTP response, populating the
+    /// shared-secret / content-type headers the client needs to decrypt the payload.
+    /// </summary>
+    protected IActionResult HandlePeerPayloadResponse(EncryptedKeyHeader encryptedKeyHeader, bool isEncrypted,
+        PayloadStream payloadStream)
+    {
+        if (payloadStream == null)
+        {
+            return NotFound();
+        }
+
+        AddGuestApiCacheHeader();
+
+        HttpContext.Response.Headers.Append(HttpHeaderConstants.PayloadEncrypted, isEncrypted.ToString());
+        HttpContext.Response.Headers.Append(HttpHeaderConstants.PayloadKey, payloadStream.Key);
+        HttpContext.Response.Headers.LastModified = DriveFileUtility.GetLastModifiedHeaderValue(payloadStream.LastModified);
+        HttpContext.Response.Headers.Append(HttpHeaderConstants.DecryptedContentType, payloadStream.ContentType);
+        HttpContext.Response.Headers.Append(HttpHeaderConstants.SharedSecretEncryptedKeyHeader64, encryptedKeyHeader.ToBase64());
+        HttpContext.Response.Headers.ContentLength = payloadStream.ContentLength;
+        return new FileStreamResult(payloadStream.Stream, "application/octet-stream");
+    }
+
+    /// <summary>
+    /// Renders a thumbnail stream retrieved from a peer identity as an HTTP response, populating the
+    /// shared-secret / content-type headers the client needs to decrypt the thumbnail.
+    /// </summary>
+    protected IActionResult HandlePeerThumbnailResponse(EncryptedKeyHeader encryptedKeyHeader, bool isEncrypted,
+        string decryptedContentType, UnixTimeUtc? lastModified, Stream thumb)
+    {
+        if (thumb == Stream.Null)
+        {
+            return NotFound();
+        }
+
+        AddGuestApiCacheHeader();
+
+        HttpContext.Response.Headers.Append(HttpHeaderConstants.PayloadEncrypted, isEncrypted.ToString());
+        HttpContext.Response.Headers.Append(HttpHeaderConstants.DecryptedContentType, decryptedContentType);
+        HttpContext.Response.Headers.LastModified = DriveFileUtility.GetLastModifiedHeaderValue(lastModified);
+        HttpContext.Response.Headers.Append(HttpHeaderConstants.SharedSecretEncryptedKeyHeader64, encryptedKeyHeader.ToBase64());
+        return new FileStreamResult(thumb, "application/octet-stream");
     }
 
     /// <summary>

--- a/src/apps/Odin.Hosting/Controllers/Base/Transit/PeerQueryControllerBase.cs
+++ b/src/apps/Odin.Hosting/Controllers/Base/Transit/PeerQueryControllerBase.cs
@@ -118,7 +118,7 @@ namespace Odin.Hosting.Controllers.Base.Transit
             var (encryptedKeyHeader, isEncrypted, payloadStream) = await peerDriveQueryService.GetPayloadStreamAsync(id,
                 request.File, request.Key, request.Chunk, GetHttpFileSystemResolver().GetFileSystemType(), WebOdinContext);
 
-            return HandlePayloadResponse(encryptedKeyHeader, isEncrypted, payloadStream);
+            return HandlePeerPayloadResponse(encryptedKeyHeader, isEncrypted, payloadStream);
         }
 
         [SwaggerOperation(Tags = new[] { ControllerConstants.PeerQuery })]
@@ -166,7 +166,7 @@ namespace Odin.Hosting.Controllers.Base.Transit
                     request.PayloadKey,
                     GetHttpFileSystemResolver().GetFileSystemType(), WebOdinContext);
 
-            return HandleThumbnailResponse(encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb);
+            return HandlePeerThumbnailResponse(encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb);
         }
 
         [SwaggerOperation(Tags = new[] { ControllerConstants.PeerQuery })]
@@ -269,7 +269,7 @@ namespace Odin.Hosting.Controllers.Base.Transit
             var (encryptedKeyHeader, isEncrypted, payloadStream) =
                 await peerDriveQueryService.GetPayloadByGlobalTransitIdAsync(id, file, key, chunk, fst, WebOdinContext);
 
-            return HandlePayloadResponse(encryptedKeyHeader, isEncrypted, payloadStream);
+            return HandlePeerPayloadResponse(encryptedKeyHeader, isEncrypted, payloadStream);
         }
 
         [SwaggerOperation(Tags = new[] { ControllerConstants.PeerQuery })]
@@ -300,7 +300,7 @@ namespace Odin.Hosting.Controllers.Base.Transit
             var (encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb) =
                 await peerDriveQueryService.GetThumbnailByGlobalTransitIdAsync(id, file, payloadKey, width, height, directMatchOnly, fst, WebOdinContext);
 
-            return HandleThumbnailResponse(encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb);
+            return HandlePeerThumbnailResponse(encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb);
         }
 
         [SwaggerOperation(Tags = new[] { ControllerConstants.PeerQuery })]
@@ -332,41 +332,6 @@ namespace Odin.Hosting.Controllers.Base.Transit
             }
 
             return new JsonResult(result);
-        }
-
-        private IActionResult HandleThumbnailResponse(EncryptedKeyHeader encryptedKeyHeader, bool isEncrypted, string decryptedContentType,
-            UnixTimeUtc? lastModified, Stream thumb)
-        {
-            if (thumb == Stream.Null)
-            {
-                return NotFound();
-            }
-
-            AddGuestApiCacheHeader();
-
-            HttpContext.Response.Headers.Append(HttpHeaderConstants.PayloadEncrypted, isEncrypted.ToString());
-            HttpContext.Response.Headers.Append(HttpHeaderConstants.DecryptedContentType, decryptedContentType);
-            HttpContext.Response.Headers.LastModified = DriveFileUtility.GetLastModifiedHeaderValue(lastModified);
-            HttpContext.Response.Headers.Append(HttpHeaderConstants.SharedSecretEncryptedKeyHeader64, encryptedKeyHeader.ToBase64());
-            return new FileStreamResult(thumb, "application/octet-stream");
-        }
-
-        private IActionResult HandlePayloadResponse(EncryptedKeyHeader encryptedKeyHeader, bool isEncrypted, PayloadStream payloadStream)
-        {
-            if (payloadStream == null)
-            {
-                return NotFound();
-            }
-
-            AddGuestApiCacheHeader();
-
-            HttpContext.Response.Headers.Append(HttpHeaderConstants.PayloadEncrypted, isEncrypted.ToString());
-            HttpContext.Response.Headers.Append(HttpHeaderConstants.PayloadKey, payloadStream.Key);
-            HttpContext.Response.Headers.LastModified = DriveFileUtility.GetLastModifiedHeaderValue(payloadStream.LastModified);
-            HttpContext.Response.Headers.Append(HttpHeaderConstants.DecryptedContentType, payloadStream.ContentType);
-            HttpContext.Response.Headers.Append(HttpHeaderConstants.SharedSecretEncryptedKeyHeader64, encryptedKeyHeader.ToBase64());
-            HttpContext.Response.Headers.ContentLength = payloadStream.ContentLength;
-            return new FileStreamResult(payloadStream.Stream, "application/octet-stream");
         }
     }
 }

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DrivePeerFileReadonlyController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DrivePeerFileReadonlyController.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Odin.Hosting.Controllers.Base;
+using Odin.Hosting.UnifiedV2.Authentication.Policy;
+using Odin.Services.Drives;
+using Odin.Services.Drives.FileSystem.Base;
+using Odin.Services.Peer.Outgoing.Drive.Query;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Odin.Hosting.UnifiedV2.Drive.Read
+{
+    /// <summary>
+    /// Reads a single file's header, payload, and thumbnails from a drive hosted by another (peer)
+    /// identity — the V2 "over peer" equivalent of <c>/api/apps/v1/transit/query/{header,payload,thumb}</c>.
+    /// All shared-secret re-encryption is performed inside <see cref="PeerDriveQueryService"/>; this
+    /// controller only forwards the resulting streams/headers.
+    /// </summary>
+    [ApiController]
+    [Route(UnifiedApiRouteConstants.PeerByFileId)]
+    [UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]
+    [ApiExplorerSettings(GroupName = "v2")]
+    public class V2DrivePeerFileReadonlyController(PeerDriveQueryService peerDriveQueryService) : OdinControllerBase
+    {
+        [HttpGet("header")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
+        public async Task<IActionResult> GetFileHeader(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromRoute] Guid fileId)
+        {
+            AssertIsValidOdinId(odinId, out var id);
+
+            var result = await peerDriveQueryService.GetFileHeaderAsync(
+                id, ToExternalFile(driveId, fileId), GetHttpFileSystemResolver().GetFileSystemType(), WebOdinContext);
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return new JsonResult(result);
+        }
+
+        // Full payload (Range header honored)
+        [HttpGet("payload/{payloadKey}")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
+        [NoSharedSecretOnRequest]
+        [NoSharedSecretOnResponse]
+        public Task<IActionResult> GetPayload(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromRoute] Guid fileId,
+            [FromRoute] string payloadKey)
+        {
+            return GetPayloadInternal(odinId, driveId, fileId, payloadKey, GetChunk(null, null));
+        }
+
+        // Ranged payload (route-based)
+        [HttpGet("payload/{payloadKey}/{start:int}/{length:int}")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
+        [NoSharedSecretOnRequest]
+        [NoSharedSecretOnResponse]
+        public Task<IActionResult> GetPayload(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromRoute] Guid fileId,
+            [FromRoute] string payloadKey,
+            [FromRoute] int start,
+            [FromRoute] int length)
+        {
+            return GetPayloadInternal(odinId, driveId, fileId, payloadKey, GetChunk(start, length));
+        }
+
+        [HttpGet("payload/{payloadKey}/thumb/{width}/{height}")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
+        [NoSharedSecretOnRequest]
+        [NoSharedSecretOnResponse]
+        public async Task<IActionResult> GetThumbnail(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromRoute] Guid fileId,
+            [FromRoute] string payloadKey,
+            [FromRoute] int width,
+            [FromRoute] int height)
+        {
+            AssertIsValidOdinId(odinId, out var id);
+
+            var (encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb) =
+                await peerDriveQueryService.GetThumbnailAsync(id, ToExternalFile(driveId, fileId), width, height,
+                    payloadKey, GetHttpFileSystemResolver().GetFileSystemType(), WebOdinContext);
+
+            return HandlePeerThumbnailResponse(encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb);
+        }
+
+        private async Task<IActionResult> GetPayloadInternal(string odinId, Guid driveId, Guid fileId, string payloadKey,
+            FileChunk chunk)
+        {
+            AssertIsValidOdinId(odinId, out var id);
+
+            var (encryptedKeyHeader, isEncrypted, payloadStream) = await peerDriveQueryService.GetPayloadStreamAsync(
+                id, ToExternalFile(driveId, fileId), payloadKey, chunk, GetHttpFileSystemResolver().GetFileSystemType(),
+                WebOdinContext);
+
+            return HandlePeerPayloadResponse(encryptedKeyHeader, isEncrypted, payloadStream);
+        }
+
+        // The remote resolves the drive by alias (matching the peer "exists" endpoints), so Type is left empty.
+        private static ExternalFileIdentifier ToExternalFile(Guid driveId, Guid fileId)
+        {
+            return new ExternalFileIdentifier
+            {
+                FileId = fileId,
+                TargetDrive = new TargetDrive { Alias = driveId, Type = Guid.Empty }
+            };
+        }
+    }
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DrivePeerQueryBatchController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DrivePeerQueryBatchController.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Odin.Hosting.Controllers.Base;
+using Odin.Hosting.UnifiedV2.Authentication.Policy;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Query;
+using Odin.Services.Peer.Outgoing.Drive.Query;
+using Odin.Services.Util;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Odin.Hosting.UnifiedV2.Drive.Read
+{
+    /// <summary>
+    /// Queries files on a drive hosted by another (peer) identity — the V2 "over peer" equivalent of
+    /// <c>POST /api/apps/v1/transit/query/batch</c>. Used by clients that mount a drive owned by a
+    /// different identity (e.g. a collaborative community drive) and need to catch up on its files.
+    /// </summary>
+    [ApiController]
+    [Route(UnifiedApiRouteConstants.PeerByDriveId)]
+    [UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]
+    [ApiExplorerSettings(GroupName = "v2")]
+    public class V2DrivePeerQueryBatchController(PeerDriveQueryService peerDriveQueryService) : OdinControllerBase
+    {
+        [HttpPost("query-batch")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileQuery])]
+        public async Task<QueryBatchResponse> QueryBatch(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromBody] QueryBatchRequestV2 request)
+        {
+            AssertIsValidOdinId(odinId, out var id);
+            OdinValidationUtils.AssertNotNull(request, "request");
+            OdinValidationUtils.AssertNotNull(request.QueryParams, "QueryParams");
+            OdinValidationUtils.AssertNotNull(request.ResultOptionsRequest, "ResultOptionsRequest");
+
+            var fst = GetHttpFileSystemResolver().GetFileSystemType();
+
+            // PeerDriveQueryService talks to the remote perimeter using the V1 wire shape
+            // (FileQueryParamsV1, which carries the TargetDrive). The V2 route supplies the
+            // drive by alias; the remote resolves the drive by alias, matching the existing
+            // peer "exists" endpoints.
+            var v1Request = new QueryBatchRequest
+            {
+                QueryParams = ToV1QueryParams(request.QueryParams, driveId),
+                ResultOptionsRequest = request.ResultOptionsRequest,
+                FileSystemType = fst
+            };
+
+            var batch = await peerDriveQueryService.GetBatchAsync(id, v1Request, fst, WebOdinContext);
+            return QueryBatchResponse.FromResult(batch);
+        }
+
+        private static FileQueryParamsV1 ToV1QueryParams(FileQueryParams p, Guid driveId)
+        {
+            return new FileQueryParamsV1
+            {
+                TargetDrive = new TargetDrive { Alias = driveId, Type = Guid.Empty },
+                FileType = p.FileType,
+                FileState = p.FileState,
+                DataType = p.DataType,
+                ArchivalStatus = p.ArchivalStatus,
+                Sender = p.Sender,
+                GroupId = p.GroupId,
+                UserDate = p.UserDate,
+                ClientUniqueIdAtLeastOne = p.ClientUniqueIdAtLeastOne,
+                TagsMatchAtLeastOne = p.TagsMatchAtLeastOne,
+                TagsMatchAll = p.TagsMatchAll,
+                LocalTagsMatchAtLeastOne = p.LocalTagsMatchAtLeastOne,
+                LocalTagsMatchAll = p.LocalTagsMatchAll,
+                GlobalTransitId = p.GlobalTransitId
+            };
+        }
+    }
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Write/V2DrivePeerWriteController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Write/V2DrivePeerWriteController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Odin.Hosting.Controllers.Base.Transit;
+using Odin.Hosting.UnifiedV2.Authentication.Policy;
+using Odin.Services.Base;
+using Odin.Services.Drives.Management;
+using Odin.Services.Peer.Outgoing.Drive.Transfer;
+
+namespace Odin.Hosting.UnifiedV2.Drive.Write
+{
+    /// <summary>
+    /// Writes a file directly to a drive hosted by another (peer) identity, without keeping a local
+    /// copy — the V2 "over peer" equivalent of <c>POST /api/apps/v1/transit/sender/files/send</c>.
+    /// Reuses the V1 multipart upload + transient-temp-drive transfer path verbatim
+    /// (<see cref="PeerSenderControllerBase"/>): the multipart <c>instructions</c> part carries the
+    /// <c>RemoteTargetDrive</c> and <c>Recipients</c>, so the file is staged transiently and sent to
+    /// the owner over the outbox rather than stored on the caller's drive.
+    ///
+    /// Inherits <c>POST files/send</c> and <c>POST files/senddeleterequest</c>, producing
+    /// <c>/api/v2/peer/{odinId}/drives/{driveId}/files/send</c> (and .../senddeleterequest).
+    /// </summary>
+    [ApiController]
+    [Route(UnifiedApiRouteConstants.PeerByDriveId)]
+    [UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]
+    [ApiExplorerSettings(GroupName = "v2")]
+    [NoSharedSecretOnRequest]
+    [NoSharedSecretOnResponse]
+    public class V2DrivePeerWriteController(
+        ILogger<V2DrivePeerWriteController> logger,
+        PeerOutgoingTransferService peerOutgoingTransferService,
+        DriveManager driveManager,
+        FileSystemResolver fileSystemResolver)
+        : PeerSenderControllerBase(logger, peerOutgoingTransferService, driveManager, fileSystemResolver);
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2PeerNotificationController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2PeerNotificationController.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Odin.Hosting.Controllers.Base;
+using Odin.Hosting.UnifiedV2.Authentication.Policy;
+using Odin.Services.Peer.AppNotification;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Odin.Hosting.UnifiedV2.Notifications
+{
+    /// <summary>
+    /// Manages subscriptions to live notifications on drives hosted by other (peer) identities — the
+    /// V2 equivalent of <c>/api/apps/v1/notify/peer/{token,subscriptions/push-notification}</c>.
+    /// A client first fetches a remote notification token, then subscribes; live events arrive over
+    /// the peer websocket (<see cref="V2PeerNotificationSocketController"/>).
+    /// </summary>
+    [ApiController]
+    [Route(UnifiedApiRouteConstants.PeerNotifyRoot)]
+    [UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]
+    [ApiExplorerSettings(GroupName = "v2")]
+    public class V2PeerNotificationController(PeerAppNotificationService peerAppNotificationService) : OdinControllerBase
+    {
+        [HttpPost("token")]
+        [SwaggerOperation(Tags = [SwaggerInfo.Notifications])]
+        public async Task<AppNotificationTokenResponse> GetToken([FromBody] GetRemoteTokenRequest request)
+        {
+            return await peerAppNotificationService.GetRemoteNotificationToken(request, WebOdinContext);
+        }
+
+        [HttpPost("subscriptions/push-notification")]
+        [SwaggerOperation(Tags = [SwaggerInfo.Notifications])]
+        public async Task<IActionResult> Subscribe([FromBody] PeerNotificationSubscription request)
+        {
+            await peerAppNotificationService.SubscribePeerAsync(request, WebOdinContext);
+            return NoContent();
+        }
+
+        [HttpDelete("subscriptions/push-notification")]
+        [SwaggerOperation(Tags = [SwaggerInfo.Notifications])]
+        public async Task<IActionResult> Unsubscribe([FromBody] PeerNotificationSubscription request)
+        {
+            await peerAppNotificationService.UnsubscribePeerAsync(request, WebOdinContext);
+            return NoContent();
+        }
+
+        [HttpGet("subscriptions/push-notification")]
+        [SwaggerOperation(Tags = [SwaggerInfo.Notifications])]
+        public async Task<List<PeerNotificationSubscription>> GetSubscriptions()
+        {
+            return await peerAppNotificationService.GetAllSubscriptions(WebOdinContext);
+        }
+    }
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2PeerNotificationSocketController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2PeerNotificationSocketController.cs
@@ -1,0 +1,85 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Odin.Hosting.Controllers.Base;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Configuration.VersionUpgrade;
+
+namespace Odin.Hosting.UnifiedV2.Notifications
+{
+    /// <summary>
+    /// WebSocket entry point for live notifications on a drive hosted by another (peer) identity —
+    /// the V2 equivalent of <c>WS /api/apps/v1/notify/peer/ws</c>. The upgrade itself is anonymous;
+    /// the client authenticates in-band by sending a <c>SocketAuthenticationPackage</c> carrying its
+    /// peer-notification-subscriber token as the first message, which
+    /// <see cref="PeerAppNotificationHandler"/> validates. Two routes are exposed so both native
+    /// HTTP/1.1 clients and WASM/HTTP-2 Extended-CONNECT clients can upgrade, mirroring
+    /// <see cref="V2NotificationSocketController"/>.
+    /// </summary>
+    [ApiController]
+    [AllowAnonymous]
+    [ApiExplorerSettings(GroupName = "v2")]
+    public class V2PeerNotificationSocketController(
+        PeerAppNotificationHandler notificationHandler,
+        IHostApplicationLifetime hostApplicationLifetime)
+        : OdinControllerBase
+    {
+        [HttpGet]
+        [Route(UnifiedApiRouteConstants.PeerNotifySocket)]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public Task Connect()
+        {
+            return HandleAsync();
+        }
+
+        // Browser/WASM clients upgrade over HTTP/2 Extended CONNECT (RFC 8441), which MVC routing
+        // rejects with 405 when only [HttpGet] is present; the wasm-facing route accepts both verbs.
+        [AcceptVerbs("GET", "CONNECT")]
+        [Route(UnifiedApiRouteConstants.PeerNotifySocketWasm)]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public Task ConnectWasm()
+        {
+            return HandleAsync();
+        }
+
+        private async Task HandleAsync()
+        {
+            if (!HttpContext.WebSockets.IsWebSocketRequest)
+            {
+                HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return;
+            }
+
+            using var cancellationTokenSources = CancellationTokenSource.CreateLinkedTokenSource(
+                HttpContext.RequestAborted,
+                hostApplicationLifetime.ApplicationStopping);
+
+            try
+            {
+                using var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync(new WebSocketAcceptContext
+                {
+                    DangerousEnableCompression = true
+                });
+
+                // Authentication happens in-band: the handler treats the first message as a
+                // SocketAuthenticationPackage and resolves the peer-subscriber context from it.
+                await notificationHandler.EstablishConnection(webSocket, WebOdinContext, cancellationTokenSources.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore
+            }
+            catch (InvalidOperationException)
+            {
+                // Extended CONNECT requires a 2XX status; signal the client an upgrade is required.
+                VersionUpgradeScheduler.SetRequiresUpgradeResponse(HttpContext);
+            }
+        }
+    }
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/SwaggerInfo.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/SwaggerInfo.cs
@@ -25,6 +25,9 @@ public static class SwaggerInfo
     public const string FileTransfer = "File Transfer";
     
     public const string Connections = "Connection Operations";
-    
+
     public const string Links = "Links";
+
+    // Peer notification subscriptions (live updates on drives hosted by other identities)
+    public const string Notifications = "Notifications";
 }

--- a/src/apps/Odin.Hosting/UnifiedV2/UnifiedApiRouteConstants.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/UnifiedApiRouteConstants.cs
@@ -23,6 +23,13 @@ public static class UnifiedApiRouteConstants
     public const string PeerByOdinId = PeerRoot + "/{odinId}";
     public const string PeerByDriveId = PeerByOdinId + "/drives/{driveId:guid}";
     public const string PeerFilesRoot = PeerByDriveId + "/files";
+    public const string PeerByFileId = PeerFilesRoot + "/{fileId:guid}";
     public const string PeerByUniqueId = PeerFilesRoot + "/by-uid/{uid:guid}";
     public const string PeerByGtid = PeerFilesRoot + "/by-gtid/{gtid:guid}";
+
+    // Peer notifications (subscribe to live updates on a drive hosted by another identity)
+    public const string PeerNotifyRoot = PeerRoot + "/notify";
+    public const string PeerSubscriptions = PeerNotifyRoot + "/subscriptions";
+    public const string PeerNotifySocket = PeerNotifyRoot + "/ws-token";
+    public const string PeerNotifySocketWasm = PeerNotifyRoot + "/ws-token-wasm";
 }

--- a/tests/apps/Odin.Hosting.Tests.V2/Api/DriveHandles.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Api/DriveHandles.cs
@@ -16,6 +16,7 @@ public sealed class DriveHandles
     public DriveWriterV2Client Writer { get; }
     public DriveGroupReactionV2Client Reactions { get; }
     public DrivePeerReaderV2Client Peer { get; }
+    public DrivePeerWriterV2Client PeerWriter { get; }
 
     public DriveHandles(OdinId identity, IApiClientFactory factory, FileSystemType fileSystemType = FileSystemType.Standard)
     {
@@ -23,5 +24,6 @@ public sealed class DriveHandles
         Writer = new DriveWriterV2Client(identity, factory, fileSystemType);
         Reactions = new DriveGroupReactionV2Client(identity, factory);
         Peer = new DrivePeerReaderV2Client(identity, factory);
+        PeerWriter = new DrivePeerWriterV2Client(identity, factory, fileSystemType);
     }
 }

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/EncryptedPeerContentTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/EncryptedPeerContentTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Hosting.Tests.OwnerApi.ApiClient.Drive;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Hosting.Tests.V2.Peer;
+using Odin.Services.Authorization.Acl;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Query;
+using Odin.Services.Drives.DriveCore.Storage;
+using Odin.Services.Drives.FileSystem.Base.Upload;
+using Odin.Services.Peer.Encryption;
+using Odin.Services.Peer.Outgoing.Drive;
+
+namespace Odin.Hosting.Tests.V2.Ported.Peer;
+
+/// <summary>
+/// Exercises the security-critical part of the peer transport: the shared-secret re-encryption path.
+/// When a member reads an ENCRYPTED file from an owner-hosted drive over peer, the server must re-wrap
+/// the file's key header from the ICR-shared-secret into the MEMBER's own shared secret
+/// (<c>PeerDriveQueryService.TransformSharedSecret</c>/<c>ReEncrypt</c>). These tests prove the member
+/// (and, for writes, the owner) can decrypt with their OWN shared secret. Decryption pattern reused
+/// from <c>Ported/DriveRead/GetFileByUniqueIdTests</c> and <c>Peer/PeerScenarioTests</c>.
+/// </summary>
+[TestFixture]
+public class EncryptedPeerContentTests : V2Fixture
+{
+    private const int CommunityMessageFileType = 7020;
+
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task Member_ReadsEncryptedHeaderAndPayloadOverPeer()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Read, "community",
+            allowAnonymousReads: false);
+
+        var keyHeader = KeyHeader.NewRandom16();
+        const string plaintext = "secret community message";
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected);
+        metadata.AppData.Content = plaintext;
+        var payload = SamplePayloadDefinitions.GetPayloadDefinitionWithThumbnail1();
+        payload.Iv = ByteArrayUtil.GetRndByteArray(16); // encrypted payloads require a per-file IV
+        var payloads = new List<TestPayloadDefinition> { payload };
+        var manifest = new UploadManifest { PayloadDescriptors = payloads.ToPayloadDescriptorList().ToList() };
+
+        var (upload, _, _, _) = await owner.Drives.Writer.CreateEncryptedFile(
+            drive.Alias, metadata, new TransitOptions(), manifest, payloads, notificationOptions: null, keyHeader);
+        Assert.That(upload.IsSuccessStatusCode, Is.True, $"owner encrypted upload failed: {upload.StatusCode}");
+        var fileId = upload.Content!.FileId;
+
+        // Header over peer → decrypt content with the MEMBER's own shared secret.
+        var headerResp = await member.Drives.Peer.GetFileHeaderAsync(owner.Identity, drive.Alias, fileId);
+        Assert.That(headerResp.IsSuccessStatusCode, Is.True, $"peer header failed: {headerResp.StatusCode}");
+        var header = headerResp.Content!;
+        Assert.That(header.FileMetadata.IsEncrypted, Is.True);
+
+        var memberSecret = member.Drives.Reader.GetSharedSecret();
+        var headerKeyHeader = header.SharedSecretEncryptedKeyHeader.DecryptAesToKeyHeader(ref memberSecret);
+        var decryptedContent = headerKeyHeader.Decrypt(header.FileMetadata.AppData.Content.FromBase64()).ToStringFromUtf8Bytes();
+        Assert.That(decryptedContent, Is.EqualTo(plaintext),
+            "header content must decrypt with the member's own shared secret (proves ICR→owner re-encryption)");
+
+        // Payload over peer → decrypt with the MEMBER's own shared secret.
+        var payloadResp = await member.Drives.Peer.GetPayloadAsync(owner.Identity, drive.Alias, fileId, payload.Key);
+        Assert.That(payloadResp.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"peer payload failed: {payloadResp.StatusCode}");
+        Assert.That(payloadResp.Headers!.TryGetValues(HttpHeaderConstants.PayloadEncrypted, out var encVals), Is.True);
+        Assert.That(bool.Parse(encVals!.Single()), Is.True, "payload should be reported encrypted");
+        Assert.That(payloadResp.Headers.TryGetValues(HttpHeaderConstants.SharedSecretEncryptedKeyHeader64, out var ekhVals), Is.True);
+
+        var payloadEkh = EncryptedKeyHeader.FromBase64(ekhVals!.Single());
+        var memberSecret2 = member.Drives.Reader.GetSharedSecret();
+        var payloadKeyHeader = payloadEkh.DecryptAesToKeyHeader(ref memberSecret2);
+        var decryptedPayload = payloadKeyHeader.Decrypt(await payloadResp.Content!.ReadAsByteArrayAsync());
+        Assert.That(ByteArrayUtil.EquiByteArrayCompare(decryptedPayload, payload.Content), Is.True,
+            "payload must decrypt with the member's own shared secret over peer");
+    }
+
+    [Test]
+    public async Task Member_WritesEncryptedFileToOwnerOverPeer()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Write, "community",
+            allowAnonymousReads: false);
+
+        var keyHeader = KeyHeader.NewRandom16();
+        const string plaintext = "encrypted message written over peer";
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected,
+            allowDistribution: true);
+        metadata.AppData.Content = plaintext;
+
+        var send = await member.Drives.PeerWriter.SendEncryptedFileOverPeer(owner.Identity, drive, metadata, keyHeader);
+        Assert.That(send.IsSuccessStatusCode, Is.True, $"encrypted write-over-peer failed: {send.StatusCode}");
+        var gtid = send.Content!.RemoteGlobalTransitIdFileIdentifier?.GlobalTransitId
+                   ?? throw new InvalidOperationException("write-over-peer must yield a remote GlobalTransitId");
+
+        await member.Sync.DrainOutboxAsync();
+        await owner.Sync.ProcessInboxAsync(drive);
+
+        var q = await owner.Drives.Reader.GetBatchAsync(drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { GlobalTransitId = new[] { gtid } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 10, IncludeMetadataHeader = true }
+        });
+        Assert.That(q.IsSuccessStatusCode, Is.True, $"owner local query failed: {q.StatusCode}");
+        var header = q.Content!.SearchResults.SingleOrDefault();
+        Assert.That(header, Is.Not.Null, "owner should have received the encrypted file over peer");
+        Assert.That(header!.FileMetadata.IsEncrypted, Is.True);
+
+        // Owner decrypts with the OWNER's own shared secret (inbox re-encrypted the key header for the owner).
+        var ownerSecret = owner.Drives.Reader.GetSharedSecret();
+        var kh = header.SharedSecretEncryptedKeyHeader.DecryptAesToKeyHeader(ref ownerSecret);
+        var decrypted = kh.Decrypt(header.FileMetadata.AppData.Content.FromBase64()).ToStringFromUtf8Bytes();
+        Assert.That(decrypted, Is.EqualTo(plaintext));
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerAuthMatrixTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerAuthMatrixTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core.Identity;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Hosting.Tests.V2.Peer;
+using Odin.Services.Authorization.Acl;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Authorization.Permissions;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Query;
+
+namespace Odin.Hosting.Tests.V2.Ported.Peer;
+
+/// <summary>
+/// Verifies the authorization policy on the peer endpoints (`[UnifiedV2Authorize(OwnerOrApp)]`): an App
+/// caller holding <see cref="PermissionKeys.UseTransitRead"/> can read over peer, while a Guest
+/// (YouAuth) caller is rejected. Owner is already covered by the other peer fixtures.
+/// </summary>
+[TestFixture]
+public class PeerAuthMatrixTests : V2Fixture
+{
+    private const int CommunityMessageFileType = 7020;
+
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task AppCaller_WithUseTransitRead_CanQueryAndReadOverPeer()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Read, "community",
+            allowAnonymousReads: false);
+
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected);
+        metadata.AppData.Content = "hi from owner";
+        var upload = await owner.Drives.Writer.UploadNewMetadata(drive.Alias, metadata);
+        Assert.That(upload.IsSuccessStatusCode, Is.True, $"owner upload failed: {upload.StatusCode}");
+
+        // App registered on the member, granted drive Read + the UseTransitRead permission key.
+        var app = await AppSession.SetupAsync(member, drive, DrivePermission.Read,
+            permissionKeys: new List<int> { PermissionKeys.UseTransitRead });
+
+        var query = await app.Drives.Peer.QueryBatchAsync(owner.Identity, drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { FileType = new[] { CommunityMessageFileType } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 10, IncludeMetadataHeader = true }
+        });
+        Assert.That(query.IsSuccessStatusCode, Is.True,
+            $"App caller with UseTransitRead should query over peer; got {query.StatusCode}");
+        var fileId = query.Content!.SearchResults.Single().FileId;
+
+        var header = await app.Drives.Peer.GetFileHeaderAsync(owner.Identity, drive.Alias, fileId);
+        Assert.That(header.IsSuccessStatusCode, Is.True, $"App caller should read the header over peer; got {header.StatusCode}");
+    }
+
+    [Test]
+    public async Task GuestCaller_IsRejectedFromPeerQuery()
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var drive = TargetDrive.NewTargetDrive();
+        await owner.Admin.CreateDrive(drive, "community", allowAnonymousReads: false);
+
+        var guest = await GuestSession.SetupAsync(owner, drive, DrivePermission.Read);
+
+        var response = await guest.Drives.Peer.QueryBatchAsync((OdinId)Identities.Sam, drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { FileType = new[] { CommunityMessageFileType } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 10 }
+        });
+
+        Assert.That(response.IsSuccessStatusCode, Is.False,
+            $"Guest/YouAuth caller must be rejected by the OwnerOrApp policy; got {response.StatusCode}");
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerNotificationSubscriptionTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerNotificationSubscriptionTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core.Identity;
+using Odin.Hosting.Tests._V2.ApiClient;
+using Odin.Hosting.Tests.V2.Api;
+
+namespace Odin.Hosting.Tests.V2.Ported.Peer;
+
+/// <summary>
+/// Cap 4a of the chat-kmp V2 peer transport: REST management of subscriptions to live notifications
+/// on drives hosted by other identities (<c>/api/v2/peer/notify/subscriptions/push-notification</c>).
+/// Based on the V1 <c>_Universal/Peer/PeerAppNotificationsWebSocket</c> subscription client. The
+/// websocket delivery itself is covered by a WebScaffold test (the fast framework does not host WS).
+/// </summary>
+[TestFixture]
+public class PeerNotificationSubscriptionTests : V2Fixture
+{
+    protected override string[] HostIdentities => [Identities.Frodo];
+
+    [Test]
+    public async Task Subscribe_List_Unsubscribe_RoundTrips()
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var client = new PeerNotificationV2Client(owner.Identity, owner.Factory);
+
+        var peer = (OdinId)Identities.Sam;
+        var subscriptionId = Guid.NewGuid();
+
+        var subscribe = await client.SubscribeAsync(peer, subscriptionId);
+        Assert.That(subscribe.IsSuccessStatusCode, Is.True, $"subscribe failed: {subscribe.StatusCode}");
+
+        var afterSubscribe = await client.GetSubscriptionsAsync();
+        Assert.That(afterSubscribe.IsSuccessStatusCode, Is.True, $"list failed: {afterSubscribe.StatusCode}");
+        Assert.That(afterSubscribe.Content!.Any(s => s.SubscriptionId == subscriptionId && s.Identity == peer), Is.True,
+            "subscription should be listed after subscribe");
+
+        var unsubscribe = await client.UnsubscribeAsync(peer, subscriptionId);
+        Assert.That(unsubscribe.IsSuccessStatusCode, Is.True, $"unsubscribe failed: {unsubscribe.StatusCode}");
+
+        var afterUnsubscribe = await client.GetSubscriptionsAsync();
+        Assert.That(afterUnsubscribe.IsSuccessStatusCode, Is.True);
+        Assert.That(afterUnsubscribe.Content!.Any(s => s.SubscriptionId == subscriptionId), Is.False,
+            "subscription should be gone after unsubscribe");
+    }
+
+    [Test]
+    public async Task Subscribe_EmptySubscriptionId_IsRejected()
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var client = new PeerNotificationV2Client(owner.Identity, owner.Factory);
+
+        var response = await client.SubscribeAsync((OdinId)Identities.Sam, Guid.Empty);
+        Assert.That(response.IsSuccessStatusCode, Is.False,
+            $"empty subscription id should be rejected; got {response.StatusCode}");
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerQueryAndContentTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerQueryAndContentTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Hosting.Tests.OwnerApi.ApiClient.Drive;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Hosting.Tests.V2.Peer;
+using Odin.Services.Authorization.Acl;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Query;
+using Odin.Services.Drives.FileSystem.Base;
+using Odin.Services.Drives.FileSystem.Base.Upload;
+
+namespace Odin.Hosting.Tests.V2.Ported.Peer;
+
+/// <summary>
+/// Cap 1 + Cap 2 of the chat-kmp V2 peer transport: a member queries and reads files from a drive
+/// hosted by another identity over peer. Models the community read path
+/// (<c>queryBatchOverPeer</c> + <c>getContentFromHeaderOverPeer</c>). Based on the battle-tested V1
+/// <c>_Universal/Peer</c> query flows.
+///
+/// Layout: <c>owner</c> (Sam) hosts the drive and uploads files locally; <c>member</c> (Frodo) is
+/// connected and granted Read on the owner's drive, then reads over peer.
+/// </summary>
+[TestFixture]
+public class PeerQueryAndContentTests : V2Fixture
+{
+    private const int CommunityMessageFileType = 7020;
+
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task Member_CanQueryBatchOwnerDriveOverPeer()
+    {
+        var (member, owner, drive) = await SetupMemberCanReadOwnerDriveAsync();
+
+        // Owner posts two messages locally on the community drive.
+        var f1 = await OwnerUploadsMessage(owner, drive, "hello");
+        var f2 = await OwnerUploadsMessage(owner, drive, "world");
+
+        var response = await member.Drives.Peer.QueryBatchAsync(owner.Identity, drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { FileType = new[] { CommunityMessageFileType } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 100, IncludeMetadataHeader = true }
+        });
+
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"peer query-batch failed: {response.StatusCode}");
+        var fileIds = response.Content!.SearchResults.Select(r => r.FileId).ToList();
+        Assert.That(fileIds, Has.Member(f1.FileId));
+        Assert.That(fileIds, Has.Member(f2.FileId));
+    }
+
+    [Test]
+    public async Task Member_QueryBatchOverPeer_EmptyDrive_ReturnsNoResults()
+    {
+        var (member, owner, drive) = await SetupMemberCanReadOwnerDriveAsync();
+
+        var response = await member.Drives.Peer.QueryBatchAsync(owner.Identity, drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { FileType = new[] { CommunityMessageFileType } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 100, IncludeMetadataHeader = true }
+        });
+
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"peer query-batch failed: {response.StatusCode}");
+        Assert.That(response.Content!.SearchResults.Count(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Member_CanGetHeaderAndPayloadAndThumbnailOverPeer()
+    {
+        var (member, owner, drive) = await SetupMemberCanReadOwnerDriveAsync();
+
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected);
+        var payload = SamplePayloadDefinitions.GetPayloadDefinitionWithThumbnail1();
+        var manifest = new UploadManifest
+        {
+            PayloadDescriptors = new List<TestPayloadDefinition> { payload }.ToPayloadDescriptorList().ToList()
+        };
+        var uploaded = await owner.Drives.Writer.CreateNewUnencryptedFile(
+            drive.Alias, metadata, manifest, new List<TestPayloadDefinition> { payload });
+        Assert.That(uploaded.IsSuccessStatusCode, Is.True, $"owner upload failed: {uploaded.StatusCode}");
+        var fileId = uploaded.Content!.FileId;
+
+        // header
+        var header = await member.Drives.Peer.GetFileHeaderAsync(owner.Identity, drive.Alias, fileId);
+        Assert.That(header.IsSuccessStatusCode, Is.True, $"peer header failed: {header.StatusCode}");
+        Assert.That(header.Content!.FileMetadata.Payloads.Count(), Is.EqualTo(1));
+
+        // payload (unencrypted → bytes come back verbatim)
+        var payloadResponse = await member.Drives.Peer.GetPayloadAsync(owner.Identity, drive.Alias, fileId, payload.Key);
+        Assert.That(payloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), "peer payload should be 200");
+        var payloadBytes = await payloadResponse.Content!.ReadAsByteArrayAsync();
+        Assert.That(payloadBytes.ToBase64(), Is.EqualTo(payload.Content.ToBase64()), "payload content mismatch over peer");
+
+        // thumbnail
+        var thumb = payload.Thumbnails.Single();
+        var thumbResponse = await member.Drives.Peer.GetThumbnailAsync(
+            owner.Identity, drive.Alias, fileId, payload.Key, thumb.PixelWidth, thumb.PixelHeight);
+        Assert.That(thumbResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), "peer thumbnail should be 200");
+        var thumbBytes = await thumbResponse.Content!.ReadAsByteArrayAsync();
+        Assert.That(thumbBytes.ToBase64(), Is.EqualTo(thumb.Content.ToBase64()), "thumbnail content mismatch over peer");
+    }
+
+    [Test]
+    public async Task Member_ReadsRangedPayloadOverPeer()
+    {
+        var (member, owner, drive) = await SetupMemberCanReadOwnerDriveAsync();
+
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected);
+        var payload = SamplePayloadDefinitions.GetPayloadDefinition1();
+        var manifest = new UploadManifest
+        {
+            PayloadDescriptors = new List<TestPayloadDefinition> { payload }.ToPayloadDescriptorList().ToList()
+        };
+        var uploaded = await owner.Drives.Writer.CreateNewUnencryptedFile(
+            drive.Alias, metadata, manifest, new List<TestPayloadDefinition> { payload });
+        Assert.That(uploaded.IsSuccessStatusCode, Is.True, $"owner upload failed: {uploaded.StatusCode}");
+        var fileId = uploaded.Content!.FileId;
+
+        const int start = 1;
+        const int length = 4;
+        var response = await member.Drives.Peer.GetPayloadAsync(
+            owner.Identity, drive.Alias, fileId, payload.Key, new FileChunk { Start = start, Length = length });
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"peer ranged payload failed: {response.StatusCode}");
+
+        var bytes = await response.Content!.ReadAsByteArrayAsync();
+        var expected = payload.Content.Skip(start).Take(length).ToArray();
+        Assert.That(bytes.Length, Is.EqualTo(expected.Length), "ranged read returned the wrong number of bytes");
+        Assert.That(ByteArrayUtil.EquiByteArrayCompare(bytes, expected), Is.True, "ranged payload slice mismatch over peer");
+    }
+
+    [Test]
+    public async Task Member_GetHeaderOverPeer_MissingFile_ReturnsNotFound()
+    {
+        var (member, owner, drive) = await SetupMemberCanReadOwnerDriveAsync();
+
+        var header = await member.Drives.Peer.GetFileHeaderAsync(owner.Identity, drive.Alias, Guid.NewGuid());
+        Assert.That(header.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    public async Task NotConnectedMember_QueryBatchOverPeer_IsRejected()
+    {
+        // Both identities exist and each has the drive, but no connection / grant exists.
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+
+        var drive = TargetDrive.NewTargetDrive();
+        await member.Admin.CreateDrive(drive, "member copy", allowAnonymousReads: false);
+        await owner.Admin.CreateDrive(drive, "owner copy", allowAnonymousReads: false);
+
+        var response = await member.Drives.Peer.QueryBatchAsync(owner.Identity, drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { FileType = new[] { CommunityMessageFileType } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 10, IncludeMetadataHeader = true }
+        });
+
+        Assert.That(response.IsSuccessStatusCode, Is.False,
+            $"unconnected member should not be able to query the owner's drive; got {response.StatusCode}");
+    }
+
+    // -----------------------------------------------------------------------------------------
+
+    private async Task<(OwnerSession member, OwnerSession owner, TargetDrive drive)> SetupMemberCanReadOwnerDriveAsync()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        // sender = member: the member is granted Read on the owner's (recipient's) drive.
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Read, "community",
+            allowAnonymousReads: false);
+        return (member, owner, drive);
+    }
+
+    private static async Task<Odin.Hosting.UnifiedV2.Drive.Write.CreateFileResult> OwnerUploadsMessage(
+        OwnerSession owner, TargetDrive drive, string content)
+    {
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected);
+        metadata.AppData.Content = content;
+        var response = await owner.Drives.Writer.UploadNewMetadata(drive.Alias, metadata);
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"owner upload failed: {response.StatusCode}");
+        return response.Content!;
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerTokenDeleteCommentTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerTokenDeleteCommentTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core.Storage;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Hosting.Tests._V2.ApiClient;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Hosting.Tests.V2.Peer;
+using Odin.Services.Apps;
+using Odin.Services.Authorization.Acl;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Query;
+using Odin.Services.Drives.DriveCore.Storage;
+
+namespace Odin.Hosting.Tests.V2.Ported.Peer;
+
+/// <summary>
+/// "Comprehensive" extras for the V2 peer transport: the V2 remote-notification token endpoint,
+/// delete-over-peer, and proof that the peer endpoints honor the file-system-type header.
+/// </summary>
+[TestFixture]
+public class PeerTokenDeleteCommentTests : V2Fixture
+{
+    private const int CommunityMessageFileType = 7020;
+
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task V2TokenEndpoint_ReturnsTokenForConnectedPeer()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Read, "community", allowAnonymousReads: false);
+
+        var client = new PeerNotificationV2Client(member.Identity, member.Factory);
+        var response = await client.GetTokenAsync(owner.Identity);
+
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"V2 token endpoint failed: {response.StatusCode}");
+        Assert.That(response.Content!.AuthenticationToken64, Is.Not.Null.And.Not.Empty);
+        Assert.That(response.Content.SharedSecret, Is.Not.Null);
+        Assert.That(response.Content.SharedSecret.Length, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public async Task Member_DeletesFileOnOwnerOverPeer()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Write, "community",
+            allowAnonymousReads: false);
+
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected,
+            allowDistribution: true);
+        metadata.AppData.Content = "to be deleted over peer";
+
+        var send = await member.Drives.PeerWriter.SendUnencryptedFileOverPeer(owner.Identity, drive, metadata);
+        Assert.That(send.IsSuccessStatusCode, Is.True, $"seed write-over-peer failed: {send.StatusCode}");
+        var gtid = send.Content!.RemoteGlobalTransitIdFileIdentifier!.GlobalTransitId;
+
+        await member.Sync.DrainOutboxAsync();
+        await owner.Sync.ProcessInboxAsync(drive);
+
+        Assert.That(await QueryByGtid(owner, drive, gtid), Is.Not.Null, "file should exist on owner before delete");
+
+        var del = await member.Drives.PeerWriter.SendDeleteRequestOverPeer(owner.Identity, drive, gtid);
+        Assert.That(del.IsSuccessStatusCode, Is.True, $"delete-over-peer failed: {del.StatusCode}");
+
+        await member.Sync.DrainOutboxAsync();
+        await owner.Sync.ProcessInboxAsync(drive);
+
+        var after = await QueryByGtid(owner, drive, gtid);
+        Assert.That(after == null || after.FileState == FileState.Deleted, Is.True,
+            "owner's copy should be deleted after a delete-over-peer request");
+    }
+
+    [Test]
+    public async Task PeerQuery_HonorsFileSystemTypeHeader()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Read, "community",
+            allowAnonymousReads: false);
+
+        // Upload a STANDARD file on the owner's drive.
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected);
+        var upload = await owner.Drives.Writer.UploadNewMetadata(drive.Alias, metadata);
+        Assert.That(upload.IsSuccessStatusCode, Is.True, $"owner upload failed: {upload.StatusCode}");
+        var fileId = upload.Content!.FileId;
+
+        QueryBatchRequest Req() => new()
+        {
+            QueryParams = new FileQueryParamsV1 { FileType = new[] { CommunityMessageFileType } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 10, IncludeMetadataHeader = true }
+        };
+
+        // Standard FST → the file is found.
+        var standard = await member.Drives.Peer.QueryBatchAsync(owner.Identity, drive.Alias, Req(), FileSystemType.Standard);
+        Assert.That(standard.IsSuccessStatusCode, Is.True, $"standard peer query failed: {standard.StatusCode}");
+        Assert.That(standard.Content!.SearchResults.Any(r => r.FileId == fileId), Is.True);
+
+        // Comment FST → the Standard file is NOT in the comment store (proves the FST header routes
+        // over peer). Note: standalone comment files require a parent reference, so this asserts store
+        // isolation rather than creating a comment.
+        var comment = await member.Drives.Peer.QueryBatchAsync(owner.Identity, drive.Alias, Req(), FileSystemType.Comment);
+        Assert.That(comment.IsSuccessStatusCode, Is.True, $"comment peer query failed: {comment.StatusCode}");
+        Assert.That(comment.Content!.SearchResults.Any(r => r.FileId == fileId), Is.False,
+            "a Standard file must not appear in a Comment-filesystem peer query");
+    }
+
+    private static async Task<SharedSecretEncryptedFileHeader> QueryByGtid(OwnerSession session, TargetDrive drive, Guid gtid)
+    {
+        var q = await session.Drives.Reader.GetBatchAsync(drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { GlobalTransitId = new[] { gtid } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 10, IncludeMetadataHeader = true }
+        });
+        Assert.That(q.IsSuccessStatusCode, Is.True, $"local query failed: {q.StatusCode}");
+        return q.Content!.SearchResults.SingleOrDefault();
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/WriteOverPeerTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/WriteOverPeerTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Hosting.Tests.OwnerApi.ApiClient.Drive;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Hosting.Tests.V2.Peer;
+using Odin.Services.Authorization.Acl;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Query;
+using Odin.Services.Drives.FileSystem.Base.Upload;
+
+namespace Odin.Hosting.Tests.V2.Ported.Peer;
+
+/// <summary>
+/// Cap 3 of the chat-kmp V2 peer transport: a member writes a file directly to a drive hosted by
+/// another identity, with NO local copy (the community <c>uploadFileOverPeer</c> path). Based on the
+/// battle-tested V1 <c>_Universal/Peer/DirectSend</c> tests.
+///
+/// Layout: <c>member</c> (Frodo) is granted Write on the <c>owner</c> (Sam) drive and sends a message
+/// straight to it over peer. The file appears on the owner and NOT on the member.
+/// </summary>
+[TestFixture]
+public class WriteOverPeerTests : V2Fixture
+{
+    private const int CommunityMessageFileType = 7020;
+
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task Member_WritesFileToOwnerDriveOverPeer_NoLocalCopy()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+
+        // member (sender) is granted Write on the owner's (recipient's) drive.
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Write, "community",
+            allowAnonymousReads: false);
+
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected,
+            allowDistribution: true);
+        metadata.AppData.Content = "hello from the member over peer";
+
+        var send = await member.Drives.PeerWriter.SendUnencryptedFileOverPeer(owner.Identity, drive, metadata);
+        Assert.That(send.IsSuccessStatusCode, Is.True, $"write-over-peer failed: {send.StatusCode}");
+
+        var gtid = send.Content!.RemoteGlobalTransitIdFileIdentifier?.GlobalTransitId
+                   ?? throw new InvalidOperationException("write-over-peer must yield a remote GlobalTransitId");
+
+        await member.Sync.DrainOutboxAsync();
+        await owner.Sync.ProcessInboxAsync(drive);
+
+        // The owner now hosts the file.
+        var ownerCopy = await QueryByGtid(owner, drive, gtid);
+        Assert.That(ownerCopy, Is.Not.Null, "owner should have received the file written over peer");
+        Assert.That(ownerCopy!.FileMetadata.AppData.Content, Is.EqualTo("hello from the member over peer"));
+
+        // The member kept no local copy (the write was staged transiently and sent).
+        var memberCopy = await QueryByGtid(member, drive, gtid);
+        Assert.That(memberCopy, Is.Null, "member must not retain a local copy of a write-over-peer file");
+    }
+
+    [Test]
+    public async Task Member_WritesFileWithPayloadToOwnerOverPeer()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Write, "community",
+            allowAnonymousReads: false);
+
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected,
+            allowDistribution: true);
+        metadata.AppData.Content = "message with attachment";
+        var payload = SamplePayloadDefinitions.GetPayloadDefinition1();
+        var payloads = new List<TestPayloadDefinition> { payload };
+        var manifest = new UploadManifest { PayloadDescriptors = payloads.ToPayloadDescriptorList().ToList() };
+
+        var send = await member.Drives.PeerWriter.SendUnencryptedFileOverPeer(owner.Identity, drive, metadata, payloads, manifest);
+        Assert.That(send.IsSuccessStatusCode, Is.True, $"write-with-payload over peer failed: {send.StatusCode}");
+        var gtid = send.Content!.RemoteGlobalTransitIdFileIdentifier!.GlobalTransitId;
+
+        await member.Sync.DrainOutboxAsync();
+        await owner.Sync.ProcessInboxAsync(drive);
+
+        var ownerCopy = await QueryByGtid(owner, drive, gtid);
+        Assert.That(ownerCopy, Is.Not.Null, "owner should have received the file");
+        Assert.That(ownerCopy!.FileMetadata.Payloads.Count(), Is.EqualTo(1), "the payload should be present on the owner's copy");
+
+        var payloadResponse = await owner.Drives.Reader.GetPayloadAsync(drive.Alias, ownerCopy.FileId, payload.Key);
+        Assert.That(payloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        var bytes = await payloadResponse.Content!.ReadAsByteArrayAsync();
+        Assert.That(ByteArrayUtil.EquiByteArrayCompare(bytes, payload.Content), Is.True, "payload content mismatch on owner");
+    }
+
+    [Test]
+    public async Task Member_UnauthorizedWrite_IsRejected()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        // Member is granted only READ on the owner's drive — not Write.
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Read, "community",
+            allowAnonymousReads: false);
+
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected,
+            allowDistribution: true);
+        metadata.AppData.Content = "i should not be allowed to write this";
+
+        var send = await member.Drives.PeerWriter.SendUnencryptedFileOverPeer(owner.Identity, drive, metadata);
+        var gtid = send.Content?.RemoteGlobalTransitIdFileIdentifier?.GlobalTransitId ?? Guid.Empty;
+
+        await member.Sync.DrainOutboxAsync();
+        await owner.Sync.ProcessInboxAsync(drive);
+
+        // Regardless of where the rejection surfaces (send status or remote perimeter), the file must
+        // not land on the owner's drive.
+        if (gtid != Guid.Empty)
+        {
+            var ownerCopy = await QueryByGtid(owner, drive, gtid);
+            Assert.That(ownerCopy, Is.Null, "a write from a Read-only member must not land on the owner's drive");
+        }
+    }
+
+    private static async Task<Odin.Services.Apps.SharedSecretEncryptedFileHeader> QueryByGtid(
+        OwnerSession session, TargetDrive drive, Guid gtid)
+    {
+        var q = await session.Drives.Reader.GetBatchAsync(drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { GlobalTransitId = new[] { gtid } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 10, IncludeMetadataHeader = true }
+        });
+        Assert.That(q.IsSuccessStatusCode, Is.True, $"local query failed: {q.StatusCode}");
+        return q.Content!.SearchResults.SingleOrDefault();
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_Universal/Peer/PeerAppNotificationsWebSocket/PeerTestAppWebSocketListener.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/Peer/PeerAppNotificationsWebSocket/PeerTestAppWebSocketListener.cs
@@ -32,7 +32,8 @@ public sealed class PeerTestAppWebSocketListener
         }
     }
 
-    public async Task ConnectAsync(OdinId identity, ClientAccessToken token, EstablishConnectionOptions options)
+    public async Task ConnectAsync(OdinId identity, ClientAccessToken token, EstablishConnectionOptions options,
+        string pathOverride = null)
     {
         _token = token;
         // _clientWebSocket.Options.Cookies = new CookieContainer();
@@ -47,7 +48,8 @@ public sealed class PeerTestAppWebSocketListener
         //
         // Connect to the socket
         //
-        var uri = new Uri($"wss://{identity}:{WebScaffold.HttpsPort}{GuestApiPathConstantsV1.PeerNotificationsV1}/ws");
+        var path = pathOverride ?? (GuestApiPathConstantsV1.PeerNotificationsV1 + "/ws");
+        var uri = new Uri($"wss://{identity}:{WebScaffold.HttpsPort}{path}");
         await _clientWebSocket.ConnectAsync(uri, tokenSource.Token);
 
         var request = new SocketCommand

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DrivePeerReaderV2Client.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DrivePeerReaderV2Client.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Odin.Core.Identity;
+using Odin.Core.Storage;
 using Odin.Hosting.Tests._Universal.ApiClient.Factory;
+using Odin.Services.Apps;
+using Odin.Services.Drives;
+using Odin.Services.Drives.FileSystem.Base;
 using Odin.Services.Peer.Outgoing.Drive.Query;
 using Refit;
 
@@ -21,5 +26,42 @@ public class DrivePeerReaderV2Client(OdinId identity, IApiClientFactory factory)
         var client = factory.CreateHttpClient(identity, out var sharedSecret);
         var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
         return await svc.GetFileExistsByGtid(peer.DomainName, driveId, gtid);
+    }
+
+    public async Task<ApiResponse<QueryBatchResponse>> QueryBatchAsync(OdinId peer, Guid driveId, QueryBatchRequest request,
+        FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        return await svc.QueryBatch(peer.DomainName, driveId, request);
+    }
+
+    public async Task<ApiResponse<SharedSecretEncryptedFileHeader>> GetFileHeaderAsync(OdinId peer, Guid driveId, Guid fileId,
+        FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetFileHeader(peer.DomainName, driveId, fileId);
+    }
+
+    public async Task<ApiResponse<HttpContent>> GetPayloadAsync(OdinId peer, Guid driveId, Guid fileId, string payloadKey,
+        FileChunk chunk = null, FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        if (chunk == null)
+        {
+            return await svc.GetPayload(peer.DomainName, driveId, fileId, payloadKey);
+        }
+
+        return await svc.GetPayload(peer.DomainName, driveId, fileId, payloadKey, chunk.Start, chunk.Length);
+    }
+
+    public async Task<ApiResponse<HttpContent>> GetThumbnailAsync(OdinId peer, Guid driveId, Guid fileId, string payloadKey,
+        int width, int height, FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetThumbnail(peer.DomainName, driveId, fileId, payloadKey, width, height);
     }
 }

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DrivePeerWriterV2Client.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DrivePeerWriterV2Client.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Odin.Core;
+using Odin.Core.Identity;
+using Odin.Core.Serialization;
+using Odin.Core.Storage;
+using Odin.Hosting.Controllers.Base.Transit;
+using Odin.Hosting.Tests.OwnerApi.ApiClient.Drive;
+using Odin.Hosting.Tests._Universal.ApiClient.Factory;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Storage;
+using Odin.Services.Drives.FileSystem.Base.Upload;
+using Odin.Services.Peer.Encryption;
+using Odin.Services.Peer.Outgoing.Drive;
+using Odin.Services.Peer.Outgoing.Drive.Transfer;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+/// <summary>
+/// V2 client for the "write over peer" endpoint (<c>POST /api/v2/peer/{odinId}/drives/{driveId}/files/send</c>).
+/// Builds the same multipart bundle V1 transit send uses (TransitInstructionSet + metadata descriptor +
+/// payloads); the file lands on the remote owner's drive with no local copy.
+/// </summary>
+public class DrivePeerWriterV2Client(OdinId identity, IApiClientFactory factory, FileSystemType fileSystemType = FileSystemType.Standard)
+{
+    public async Task<ApiResponse<TransitResult>> SendUnencryptedFileOverPeer(
+        OdinId recipient,
+        TargetDrive remoteTargetDrive,
+        UploadFileMetadata fileMetadata,
+        List<TestPayloadDefinition> payloads = null,
+        UploadManifest manifest = null,
+        Guid? overwriteGlobalTransitFileId = null)
+    {
+        payloads ??= new List<TestPayloadDefinition>();
+        var transferIv = ByteArrayUtil.GetRndByteArray(16);
+        var keyHeader = KeyHeader.NewRandom16();
+
+        var instructionSet = new TransitInstructionSet
+        {
+            TransferIv = transferIv,
+            Recipients = new List<string> { recipient },
+            RemoteTargetDrive = remoteTargetDrive,
+            OverwriteGlobalTransitFileId = overwriteGlobalTransitFileId,
+            Manifest = manifest
+        };
+
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+
+        var instructionStream = new MemoryStream(OdinSystemSerializer.Serialize(instructionSet).ToUtf8ByteArray());
+
+        var descriptor = new UploadFileDescriptor
+        {
+            EncryptedKeyHeader = EncryptedKeyHeader.EncryptKeyHeaderAes(keyHeader, transferIv, ref sharedSecret),
+            FileMetadata = fileMetadata
+        };
+
+        var fileDescriptorCipher = TestUtils.JsonEncryptAes(descriptor, transferIv, ref sharedSecret);
+
+        List<StreamPart> parts =
+        [
+            new StreamPart(instructionStream, "instructionSet.encrypted", "application/json",
+                Enum.GetName(MultipartUploadParts.Instructions)),
+
+            new StreamPart(fileDescriptorCipher, "fileDescriptor.encrypted", "application/json",
+                Enum.GetName(MultipartUploadParts.Metadata))
+        ];
+
+        foreach (var payloadDefinition in payloads)
+        {
+            parts.Add(new StreamPart(new MemoryStream(payloadDefinition.Content), payloadDefinition.Key,
+                payloadDefinition.ContentType, Enum.GetName(MultipartUploadParts.Payload)));
+
+            foreach (var thumbnail in payloadDefinition.Thumbnails ?? new List<ThumbnailContent>())
+            {
+                var thumbnailKey = $"{payloadDefinition.Key}{thumbnail.PixelWidth}{thumbnail.PixelHeight}";
+                parts.Add(new StreamPart(new MemoryStream(thumbnail.Content), thumbnailKey, thumbnail.ContentType,
+                    Enum.GetName(MultipartUploadParts.Thumbnail)));
+            }
+        }
+
+        var svc = RestService.For<IDrivePeerWriteHttpClientApiV2>(client);
+        var response = await svc.SendFile(recipient.DomainName, remoteTargetDrive.Alias, parts.ToArray());
+
+        keyHeader.AesKey.Wipe();
+        return response;
+    }
+
+    public async Task<ApiResponse<TransitResult>> SendEncryptedFileOverPeer(
+        OdinId recipient,
+        TargetDrive remoteTargetDrive,
+        UploadFileMetadata fileMetadata,
+        KeyHeader keyHeader,
+        List<TestPayloadDefinition> payloads = null,
+        UploadManifest manifest = null,
+        Guid? overwriteGlobalTransitFileId = null)
+    {
+        payloads ??= new List<TestPayloadDefinition>();
+        var transferIv = ByteArrayUtil.GetRndByteArray(16);
+
+        var instructionSet = new TransitInstructionSet
+        {
+            TransferIv = transferIv,
+            Recipients = new List<string> { recipient },
+            RemoteTargetDrive = remoteTargetDrive,
+            OverwriteGlobalTransitFileId = overwriteGlobalTransitFileId,
+            Manifest = manifest
+        };
+
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+
+        var instructionStream = new MemoryStream(OdinSystemSerializer.Serialize(instructionSet).ToUtf8ByteArray());
+
+        // Encrypt the metadata content with the file key header.
+        var encryptedContent64 = keyHeader.EncryptDataAes(fileMetadata.AppData.Content.ToUtf8ByteArray()).ToBase64();
+        fileMetadata.AppData.Content = encryptedContent64;
+        fileMetadata.IsEncrypted = true;
+
+        var descriptor = new UploadFileDescriptor
+        {
+            EncryptedKeyHeader = EncryptedKeyHeader.EncryptKeyHeaderAes(keyHeader, transferIv, ref sharedSecret),
+            FileMetadata = fileMetadata
+        };
+
+        var fileDescriptorCipher = TestUtils.JsonEncryptAes(descriptor, transferIv, ref sharedSecret);
+
+        List<StreamPart> parts =
+        [
+            new StreamPart(instructionStream, "instructionSet.encrypted", "application/json",
+                Enum.GetName(MultipartUploadParts.Instructions)),
+
+            new StreamPart(fileDescriptorCipher, "fileDescriptor.encrypted", "application/json",
+                Enum.GetName(MultipartUploadParts.Metadata))
+        ];
+
+        foreach (var payload in payloads)
+        {
+            var payloadKeyHeader = new KeyHeader
+            {
+                Iv = payload.Iv,
+                AesKey = new SensitiveByteArray(keyHeader.AesKey.GetKey())
+            };
+
+            var payloadCipher = payloadKeyHeader.EncryptDataAesAsStream(payload.Content);
+            parts.Add(new StreamPart(payloadCipher, payload.Key, payload.ContentType,
+                Enum.GetName(MultipartUploadParts.Payload)));
+
+            foreach (var thumb in payload.Thumbnails ?? new List<ThumbnailContent>())
+            {
+                var thumbCipher = payloadKeyHeader.EncryptDataAesAsStream(thumb.Content);
+                var thumbKey = $"{payload.Key}{thumb.PixelWidth}{thumb.PixelHeight}";
+                parts.Add(new StreamPart(thumbCipher, thumbKey, thumb.ContentType,
+                    Enum.GetName(MultipartUploadParts.Thumbnail)));
+            }
+        }
+
+        var svc = RestService.For<IDrivePeerWriteHttpClientApiV2>(client);
+        var response = await svc.SendFile(recipient.DomainName, remoteTargetDrive.Alias, parts.ToArray());
+
+        keyHeader.AesKey.Wipe();
+        return response;
+    }
+
+    public async Task<ApiResponse<Dictionary<string, DeleteLinkedFileStatus>>> SendDeleteRequestOverPeer(
+        OdinId recipient, TargetDrive remoteTargetDrive, Guid globalTransitId)
+    {
+        var client = factory.CreateHttpClient(identity, out _, fileSystemType);
+
+        var request = new DeleteFileByGlobalTransitIdRequest
+        {
+            FileSystemType = fileSystemType,
+            GlobalTransitIdFileIdentifier = new GlobalTransitIdFileIdentifier
+            {
+                GlobalTransitId = globalTransitId,
+                TargetDrive = remoteTargetDrive
+            },
+            Recipients = new List<string> { recipient }
+        };
+
+        var svc = RestService.For<IDrivePeerWriteHttpClientApiV2>(client);
+        return await svc.SendDeleteRequest(recipient.DomainName, remoteTargetDrive.Alias, request);
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerNotificationHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerNotificationHttpClientApiV2.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Odin.Hosting.UnifiedV2;
+using Odin.Services.Peer.AppNotification;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+public interface IDrivePeerNotificationHttpClientApiV2
+{
+    [Post(UnifiedApiRouteConstants.PeerNotifyRoot + "/token")]
+    Task<ApiResponse<AppNotificationTokenResponse>> GetToken([Body] GetRemoteTokenRequest request);
+
+    [Post(UnifiedApiRouteConstants.PeerNotifyRoot + "/subscriptions/push-notification")]
+    Task<ApiResponse<HttpContent>> Subscribe([Body] PeerNotificationSubscription request);
+
+    [Delete(UnifiedApiRouteConstants.PeerNotifyRoot + "/subscriptions/push-notification")]
+    Task<ApiResponse<HttpContent>> Unsubscribe([Body] PeerNotificationSubscription request);
+
+    [Get(UnifiedApiRouteConstants.PeerNotifyRoot + "/subscriptions/push-notification")]
+    Task<ApiResponse<List<PeerNotificationSubscription>>> GetSubscriptions();
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerQueryHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerQueryHttpClientApiV2.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Odin.Hosting.UnifiedV2;
+using Odin.Services.Apps;
+using Odin.Services.Drives;
 using Odin.Services.Peer.Outgoing.Drive.Query;
 using Refit;
 
@@ -19,4 +22,41 @@ public interface IDrivePeerQueryHttpClientApiV2
         [AliasAs("odinId")] string odinId,
         [AliasAs("driveId:guid")] Guid driveId,
         [AliasAs("gtid:guid")] Guid gtid);
+
+    [Post(UnifiedApiRouteConstants.PeerByDriveId + "/query-batch")]
+    Task<ApiResponse<QueryBatchResponse>> QueryBatch(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [Body] QueryBatchRequest request);
+
+    [Get(UnifiedApiRouteConstants.PeerByFileId + "/header")]
+    Task<ApiResponse<SharedSecretEncryptedFileHeader>> GetFileHeader(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId);
+
+    [Get(UnifiedApiRouteConstants.PeerByFileId + "/payload/{payloadKey}")]
+    Task<ApiResponse<HttpContent>> GetPayload(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [AliasAs("payloadKey")] string payloadKey);
+
+    [Get(UnifiedApiRouteConstants.PeerByFileId + "/payload/{payloadKey}/{start:int}/{length:int}")]
+    Task<ApiResponse<HttpContent>> GetPayload(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [AliasAs("payloadKey")] string payloadKey,
+        [AliasAs("start:int")] int start,
+        [AliasAs("length:int")] int length);
+
+    [Get(UnifiedApiRouteConstants.PeerByFileId + "/payload/{payloadKey}/thumb/{width}/{height}")]
+    Task<ApiResponse<HttpContent>> GetThumbnail(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("fileId:guid")] Guid fileId,
+        [AliasAs("payloadKey")] string payloadKey,
+        [AliasAs("width")] int width,
+        [AliasAs("height")] int height);
 }

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerWriteHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerWriteHttpClientApiV2.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Odin.Hosting.Controllers.Base.Transit;
+using Odin.Hosting.UnifiedV2;
+using Odin.Services.Peer.Outgoing.Drive;
+using Odin.Services.Peer.Outgoing.Drive.Transfer;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+public interface IDrivePeerWriteHttpClientApiV2
+{
+    // Direct write-over-peer: posts a multipart TransitInstructionSet/metadata/payload bundle that
+    // the server stages on the transient temp drive and sends to the RemoteTargetDrive owner.
+    [Multipart]
+    [Post(UnifiedApiRouteConstants.PeerByDriveId + "/files/send")]
+    Task<ApiResponse<TransitResult>> SendFile(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        StreamPart[] streamdata);
+
+    // Delete-over-peer: asks the remote owner to delete a file by its global transit id.
+    [Post(UnifiedApiRouteConstants.PeerByDriveId + "/files/senddeleterequest")]
+    Task<ApiResponse<Dictionary<string, DeleteLinkedFileStatus>>> SendDeleteRequest(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [Body] DeleteFileByGlobalTransitIdRequest request);
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/PeerNotificationV2Client.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/PeerNotificationV2Client.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Odin.Core.Identity;
+using Odin.Hosting.Tests._Universal.ApiClient.Factory;
+using Odin.Services.Peer.AppNotification;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+/// <summary>
+/// V2 client for managing subscriptions to live notifications on drives hosted by other identities
+/// (<c>/api/v2/peer/notify/...</c>).
+/// </summary>
+public class PeerNotificationV2Client(OdinId identity, IApiClientFactory factory)
+{
+    public async Task<ApiResponse<AppNotificationTokenResponse>> GetTokenAsync(OdinId peer)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerNotificationHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetToken(new GetRemoteTokenRequest { Identity = peer });
+    }
+
+    public async Task<ApiResponse<HttpContent>> SubscribeAsync(OdinId peer, Guid subscriptionId)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerNotificationHttpClientApiV2>(client, sharedSecret);
+        return await svc.Subscribe(new PeerNotificationSubscription { Identity = peer, SubscriptionId = subscriptionId });
+    }
+
+    public async Task<ApiResponse<HttpContent>> UnsubscribeAsync(OdinId peer, Guid subscriptionId)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerNotificationHttpClientApiV2>(client, sharedSecret);
+        return await svc.Unsubscribe(new PeerNotificationSubscription { Identity = peer, SubscriptionId = subscriptionId });
+    }
+
+    public async Task<ApiResponse<List<PeerNotificationSubscription>>> GetSubscriptionsAsync()
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerNotificationHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetSubscriptions();
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/Peer/V2PeerAppNotificationWebSocketTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/Peer/V2PeerAppNotificationWebSocketTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Odin.Core.Serialization;
+using Odin.Hosting.Tests._Universal.ApiClient.App;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Hosting.Tests._Universal.Peer.PeerAppNotificationsWebSocket;
+using Odin.Hosting.UnifiedV2;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Authorization.Acl;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Authorization.Permissions;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Storage;
+using Odin.Services.Drives.FileSystem.Base.Upload;
+using Odin.Services.Peer.AppNotification;
+using Odin.Services.Peer.Outgoing.Drive;
+
+namespace Odin.Hosting.Tests._V2.Tests.Peer;
+
+/// <summary>
+/// Cap 4b of the chat-kmp V2 peer transport: a member receives live <c>fileAdded</c> notifications on
+/// a drive hosted by another identity over the V2 peer websocket
+/// (<c>/api/v2/peer/notify/ws-token</c>).
+///
+/// FLAGGED: this lives in the OLD WebScaffold framework (not the fast <c>Odin.Hosting.Tests.V2</c>),
+/// because WebSocket flows are an explicit non-goal of the fast framework — they need a real Kestrel
+/// host. The handshake/in-band-auth and assertions are ported from the battle-tested V1
+/// <c>_Universal/Peer/PeerAppNotificationsWebSocket/PeerAppNotificationTests</c>; only the websocket
+/// URL differs (V2 route instead of <c>/api/apps/v1/notify/peer/ws</c>).
+/// </summary>
+public class V2PeerAppNotificationWebSocketTests
+{
+    private WebScaffold _scaffold;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = MethodBase.GetCurrentMethod()!.DeclaringType!.Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: new List<TestIdentity> { TestIdentities.Frodo, TestIdentities.Samwise });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _scaffold.RunAfterAnyTests();
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [Test]
+    public async Task MemberReceivesFileAddedOverV2PeerWebSocket()
+    {
+        var targetDrive = TargetDrive.NewTargetDrive(SystemDriveConstants.ChannelDriveType);
+        var host = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Samwise);
+        var member = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+
+        var memberAppApi = await PrepareScenario(host, member, targetDrive);
+
+        // Member's app requests a token to listen to the host's peer notifications.
+        var tokenResponse = await memberAppApi.PeerAppNotification.GetRemoteNotificationToken(
+            new GetRemoteTokenRequest { Identity = host.Identity.OdinId });
+        ClassicAssert.IsTrue(tokenResponse.IsSuccessStatusCode, "failed to get remote notification token");
+        var token = tokenResponse.Content!.ToCat();
+
+        var listener = new PeerTestAppWebSocketListener();
+        var receivedGtid = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
+        listener.NotificationReceived += n =>
+        {
+            if (n.NotificationType == ClientNotificationType.FileAdded)
+            {
+                var driveNotification = OdinSystemSerializer.Deserialize<ClientDriveNotification>(n.Data);
+                receivedGtid.TrySetResult(driveNotification.Header.FileMetadata.GlobalTransitId.GetValueOrDefault());
+            }
+
+            return Task.CompletedTask;
+        };
+
+        // Connect to the V2 peer websocket and subscribe to the community drive.
+        await listener.ConnectAsync(host.Identity.OdinId, token,
+            new EstablishConnectionOptions { Drives = [targetDrive] },
+            UnifiedApiRouteConstants.PeerNotifySocket);
+
+        // Member posts a message to the host's drive over peer; the host's dispatcher should push
+        // a fileAdded event back over the websocket.
+        var sent = await SendChatMessage("hi over v2 peer ws", member, host, targetDrive);
+        var sentGtid = sent.RemoteGlobalTransitIdFileIdentifier.GlobalTransitId;
+
+        var winner = await Task.WhenAny(receivedGtid.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+
+        await listener.DisconnectAsync();
+        await Shutdown(host, member);
+
+        ClassicAssert.IsTrue(winner == receivedGtid.Task, "did not receive a fileAdded notification over the V2 peer websocket");
+        ClassicAssert.AreEqual(sentGtid, receivedGtid.Task.Result, "received notification was for a different file");
+    }
+
+    private async Task<AppApiClientRedux> PrepareScenario(OwnerApiClientRedux host, OwnerApiClientRedux member,
+        TargetDrive groupChannelDrive)
+    {
+        Dictionary<string, string> isCollaborativeChannel =
+            new() { { BuiltInDriveAttributes.IsCollaborativeChannel, bool.TrueString } };
+
+        await host.DriveManager.CreateDrive(groupChannelDrive, "A Group Channel Drive", "",
+            allowAnonymousReads: false, ownerOnly: false, allowSubscriptions: false, attributes: isCollaborativeChannel);
+
+        var memberCircleId = Guid.NewGuid();
+        await host.Network.CreateCircle(memberCircleId, "group members", new PermissionSetGrantRequest
+        {
+            Drives = new List<DriveGrantRequest>
+            {
+                new()
+                {
+                    PermissionedDrive = new() { Drive = groupChannelDrive, Permission = DrivePermission.ReadWrite }
+                }
+            },
+            PermissionSet = default
+        });
+
+        await host.Connections.SendConnectionRequest(member.Identity.OdinId, [memberCircleId]);
+        await member.Connections.AcceptConnectionRequest(host.Identity.OdinId);
+
+        var communityAppId = Guid.NewGuid();
+        var permissions = new PermissionSetGrantRequest
+        {
+            Drives = [],
+            PermissionSet = new PermissionSet(PermissionKeys.UseTransitWrite, PermissionKeys.UseTransitRead)
+        };
+
+        var memberAppClientAccessToken = await member.AppManager.RegisterAppAndClient(communityAppId, permissions);
+        return _scaffold.CreateAppApiClientRedux(member.Identity.OdinId, memberAppClientAccessToken);
+    }
+
+    private static async Task<TransitResult> SendChatMessage(string message, OwnerApiClientRedux sender,
+        OwnerApiClientRedux recipient, TargetDrive targetDrive)
+    {
+        var fileMetadata = new UploadFileMetadata
+        {
+            AllowDistribution = true,
+            IsEncrypted = true,
+            AppData = new() { Content = message },
+            AccessControlList = AccessControlList.Connected
+        };
+
+        var response = await sender.PeerDirect.TransferMetadata(targetDrive, fileMetadata,
+            [recipient.Identity.OdinId], null);
+        return response.Content;
+    }
+
+    private async Task Shutdown(OwnerApiClientRedux host, OwnerApiClientRedux member)
+    {
+        await _scaffold.OldOwnerApi.DisconnectIdentities(host.Identity.OdinId, member.Identity.OdinId);
+    }
+}


### PR DESCRIPTION
@
## What

Ports the four peer ("over peer" / transit) capabilities to the **V2 unified API** (`/api/v2/`), mirroring the existing, battle-tested **V1** transit endpoints. These are the backend endpoints the **chat-kmp** client needs to sync/query/write/subscribe to a collaborative drive hosted on **another identity** (the future "Community" feature, per `COMMUNITY_PART1_TRANSPORT.md`). The client targets V2, where these were missing.

The service layer was already complete and DI-registered — this is overwhelmingly thin controllers wiring existing routes to existing services. **No new service code, no DI, no migrations.**

## Capabilities added

| # | Capability | New V2 route | V1 mirrored |
|---|---|---|---|
| 1 | Query-batch over peer | `POST /api/v2/peer/{odinId}/drives/{driveId}/query-batch` | `/transit/query/batch` |
| 2 | Get header/payload/thumbnail over peer | `GET /api/v2/peer/{odinId}/drives/{driveId}/files/{fileId}/{header,payload,...}` | `/transit/query/{header,payload,thumb}` |
| 3 | Direct write-over-peer (no local copy) | `POST .../files/send` (+ `senddeleterequest`) | `/transit/sender/files/send` |
| 4 | Peer notification subscription (REST) + websocket | `/api/v2/peer/notify/{token,subscriptions,ws-token}` | `/notify/peer/{token,subscriptions,ws}` |

## Implementation notes

- **New controllers** under `UnifiedV2/Drive/{Read,Write}` and `UnifiedV2/Notifications`, all `[UnifiedV2Authorize(OwnerOrApp)]`, delegating to the existing `PeerDriveQueryService`, `PeerOutgoingTransferService`, and `PeerAppNotificationService`.
- **Write-over-peer** subclasses the V1 `PeerSenderControllerBase`, reusing the existing multipart + transient-temp-drive transfer path verbatim — the file lands only on the remote owner.
- **Peer WS** is a cookie-less endpoint (GET + HTTP/2 CONNECT) that authenticates in-band via `PeerAppNotificationHandler`, matching the V1 model.
- **Shared rendering helpers** (`HandlePeerPayloadResponse`/`HandlePeerThumbnailResponse`) were lifted from `PeerQueryControllerBase` into `OdinControllerBase` so V1 and V2 share them — no duplication.
- **Fail-soft**: remote failures propagate as the existing typed exceptions (offline → HTTP 400 with `OdinClientErrorCode`, remote-403 → 403), matching V1.
- One design note: peer read routes resolve the remote drive by alias (Type left empty), consistent with the existing peer `exists` endpoints.

## Tests

Comprehensive coverage in the fast in-process framework (`Odin.Hosting.Tests.V2/Ported/Peer/`), based on the V1 `_Universal/Peer` tests:

- **Query-batch & get-content**: found/empty/not-connected; header/payload/thumbnail; ranged payload.
- **Encrypted over peer** (read + write): verifies the security-critical shared-secret **re-encryption** path — member decrypts with its own shared secret; owner decrypts a written file with its own.
- **Auth matrix**: App caller with `UseTransitRead` allowed; Guest (YouAuth) rejected.
- **Write variations**: with-payload, unauthorized (Read-only) write rejected, no-local-copy.
- **Extras**: V2 token endpoint, delete-over-peer, file-system-type header routing.
- **Peer websocket** (`fileAdded` delivery): in the **WebScaffold** framework (flagged) — WebSockets are an explicit non-goal of the fast framework (need real Kestrel).

A few small additions to the `_V2/ApiClient` test wrappers back these (peer query/content/write/notification clients).

## Verification

- `dotnet build ./odin-core.sln` — clean.
- `dotnet test Odin.Hosting.Tests.V2 --filter "FullyQualifiedName~Ported.Peer"` — **38/38 pass**.
- WebScaffold peer-WS test + V1 regressions (`FileExistsTests`, `AppTransitQueryTestsForPublicFiles`) — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@