### PR TITLE
perf(notifications): bulk UpdateNotifications & Delete to avoid lock contention

### DIFF
--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotifications.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotifications.cs
@@ -10,8 +10,8 @@ using Odin.Core.Storage.Database.Identity.Connection;
 namespace Odin.Core.Storage.Database.Identity.Table;
 
 // CS9107: scopedConnectionFactory is intentionally captured (for the bulk
-// UpdateUnreadAsync below) as well as passed to the base ctor. The base keeps it
-// private, so the subclass needs its own reference to the same instance.
+// UpdateUnreadAsync/DeleteListAsync below) as well as passed to the base ctor.
+// The base keeps it private, so the subclass needs its own reference to it.
 #pragma warning disable CS9107
 public class TableAppNotifications(
     ScopedIdentityConnectionFactory scopedConnectionFactory,
@@ -39,7 +39,7 @@ public class TableAppNotifications(
     // Safe batch size for an IN (...) parameter list. SQLite's default
     // SQLITE_MAX_VARIABLE_NUMBER is 999; Postgres allows far more. 500 leaves
     // headroom for the other bound parameters while keeping round-trips low.
-    private const int UpdateUnreadBatchSize = 500;
+    private const int BulkBatchSize = 500;
 
     /// <summary>
     /// Sets the <c>unread</c> flag for a set of notifications in a single set-based
@@ -54,9 +54,9 @@ public class TableAppNotifications(
         var distinctIds = notificationIds.Distinct().ToList();
 
         var totalAffected = 0;
-        for (var offset = 0; offset < distinctIds.Count; offset += UpdateUnreadBatchSize)
+        for (var offset = 0; offset < distinctIds.Count; offset += BulkBatchSize)
         {
-            var batch = distinctIds.GetRange(offset, Math.Min(UpdateUnreadBatchSize, distinctIds.Count - offset));
+            var batch = distinctIds.GetRange(offset, Math.Min(BulkBatchSize, distinctIds.Count - offset));
 
             await using var cn = await scopedConnectionFactory.CreateScopedConnectionAsync();
             await using var cmd = cn.CreateCommand();
@@ -95,6 +95,45 @@ public class TableAppNotifications(
     internal async Task<int> DeleteAsync(Guid notificationId)
     {
         return await base.DeleteAsync(odinIdentity, notificationId);
+    }
+
+    /// <summary>
+    /// Deletes a set of notifications in a single set-based DELETE per batch,
+    /// rather than one round-trip per row.
+    /// </summary>
+    internal async Task<int> DeleteListAsync(List<Guid> notificationIds)
+    {
+        if (notificationIds == null || notificationIds.Count == 0)
+            return 0;
+
+        var distinctIds = notificationIds.Distinct().ToList();
+
+        var totalAffected = 0;
+        for (var offset = 0; offset < distinctIds.Count; offset += BulkBatchSize)
+        {
+            var batch = distinctIds.GetRange(offset, Math.Min(BulkBatchSize, distinctIds.Count - offset));
+
+            await using var cn = await scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+
+            var inParams = new List<string>(batch.Count);
+            for (var i = 0; i < batch.Count; i++)
+            {
+                var name = "@n" + i;
+                inParams.Add(name);
+                cmd.AddParameter(name, DbType.Binary, batch[i]);
+            }
+
+            cmd.CommandText =
+                "DELETE FROM AppNotifications " +
+                $"WHERE identityId = @identityId AND notificationId IN ({string.Join(",", inParams)})";
+
+            cmd.AddParameter("@identityId", DbType.Binary, odinIdentity.IdentityId);
+
+            totalAffected += await cmd.ExecuteNonQueryAsync();
+        }
+
+        return totalAffected;
     }
 
     public async Task<(List<AppNotificationsRecord>, Int64? nextCursor)> PagingByRowIdAsync(int count, Int64? inCursor)

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotifications.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotifications.cs
@@ -1,16 +1,24 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Linq;
 using System.Threading.Tasks;
 using Odin.Core.Identity;
+using Odin.Core.Storage;
 using Odin.Core.Storage.Database.Identity.Connection;
 
 namespace Odin.Core.Storage.Database.Identity.Table;
 
+// CS9107: scopedConnectionFactory is intentionally captured (for the bulk
+// UpdateUnreadAsync below) as well as passed to the base ctor. The base keeps it
+// private, so the subclass needs its own reference to the same instance.
+#pragma warning disable CS9107
 public class TableAppNotifications(
     ScopedIdentityConnectionFactory scopedConnectionFactory,
     OdinIdentity odinIdentity)
     : TableAppNotificationsCRUD(scopedConnectionFactory)
 {
+#pragma warning restore CS9107
     internal async Task<AppNotificationsRecord> GetAsync(Guid notificationId)
     {
         return await base.GetAsync(odinIdentity, notificationId);
@@ -26,6 +34,53 @@ public class TableAppNotifications(
     {
         item.identityId = odinIdentity;
         return await base.UpdateAsync(item);
+    }
+
+    // Safe batch size for an IN (...) parameter list. SQLite's default
+    // SQLITE_MAX_VARIABLE_NUMBER is 999; Postgres allows far more. 500 leaves
+    // headroom for the other bound parameters while keeping round-trips low.
+    private const int UpdateUnreadBatchSize = 500;
+
+    /// <summary>
+    /// Sets the <c>unread</c> flag for a set of notifications in a single set-based
+    /// UPDATE per batch, rather than one read-modify-write round-trip per row.
+    /// Only the <c>unread</c> and <c>modified</c> columns are touched.
+    /// </summary>
+    internal async Task<int> UpdateUnreadAsync(List<Guid> notificationIds, bool unread)
+    {
+        if (notificationIds == null || notificationIds.Count == 0)
+            return 0;
+
+        var distinctIds = notificationIds.Distinct().ToList();
+
+        var totalAffected = 0;
+        for (var offset = 0; offset < distinctIds.Count; offset += UpdateUnreadBatchSize)
+        {
+            var batch = distinctIds.GetRange(offset, Math.Min(UpdateUnreadBatchSize, distinctIds.Count - offset));
+
+            await using var cn = await scopedConnectionFactory.CreateScopedConnectionAsync();
+            await using var cmd = cn.CreateCommand();
+
+            var inParams = new List<string>(batch.Count);
+            for (var i = 0; i < batch.Count; i++)
+            {
+                var name = "@n" + i;
+                inParams.Add(name);
+                cmd.AddParameter(name, DbType.Binary, batch[i]);
+            }
+
+            cmd.CommandText =
+                "UPDATE AppNotifications " +
+                $"SET unread = @unread, modified = {cmd.SqlMax()}(AppNotifications.modified+1,{cmd.SqlNow()}) " +
+                $"WHERE identityId = @identityId AND notificationId IN ({string.Join(",", inParams)})";
+
+            cmd.AddParameter("@identityId", DbType.Binary, odinIdentity.IdentityId);
+            cmd.AddParameter("@unread", DbType.Int32, unread ? 1 : 0);
+
+            totalAffected += await cmd.ExecuteNonQueryAsync();
+        }
+
+        return totalAffected;
     }
 
     internal async Task<(List<AppNotificationsRecord>, string cursor)> PagingByCreatedAsync(int count, string cursorString)

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCached.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Odin.Core.Storage.Database.Identity.Table;
@@ -73,6 +74,26 @@ public class TableAppNotificationsCached(TableAppNotifications table, IIdentityT
         var result = await table.UpdateAsync(item);
 
         await InvalidateAsync(item);
+
+        return result;
+    }
+
+    //
+
+    public async Task<int> UpdateUnreadAsync(List<Guid> notificationIds, bool unread)
+    {
+        if (notificationIds == null || notificationIds.Count == 0)
+            return 0;
+
+        var result = await table.UpdateUnreadAsync(notificationIds, unread);
+
+        // Invalidate each affected record key plus the paging cache, in a single pass.
+        var actions = notificationIds
+            .Distinct()
+            .Select(id => Cache.CreateRemoveByKeyAction(GetCacheKey(id)))
+            .ToList();
+        actions.Add(Cache.CreateRemoveByTagsAction(PagingByCreateTags));
+        await Cache.InvalidateAsync(actions);
 
         return result;
     }

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableAppNotificationsCached.cs
@@ -130,4 +130,24 @@ public class TableAppNotificationsCached(TableAppNotifications table, IIdentityT
 
     //
 
+    public async Task<int> DeleteListAsync(List<Guid> notificationIds)
+    {
+        if (notificationIds == null || notificationIds.Count == 0)
+            return 0;
+
+        var result = await table.DeleteListAsync(notificationIds);
+
+        // Invalidate each deleted record key plus the paging cache, in a single pass.
+        var actions = notificationIds
+            .Distinct()
+            .Select(id => Cache.CreateRemoveByKeyAction(GetCacheKey(id)))
+            .ToList();
+        actions.Add(Cache.CreateRemoveByTagsAction(PagingByCreateTags));
+        await Cache.InvalidateAsync(actions);
+
+        return result;
+    }
+
+    //
+
 }

--- a/src/services/Odin.Services/AppNotifications/Data/NotificationDataService.cs
+++ b/src/services/Odin.Services/AppNotifications/Data/NotificationDataService.cs
@@ -134,16 +134,27 @@ public class NotificationListService(IdentityDatabase db, IMediator mediator)
     {
         odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.SendPushNotifications);
 
+        if (request.Updates == null || request.Updates.Count == 0)
+        {
+            return;
+        }
+
+        // Group by target state so the whole request collapses into at most two
+        // set-based UPDATEs, rather than a read-modify-write round-trip per row
+        // that holds the write lock for the duration of the loop.
+        var toUnread = request.Updates.Where(u => u.Unread).Select(u => u.Id).Distinct().ToList();
+        var toRead = request.Updates.Where(u => !u.Unread).Select(u => u.Id).Distinct().ToList();
+
         await using var trx = await db.BeginStackedTransactionAsync();
 
-        foreach (var update in request.Updates)
+        if (toRead.Count > 0)
         {
-            var record = await db.AppNotificationsCached.GetAsync(update.Id);
-            if (null != record)
-            {
-                record.unread = update.Unread ? 1 : 0;
-                await db.AppNotificationsCached.UpdateAsync(record);
-            }
+            await db.AppNotificationsCached.UpdateUnreadAsync(toRead, unread: false);
+        }
+
+        if (toUnread.Count > 0)
+        {
+            await db.AppNotificationsCached.UpdateUnreadAsync(toUnread, unread: true);
         }
 
         trx.Commit();
@@ -161,7 +172,7 @@ public class NotificationListService(IdentityDatabase db, IMediator mediator)
 
         var request = new UpdateNotificationListRequest()
         {
-            Updates = allByApp.Results.Select(n => new UpdateNotificationRequest()
+            Updates = allByApp.Results.Where(n => n.Unread).Select(n => new UpdateNotificationRequest()
             {
                 Id = n.Id,
                 Unread = false
@@ -184,7 +195,7 @@ public class NotificationListService(IdentityDatabase db, IMediator mediator)
 
         var request = new UpdateNotificationListRequest()
         {
-            Updates = allByAppAndType.Results.Select(n => new UpdateNotificationRequest()
+            Updates = allByAppAndType.Results.Where(n => n.Unread).Select(n => new UpdateNotificationRequest()
             {
                 Id = n.Id,
                 Unread = false

--- a/src/services/Odin.Services/AppNotifications/Data/NotificationDataService.cs
+++ b/src/services/Odin.Services/AppNotifications/Data/NotificationDataService.cs
@@ -120,13 +120,15 @@ public class NotificationListService(IdentityDatabase db, IMediator mediator)
     {
         odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.SendPushNotifications);
 
-        await using var trx = await db.BeginStackedTransactionAsync();
-
-        foreach (var id in request.IdList)
+        if (request.IdList == null || request.IdList.Count == 0)
         {
-            await db.AppNotificationsCached.DeleteAsync(id);
+            return;
         }
 
+        // Single set-based DELETE rather than a round-trip per id holding the
+        // write lock for the duration of the loop.
+        await using var trx = await db.BeginStackedTransactionAsync();
+        await db.AppNotificationsCached.DeleteListAsync(request.IdList);
         trx.Commit();
     }
 

--- a/tests/apps/Odin.Hosting.Tests/_Universal/NotificationTests/Lists/NotificationListTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/NotificationTests/Lists/NotificationListTests.cs
@@ -406,4 +406,116 @@ public class NotificationListTests
             ClassicAssert.IsTrue(results.All(n => n.Id != notificationId));
         }
     }
+
+    // Exercises a single Update request that both marks some notifications read and
+    // flips another back to unread -- i.e. the two set-based UPDATE branches
+    // (toRead / toUnread) and the multi-item IN (...) path.
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public async Task CanUpdateMultipleNotificationsWithMixedReadStates(IApiClientContext callerContext, HttpStatusCode expectedStatusCode)
+    {
+        // Setup
+        var identity = TestIdentities.Samwise;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        await ownerApiClient.DriveManager.CreateDrive(callerContext.TargetDrive, "Test Drive", "", true);
+
+        var appId = Guid.NewGuid();
+        AppNotificationOptions NewOptions() => new() { AppId = appId, TypeId = Guid.NewGuid(), TagId = Guid.NewGuid() };
+
+        var r1 = await ownerApiClient.AppNotifications.AddNotification(NewOptions());
+        var r2 = await ownerApiClient.AppNotifications.AddNotification(NewOptions());
+        var r3 = await ownerApiClient.AppNotifications.AddNotification(NewOptions());
+        ClassicAssert.IsTrue(r1.IsSuccessStatusCode && r2.IsSuccessStatusCode && r3.IsSuccessStatusCode);
+        var id1 = r1.Content.NotificationId;
+        var id2 = r2.Content.NotificationId;
+        var id3 = r3.Content.NotificationId;
+
+        // Act
+        await callerContext.Initialize(ownerApiClient);
+        var client = new AppNotificationsApiClient(identity.OdinId, callerContext.GetFactory());
+
+        // Phase 1: mark all three read in one multi-item request (toRead branch, IN-list > 1)
+        var markAllRead = new List<UpdateNotificationRequest>
+        {
+            new() { Id = id1, Unread = false },
+            new() { Id = id2, Unread = false },
+            new() { Id = id3, Unread = false },
+        };
+        var response = await client.Update(markAllRead);
+
+        // Assert
+        ClassicAssert.IsTrue(response.StatusCode == expectedStatusCode, $"Expected {expectedStatusCode} but actual was {response.StatusCode}");
+
+        if (expectedStatusCode != HttpStatusCode.OK)
+        {
+            return;
+        }
+
+        var afterPhase1 = (await ownerApiClient.AppNotifications.GetList(1000)).Content.Results;
+        ClassicAssert.IsFalse(afterPhase1.Single(n => n.Id == id1).Unread);
+        ClassicAssert.IsFalse(afterPhase1.Single(n => n.Id == id2).Unread);
+        ClassicAssert.IsFalse(afterPhase1.Single(n => n.Id == id3).Unread);
+
+        // Phase 2: one mixed request -- flip id1 back to unread (toUnread branch) and
+        // keep id2 read (toRead branch); id3 is not in the request and must be untouched.
+        var mixed = new List<UpdateNotificationRequest>
+        {
+            new() { Id = id1, Unread = true },
+            new() { Id = id2, Unread = false },
+        };
+        var mixedResponse = await client.Update(mixed);
+        ClassicAssert.IsTrue(mixedResponse.IsSuccessStatusCode);
+
+        var afterPhase2 = (await ownerApiClient.AppNotifications.GetList(1000)).Content.Results;
+        ClassicAssert.IsTrue(afterPhase2.Single(n => n.Id == id1).Unread, "id1 should have been flipped back to unread");
+        ClassicAssert.IsFalse(afterPhase2.Single(n => n.Id == id2).Unread, "id2 should remain read");
+        ClassicAssert.IsFalse(afterPhase2.Single(n => n.Id == id3).Unread, "id3 should be untouched");
+
+        // Cleanup
+        await ownerApiClient.AppNotifications.Delete([id1, id2, id3]);
+    }
+
+    // Exercises the bulk DELETE ... IN (...) path with more than one id in a single request.
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public async Task CanRemoveMultipleNotifications(IApiClientContext callerContext, HttpStatusCode expectedStatusCode)
+    {
+        // Setup
+        var identity = TestIdentities.Samwise;
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        await ownerApiClient.DriveManager.CreateDrive(callerContext.TargetDrive, "Test Drive", "", true);
+
+        var appId = Guid.NewGuid();
+        AppNotificationOptions NewOptions() => new() { AppId = appId, TypeId = Guid.NewGuid(), TagId = Guid.NewGuid() };
+
+        var r1 = await ownerApiClient.AppNotifications.AddNotification(NewOptions());
+        var r2 = await ownerApiClient.AppNotifications.AddNotification(NewOptions());
+        var r3 = await ownerApiClient.AppNotifications.AddNotification(NewOptions());
+        ClassicAssert.IsTrue(r1.IsSuccessStatusCode && r2.IsSuccessStatusCode && r3.IsSuccessStatusCode);
+        var id1 = r1.Content.NotificationId;
+        var id2 = r2.Content.NotificationId;
+        var id3 = r3.Content.NotificationId;
+
+        // Act
+        await callerContext.Initialize(ownerApiClient);
+        var client = new AppNotificationsApiClient(identity.OdinId, callerContext.GetFactory());
+
+        // Delete id1 and id2 in one multi-item request; id3 stays.
+        var response = await client.Delete([id1, id2]);
+
+        // Assert
+        ClassicAssert.IsTrue(response.StatusCode == expectedStatusCode, $"Expected {expectedStatusCode} but actual was {response.StatusCode}");
+
+        if (expectedStatusCode == HttpStatusCode.OK)
+        {
+            var results = (await ownerApiClient.AppNotifications.GetList(10000)).Content.Results;
+            ClassicAssert.IsNotNull(results);
+            ClassicAssert.IsTrue(results.All(n => n.Id != id1));
+            ClassicAssert.IsTrue(results.All(n => n.Id != id2));
+            ClassicAssert.IsNotNull(results.SingleOrDefault(n => n.Id == id3));
+
+            // Cleanup
+            await ownerApiClient.AppNotifications.Delete([id3]);
+        }
+    }
 }

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableAppNotificationsCachedTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableAppNotificationsCachedTests.cs
@@ -140,6 +140,70 @@ public class TableAppNotificationsCachedTests : IocTestBase
 
     //
 
+    [Test]
+    [TestCase(false)]
+#if RUN_REDIS_TESTS
+    [TestCase(true)]
+#endif
+    public async Task ItShouldBulkUpdateUnreadAndInvalidateCaches(bool redisEnabled)
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite, redisEnabled: redisEnabled);
+        await using var scope = Services.BeginLifetimeScope();
+        var table = scope.Resolve<TableAppNotificationsCached>();
+
+        var id1 = Guid.Parse("11111111-AAAA-0000-0000-000000000000");
+        var id2 = Guid.Parse("22222222-AAAA-0000-0000-000000000000");
+        var id3 = Guid.Parse("33333333-AAAA-0000-0000-000000000000");
+
+        foreach (var id in new[] { id1, id2, id3 })
+        {
+            await table.InsertAsync(new AppNotificationsRecord
+            {
+                notificationId = id, senderId = "frodo.com", unread = 1, data = id.ToByteArray()
+            });
+        }
+
+        // Prime per-record and paging caches.
+        await table.GetAsync(id1, TimeSpan.FromMilliseconds(2000));
+        await table.PagingByCreatedAsync(int.MaxValue, null, TimeSpan.FromMilliseconds(2000));
+
+        // Bulk mark id1 and id2 as read; id3 left untouched. A missing id (id3 is
+        // present, but pass a random absent one) must not throw.
+        var affected = await table.UpdateUnreadAsync(
+            new List<Guid> { id1, id2, Guid.NewGuid() }, unread: false);
+        Assert.That(affected, Is.EqualTo(2));
+
+        if (redisEnabled) WipeL1();
+
+        // Affected per-record keys were invalidated -> reads reflect the new state.
+        var rec1 = await table.GetAsync(id1, TimeSpan.FromMilliseconds(2000));
+        var rec2 = await table.GetAsync(id2, TimeSpan.FromMilliseconds(2000));
+        var rec3 = await table.GetAsync(id3, TimeSpan.FromMilliseconds(2000));
+        Assert.That(rec1!.unread, Is.EqualTo(0));
+        Assert.That(rec2!.unread, Is.EqualTo(0));
+        Assert.That(rec3!.unread, Is.EqualTo(1));
+
+        // Paging cache was invalidated too -> the page reflects the new state.
+        var (records, _) = await table.PagingByCreatedAsync(int.MaxValue, null, TimeSpan.FromMilliseconds(2000));
+        var unreadCount = records.FindAll(r => r.unread == 1).Count;
+        Assert.That(unreadCount, Is.EqualTo(1));
+    }
+
+    //
+
+    [Test]
+    public async Task ItShouldReturnZeroForEmptyOrNullUpdateUnread()
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite);
+        await using var scope = Services.BeginLifetimeScope();
+        var table = scope.Resolve<TableAppNotificationsCached>();
+
+        Assert.That(await table.UpdateUnreadAsync(new List<Guid>(), unread: false), Is.EqualTo(0));
+        Assert.That(await table.UpdateUnreadAsync(null!, unread: false), Is.EqualTo(0));
+    }
+
+    //
+
 
 }
 

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableAppNotificationsCachedTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableAppNotificationsCachedTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Autofac;
 using NUnit.Framework;
+using Odin.Core.Storage.Database;
 using Odin.Core.Storage.Database.Identity.Table;
 using Odin.Core.Storage.Factory;
 
@@ -259,6 +260,96 @@ public class TableAppNotificationsCachedTests : IocTestBase
 
         Assert.That(await table.DeleteListAsync(new List<Guid>()), Is.EqualTo(0));
         Assert.That(await table.DeleteListAsync(null!), Is.EqualTo(0));
+    }
+
+    //
+
+    // Performance guard: this is the whole point of the bulk methods. We assert on the
+    // DatabaseCounters round-trip count (deterministic) rather than wall-clock time.
+    // The old per-row path issued 2N reader round-trips for an update (GetAsync +
+    // UpdateAsync-with-RETURNING) and N non-query round-trips for a delete, each under a
+    // held write lock. The bulk path must be one statement per BulkBatchSize chunk,
+    // independent of the item count.
+
+    private async Task<List<Guid>> InsertUnreadAsync(TableAppNotificationsCached table, int count)
+    {
+        var ids = new List<Guid>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var id = Guid.NewGuid();
+            ids.Add(id);
+            await table.InsertAsync(new AppNotificationsRecord
+            {
+                notificationId = id, senderId = "frodo.com", unread = 1, data = id.ToByteArray()
+            });
+        }
+        return ids;
+    }
+
+    [Test]
+    public async Task BulkUpdateUnreadIssuesOneRoundTripPerBatchRegardlessOfCount()
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite);
+        await using var scope = Services.BeginLifetimeScope();
+        var table = scope.Resolve<TableAppNotificationsCached>();
+        var counters = scope.Resolve<DatabaseCounters>();
+
+        // 200 notifications -> within a single 500-id batch.
+        var ids = await InsertUnreadAsync(table, 200);
+
+        var nonQueryBefore = counters.NoDbExecuteNonQueryAsync;
+        var readerBefore = counters.NoDbExecuteReaderAsync;
+
+        var affected = await table.UpdateUnreadAsync(ids, unread: false);
+
+        Assert.That(affected, Is.EqualTo(200));
+        // Exactly one UPDATE statement, no per-row SELECTs -- the old path would have
+        // issued ~400 reader round-trips here.
+        Assert.That(counters.NoDbExecuteNonQueryAsync - nonQueryBefore, Is.EqualTo(1),
+            "bulk update must issue a single round-trip for a within-batch list");
+        Assert.That(counters.NoDbExecuteReaderAsync - readerBefore, Is.EqualTo(0),
+            "bulk update must not issue per-row SELECTs");
+    }
+
+    [Test]
+    public async Task BulkUpdateUnreadChunksLargeListsByBatchSize()
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite);
+        await using var scope = Services.BeginLifetimeScope();
+        var table = scope.Resolve<TableAppNotificationsCached>();
+        var counters = scope.Resolve<DatabaseCounters>();
+
+        // 600 notifications -> two batches (500 + 100) at BulkBatchSize = 500.
+        var ids = await InsertUnreadAsync(table, 600);
+
+        var nonQueryBefore = counters.NoDbExecuteNonQueryAsync;
+
+        var affected = await table.UpdateUnreadAsync(ids, unread: false);
+
+        Assert.That(affected, Is.EqualTo(600));
+        // Bounded by ceil(N / batch) = 2, NOT by N.
+        Assert.That(counters.NoDbExecuteNonQueryAsync - nonQueryBefore, Is.EqualTo(2),
+            "bulk update must chunk a >batch-size list into ceil(N/batch) round-trips");
+    }
+
+    [Test]
+    public async Task BulkDeleteIssuesOneRoundTripPerBatchRegardlessOfCount()
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite);
+        await using var scope = Services.BeginLifetimeScope();
+        var table = scope.Resolve<TableAppNotificationsCached>();
+        var counters = scope.Resolve<DatabaseCounters>();
+
+        var ids = await InsertUnreadAsync(table, 200);
+
+        var nonQueryBefore = counters.NoDbExecuteNonQueryAsync;
+
+        var affected = await table.DeleteListAsync(ids);
+
+        Assert.That(affected, Is.EqualTo(200));
+        // One DELETE statement vs the old path's 200 per-row deletes.
+        Assert.That(counters.NoDbExecuteNonQueryAsync - nonQueryBefore, Is.EqualTo(1),
+            "bulk delete must issue a single round-trip for a within-batch list");
     }
 
     //

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableAppNotificationsCachedTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableAppNotificationsCachedTests.cs
@@ -354,6 +354,74 @@ public class TableAppNotificationsCachedTests : IocTestBase
 
     //
 
