### PR TITLE
Grant Moments drive access to connection circles (v8 migration)

### DIFF
--- a/src/apps/Odin.Hosting/TenantServices.cs
+++ b/src/apps/Odin.Hosting/TenantServices.cs
@@ -71,6 +71,7 @@ using Odin.Core.Storage.PubSub;
 using Odin.Services.Authorization.Capi;
 using Odin.Services.Configuration.VersionUpgrade.Version5tov6;
 using Odin.Services.Configuration.VersionUpgrade.Version6tov7;
+using Odin.Services.Configuration.VersionUpgrade.Version7tov8;
 using Odin.Services.Security.Email;
 using Odin.Services.Security.Health;
 using Odin.Services.Security.PasswordRecovery.RecoveryPhrase;
@@ -339,7 +340,8 @@ public static class TenantServices
         cb.RegisterType<V4ToV5VersionMigrationService>().InstancePerLifetimeScope();
         cb.RegisterType<V5ToV6VersionMigrationService>().InstancePerLifetimeScope();
         cb.RegisterType<V6ToV7VersionMigrationService>().InstancePerLifetimeScope();
-        
+        cb.RegisterType<V7ToV8VersionMigrationService>().InstancePerLifetimeScope();
+
         cb.RegisterType<VersionUpgradeService>().InstancePerLifetimeScope();
         cb.RegisterType<VersionUpgradeScheduler>().InstancePerLifetimeScope();
 

--- a/src/services/Odin.Services/Configuration/VersionUpgrade/Version7tov8/V7ToV8VersionMigrationService.cs
+++ b/src/services/Odin.Services/Configuration/VersionUpgrade/Version7tov8/V7ToV8VersionMigrationService.cs
@@ -1,0 +1,135 @@
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Odin.Core.Exceptions;
+using Odin.Core.Storage.Database.Identity;
+using Odin.Services.Authorization.Apps;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+using Odin.Services.Drives.Management;
+using Odin.Services.Membership.Circles;
+using Odin.Services.Membership.Connections;
+
+namespace Odin.Services.Configuration.VersionUpgrade.Version7tov8
+{
+    /// <summary>
+    /// Service to handle converting data between releases
+    /// </summary>
+    public class V7ToV8VersionMigrationService(
+        ILogger<V7ToV8VersionMigrationService> logger,
+        TenantConfigService tenantConfigService,
+        CircleNetworkService circleNetworkService,
+        AppRegistrationService appRegistrationService,
+        CircleDefinitionService circleDefinitionService,
+        IdentityDatabase db,
+        IDriveManager driveManager)
+    {
+        public async Task UpgradeAsync(IOdinContext odinContext, CancellationToken cancellationToken)
+        {
+            odinContext.Caller.AssertHasMasterKey();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            logger.LogDebug("Ensuring system drives exist on identity: [{identity}]", odinContext.Tenant);
+            await tenantConfigService.EnsureSystemDrivesExist(odinContext);
+
+            //
+            // Update the confirmed-connections circle definition so it grants Write + React on the Moments drive
+            //
+            logger.LogDebug("Updating system circle definitions");
+            await circleDefinitionService.EnsureSystemCirclesExistAsync();
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await EnsureMomentsDriveIsConfiguredForConnectionCircles(odinContext, cancellationToken);
+        }
+
+        public async Task ValidateUpgradeAsync(IOdinContext odinContext, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var momentsDrive = await driveManager.GetDriveAsync(SystemDriveConstants.MomentsDrive.Alias, false);
+            if (momentsDrive == null)
+            {
+                throw new OdinSystemException("Moments drive not created");
+            }
+
+            // Get all ICRs and ensure the confirmed/auto connection circles have Write + React access to my Moments drive
+            var allIdentities = await circleNetworkService.GetConnectedIdentitiesAsync(int.MaxValue, null, odinContext);
+
+            foreach (var identity in allIdentities.Results)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var circleId in SystemCircleConstants.AllSystemCircles)
+                {
+                    // Only validate the identities who are members of this system circle
+                    if (!identity.AccessGrant.CircleGrants.TryGetValue(circleId, out var circleGrant))
+                    {
+                        continue;
+                    }
+
+                    var driveGrant = circleGrant.KeyStoreKeyEncryptedDriveGrants
+                        .SingleOrDefault(g => g.PermissionedDrive.Drive == SystemDriveConstants.MomentsDrive);
+
+                    if (driveGrant == null)
+                    {
+                        throw new OdinSystemException("Drive grant for MomentsDrive not found");
+                    }
+
+                    var hasWrite = driveGrant.PermissionedDrive.Permission.HasFlag(DrivePermission.Write);
+                    if (!hasWrite)
+                    {
+                        throw new OdinSystemException("MomentsDrive not granted write permission");
+                    }
+
+                    var hasReact = driveGrant.PermissionedDrive.Permission.HasFlag(DrivePermission.React);
+                    if (!hasReact)
+                    {
+                        throw new OdinSystemException("MomentsDrive not granted react permission");
+                    }
+                }
+            }
+        }
+
+        private async Task EnsureMomentsDriveIsConfiguredForConnectionCircles(IOdinContext odinContext,
+            CancellationToken cancellationToken)
+        {
+            odinContext.Caller.AssertHasMasterKey();
+            var allIdentities = await circleNetworkService.GetConnectedIdentitiesAsync(int.MaxValue, null, odinContext);
+
+            await using var tx = await db.BeginStackedTransactionAsync(IsolationLevel.Unspecified, cancellationToken);
+
+            foreach (var identity in allIdentities.Results)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Re-grant whichever system circles this identity is a member of so the new
+                // Moments drive grant is issued to confirmed and auto-connected identities alike
+                foreach (var circleId in SystemCircleConstants.AllSystemCircles)
+                {
+                    if (!identity.AccessGrant.CircleGrants.ContainsKey(circleId))
+                    {
+                        continue;
+                    }
+
+                    logger.LogDebug("Reconciling system circle {circleId} on Identity {odinId}", circleId, identity.OdinId);
+
+                    await circleNetworkService.RevokeCircleAccessAsync(circleId, identity.OdinId, odinContext);
+                    await circleNetworkService.GrantCircleAsync(circleId, identity.OdinId, odinContext);
+                }
+            }
+
+            var allApps = await appRegistrationService.GetRegisteredAppsAsync(odinContext);
+            foreach (var app in allApps)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                logger.LogDebug("Calling ReconcileAuthorizedCircles for app {appName}", app.Name);
+                await circleNetworkService.ReconcileAuthorizedCircles(oldAppRegistration: null, app, odinContext);
+            }
+
+            tx.Commit();
+        }
+    }
+}