+    // Concurrency: multiple requests can hit the same identity's notification table at
+    // once. This fires concurrent bulk updates and deletes, each in its OWN lifetime
+    // scope (per CLAUDE.md a single scope's connection is not safe for concurrent use,
+    // so fanning out DB work requires a child scope per branch). It asserts the
+    // operations are concurrency-safe -- no "Parallelism detected", no lock errors --
+    // and that the final state is exactly consistent. The short per-statement write-lock
+    // hold time from the bulk change is what keeps this contention cheap; the
+    // round-trip-count tests above guard that property directly.
+    [Test]
+    public async Task BulkUpdateAndDeleteAreSafeUnderConcurrentScopes()
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite);
+
+        // Seed 100 unread notifications.
+        List<Guid> allIds;
+        {
+            await using var seedScope = Services.BeginLifetimeScope();
+            var seedTable = seedScope.Resolve<TableAppNotificationsCached>();
+            allIds = await InsertUnreadAsync(seedTable, 100);
+        }
+
+        // 10 slices of 10. Slices 0-4 are marked read concurrently; slices 5-9 are
+        // bulk-deleted concurrently. Each task runs in its own child scope.
+        const int sliceSize = 10;
+        var tasks = new List<Task>();
+        for (var s = 0; s < 10; s++)
+        {
+            var slice = allIds.GetRange(s * sliceSize, sliceSize);
+            var markRead = s < 5;
+            tasks.Add(Task.Run(async () =>
+            {
+                await using var childScope = Services.BeginLifetimeScope();
+                var table = childScope.Resolve<TableAppNotificationsCached>();
+                if (markRead)
+                {
+                    await table.UpdateUnreadAsync(slice, unread: false);
+                }
+                else
+                {
+                    await table.DeleteListAsync(slice);
+                }
+            }));
+        }
+
+        // Must not throw.
+        await Task.WhenAll(tasks);
+
+        // Verify the final state is exactly consistent: 50 read survivors, 50 deleted.
+        await using var verifyScope = Services.BeginLifetimeScope();
+        var verifyTable = verifyScope.Resolve<TableAppNotificationsCached>();
+        var (records, _) = await verifyTable.PagingByCreatedAsync(int.MaxValue, null, TimeSpan.FromMilliseconds(2000));
+
+        Assert.That(records.Count, Is.EqualTo(50));
+        Assert.That(records.TrueForAll(r => r.unread == 0), Is.True, "all surviving notifications must be marked read");
+
+        var survivingIds = new HashSet<Guid>(records.ConvertAll(r => r.notificationId));
+        for (var i = 0; i < 50; i++)
+        {
+            Assert.That(survivingIds.Contains(allIds[i]), Is.True, $"read-slice id at index {i} should survive");
+        }
+        for (var i = 50; i < 100; i++)
+        {
+            Assert.That(survivingIds.Contains(allIds[i]), Is.False, $"deleted-slice id at index {i} should be gone");
+        }
+    }
+
+    //
+
 
 }
 

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableAppNotificationsCachedTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Table/TableAppNotificationsCachedTests.cs
@@ -204,6 +204,65 @@ public class TableAppNotificationsCachedTests : IocTestBase
 
     //
 
+    [Test]
+    [TestCase(false)]
+#if RUN_REDIS_TESTS
+    [TestCase(true)]
+#endif
+    public async Task ItShouldBulkDeleteAndInvalidateCaches(bool redisEnabled)
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite, redisEnabled: redisEnabled);
+        await using var scope = Services.BeginLifetimeScope();
+        var table = scope.Resolve<TableAppNotificationsCached>();
+
+        var id1 = Guid.Parse("11111111-AAAA-0000-0000-000000000000");
+        var id2 = Guid.Parse("22222222-AAAA-0000-0000-000000000000");
+        var id3 = Guid.Parse("33333333-AAAA-0000-0000-000000000000");
+
+        foreach (var id in new[] { id1, id2, id3 })
+        {
+            await table.InsertAsync(new AppNotificationsRecord
+            {
+                notificationId = id, senderId = "frodo.com", unread = 1, data = id.ToByteArray()
+            });
+        }
+
+        // Prime per-record and paging caches.
+        await table.GetAsync(id1, TimeSpan.FromMilliseconds(2000));
+        await table.PagingByCreatedAsync(int.MaxValue, null, TimeSpan.FromMilliseconds(2000));
+
+        // Bulk delete id1 and id2; id3 left intact. A missing id must not throw.
+        var affected = await table.DeleteListAsync(new List<Guid> { id1, id2, Guid.NewGuid() });
+        Assert.That(affected, Is.EqualTo(2));
+
+        if (redisEnabled) WipeL1();
+
+        // Deleted per-record keys were invalidated -> reads reflect the deletions.
+        Assert.That(await table.GetAsync(id1, TimeSpan.FromMilliseconds(2000)), Is.Null);
+        Assert.That(await table.GetAsync(id2, TimeSpan.FromMilliseconds(2000)), Is.Null);
+        Assert.That(await table.GetAsync(id3, TimeSpan.FromMilliseconds(2000)), Is.Not.Null);
+
+        // Paging cache was invalidated too -> the page reflects the deletions.
+        var (records, _) = await table.PagingByCreatedAsync(int.MaxValue, null, TimeSpan.FromMilliseconds(2000));
+        Assert.That(records.Count, Is.EqualTo(1));
+        Assert.That(records[0].notificationId, Is.EqualTo(id3));
+    }
+
+    //
+
+    [Test]
+    public async Task ItShouldReturnZeroForEmptyOrNullDeleteList()
+    {
+        await RegisterServicesAsync(DatabaseType.Sqlite);
+        await using var scope = Services.BeginLifetimeScope();
+        var table = scope.Resolve<TableAppNotificationsCached>();
+
+        Assert.That(await table.DeleteListAsync(new List<Guid>()), Is.EqualTo(0));
+        Assert.That(await table.DeleteListAsync(null!), Is.EqualTo(0));
+    }
+
+    //
+
 
 }
 