--- a/src/services/Odin.Services/Configuration/VersionUpgrade/VersionUpgradeService.cs
+++ b/src/services/Odin.Services/Configuration/VersionUpgrade/VersionUpgradeService.cs
@@ -14,6 +14,7 @@ using Odin.Services.Configuration.VersionUpgrade.Version3tov4;
 using Odin.Services.Configuration.VersionUpgrade.Version4tov5;
 using Odin.Services.Configuration.VersionUpgrade.Version5tov6;
 using Odin.Services.Configuration.VersionUpgrade.Version6tov7;
+using Odin.Services.Configuration.VersionUpgrade.Version7tov8;
 
 namespace Odin.Services.Configuration.VersionUpgrade;
 
@@ -27,6 +28,7 @@ public class VersionUpgradeService(
     V4ToV5VersionMigrationService v5,
     V5ToV6VersionMigrationService v6,
     V6ToV7VersionMigrationService v7,
+    V7ToV8VersionMigrationService v8,
     IdentityDatabase db,
     OwnerAuthenticationService authService,
     ILogger<VersionUpgradeService> logger)
@@ -204,6 +206,29 @@ public class VersionUpgradeService(
                 await v7.UpgradeAsync(odinContext, cancellationToken);
 
                 await v7.ValidateUpgradeAsync(odinContext, cancellationToken);
+
+                currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
+
+                tx.Commit();
+                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+            }
+
+            // do this after each version upgrade
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (currentVersion == 7)
+            {
+                await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
+
+                _isRunning = true;
+                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+
+                await v8.UpgradeAsync(odinContext, cancellationToken);
+
+                await v8.ValidateUpgradeAsync(odinContext, cancellationToken);
 
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 

--- a/src/services/Odin.Services/Membership/Circles/CircleConstants.cs
+++ b/src/services/Odin.Services/Membership/Circles/CircleConstants.cs
@@ -101,6 +101,15 @@ public static class SystemCircleConstants
             {
                 PermissionedDrive = new PermissionedDrive()
                 {
+                    Drive = SystemDriveConstants.MomentsDrive,
+                    Permission = DrivePermission.Write | DrivePermission.React
+                }
+            },
+
+            new DriveGrantRequest()
+            {
+                PermissionedDrive = new PermissionedDrive()
+                {
                     Drive = SystemDriveConstants.MailDrive,
                     Permission = DrivePermission.Write | DrivePermission.React
                 }

--- a/src/services/Odin.Services/Version.cs
+++ b/src/services/Odin.Services/Version.cs
@@ -11,7 +11,7 @@ public static class Version
     /// <summary>
     /// Indicates version information the current release (data structure version, code version, etc.)
     /// </summary>
-    public const int DataVersionNumber = 7;
+    public const int DataVersionNumber = 8;
 }
 
 // DO NOT CHANGE OR MOVE THIS FILE

--- a/tests/apps/Odin.Hosting.Tests/OwnerApi/Configuration/SystemInit/SystemInitializeConfigTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/OwnerApi/Configuration/SystemInit/SystemInitializeConfigTests.cs
@@ -199,10 +199,10 @@ namespace Odin.Hosting.Tests.OwnerApi.Configuration.SystemInit
                 dg => dg.PermissionedDrive.Drive == SystemDriveConstants.ChatDrive &&
                       dg.PermissionedDrive.Permission.HasFlag(DrivePermission.Write | DrivePermission.React)));
 