### PR DESCRIPTION
## Problem

`NotificationListService.UpdateNotifications` and `Delete` (in `NotificationDataService.cs`) each did a per-row DB round-trip inside a single write transaction, holding the DB write lock for the entire loop. This is the source of the observed lock contention.

- **`UpdateNotifications`**: a read-modify-write (`GetAsync` + `UpdateAsync`) round-trip *per row*.
- **`MarkReadByApp` / `MarkReadByAppAndTypeId`** made it pathological — they load *every* notification (including already-read ones) and feed them all in, so marking an app read on a busy identity = thousands of serial round-trips under the write lock.
- **`Delete`**: a `DeleteAsync` round-trip *per id*.
- In both, the paging cache was invalidated once *per row*.

In SQLite a write transaction takes a database-level write lock, so every other tenant write blocks for the full duration of these loops.

## Fix

Replace per-row loops with single set-based SQL statements:

- `TableAppNotifications.UpdateUnreadAsync(List<Guid>, bool)` — one `UPDATE ... WHERE notificationId IN (...)` per batch, touching only `unread` + `modified` (no per-row `SELECT`). The monotonic `modified = MAX(modified+1, now)` clause is carried over verbatim from the generated `UpdateAsync`, so change-tracking semantics are unchanged.
- `TableAppNotifications.DeleteListAsync(List<Guid>)` — one `DELETE ... WHERE notificationId IN (...)` per batch.
- Both chunk the IN-list at `BulkBatchSize` (500) to stay under SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` (999).
- Cached wrappers invalidate the affected record keys + the paging tag in a **single** pass (matches the existing `TableKeyValueCached` multi-key pattern).
- `UpdateNotifications` groups updates by target state → at most **two** statements.
- `MarkRead*` only submit currently-unread notifications.

### Net effect (for N updates/deletes)
| | Before | After |
|---|---|---|
| DB round-trips | 2N (update) / N (delete) | ≤2 (or ~N/500 chunks) |
| Per-row SELECTs (update) | N | 0 |
| Paging-cache invalidations | N | 1 |
| Write-lock hold time | grows with N | ~constant |

## Tests

### Correctness — storage layer (`TableAppNotificationsCachedTests`)
- `ItShouldBulkUpdateUnreadAndInvalidateCaches` — right rows flip; per-record + paging caches invalidated; missing ids don't throw.
- `ItShouldBulkDeleteAndInvalidateCaches` — right rows removed; caches invalidated; missing ids don't throw.
- `ItShouldReturnZeroForEmptyOrNullUpdateUnread` / `ItShouldReturnZeroForEmptyOrNullDeleteList` — empty/null guards.

### Performance — storage layer, deterministic round-trip counts via `DatabaseCounters`
These assert the core property of the change — round-trips don't scale with item count — without relying on wall-clock timing. They fail if anyone reintroduces a per-row round-trip.
- `BulkUpdateUnreadIssuesOneRoundTripPerBatchRegardlessOfCount` — 200 ids → exactly **1** non-query, **0** readers (old path: ~400 reader round-trips).
- `BulkUpdateUnreadChunksLargeListsByBatchSize` — 600 ids → exactly **2** non-queries, i.e. bounded by `ceil(N / BulkBatchSize)`, not N (also covers the >batch-size chunk boundary).
- `BulkDeleteIssuesOneRoundTripPerBatchRegardlessOfCount` — 200 ids → **1** non-query (old path: 200 per-row deletes).

### Concurrency — storage layer
- `BulkUpdateAndDeleteAreSafeUnderConcurrentScopes` — 10 concurrent bulk update/delete operations against the same identity's table, each in its own lifetime scope (per the CLAUDE.md scoped-connection rule). Asserts no `"Parallelism detected"` / no SQLite lock errors and an exactly-consistent final state (50 read survivors, 50 deleted). Verified stable across repeated runs. SQLite WAL + Microsoft.Data.Sqlite's command-timeout retry serialize writers; the short per-statement lock hold from this change keeps that contention cheap.

### End-to-end — integration (`NotificationListTests`, runs across owner / app / guest contexts)
The pre-existing tests only ever updated/deleted a *single* notification, so the new bulk paths had no end-to-end coverage. Added:
- `CanUpdateMultipleNotificationsWithMixedReadStates` — one request that marks several read and flips another back to unread, exercising both the `toRead` and `toUnread` set-based branches and the multi-item IN-list, and asserting out-of-request notifications stay untouched.
- `CanRemoveMultipleNotifications` — bulk delete with more than one id.

Full `NotificationListTests` suite: 27 passed. Storage suite (`TableAppNotificationsCachedTests`): 9 passed. `dotnet build` clean, 0 warnings. CI runs both SQLite and PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)