-            ClassicAssert.IsNull(autoConnectionsSystemCircle.DriveGrants.SingleOrDefault(
+            ClassicAssert.IsNotNull(autoConnectionsSystemCircle.DriveGrants.SingleOrDefault(
                 dg => dg.PermissionedDrive.Drive == SystemDriveConstants.MomentsDrive &&
                       dg.PermissionedDrive.Permission.HasFlag(DrivePermission.Write | DrivePermission.React)),
-                "auto connections do not get access to moments");
+                "auto connections get write + react access to moments");
 
             ClassicAssert.IsTrue(!autoConnectionsSystemCircle.Permissions.Keys.Exists(k => k == PermissionKeys.AllowIntroductions));
 


### PR DESCRIPTION
## Summary
Adds the next data version (**v8**) so existing identities pick up `Write | React` access to the **Moments drive** on both the **Confirmed Connections** and **Auto-connected** system circles.

The Moments drive itself is created in the v7 migration and the Confirmed Connections circle definition already declares the Moments grant (added in #1507), but already-issued circle grants on existing connections don't include it. This migration pushes the grant out, mirroring the V5ToV6 pattern used for the Shard Recovery drive.

## Changes
- Add `MomentsDrive` (`Write | React`) grant to `AutoConnectionsSystemCircleDefinition` (Confirmed Connections already had it)
- New `V7ToV8VersionMigrationService`:
  - Ensures system drives + circles exist (`EnsureSystemDrivesExist`, `EnsureSystemCirclesExistAsync` — the latter updates the stored circle definitions)
  - Re-grants whichever system circles each connected identity is a member of, so confirmed and auto-connected identities both receive the new Moments grant
  - Reconciles app authorized circles
  - Validates that every member of each system circle has `Write` + `React` on the Moments drive
- Wire the migration into `VersionUpgradeService` (`currentVersion == 7` block)
- Register the service in `TenantServices`
- Bump `Version.DataVersionNumber` 7 → 8

## Testing
- `Odin.Services` and `Odin.Hosting` build clean (0 warnings, 0 errors)
- Existing `VersionUpgradeTests` is unaffected — its forced-failure (TestMode) fires right after the v4 block, so the expected landing version of 4 is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)