### PR TITLE
Add [UploadTiming] diagnostic logging to upload/commit path

### DIFF
--- a/src/apps/Odin.Hosting/Controllers/Base/Drive/V1DriveUploadControllerBase.cs
+++ b/src/apps/Odin.Hosting/Controllers/Base/Drive/V1DriveUploadControllerBase.cs
@@ -237,6 +237,9 @@ namespace Odin.Hosting.Controllers.Base.Drive
                 throw new OdinClientException($"JSON error: {e.Message}", e);
             }
 
+            // [UploadTiming] Diagnostic: time spent receiving + staging the multipart body vs the finalize/commit step.
+            var receiveSw = System.Diagnostics.Stopwatch.StartNew();
+
             section = await reader.ReadNextSectionAsync();
             AssertIsPart(section, MultipartUploadParts.Metadata);
             logger.LogDebug("ReceiveFileStream: AddMetadata");
@@ -266,8 +269,17 @@ namespace Odin.Hosting.Controllers.Base.Drive
                 section = await reader.ReadNextSectionAsync();
             }
 
+            logger.LogInformation(
+                "[UploadTiming] Multipart receive + local staging complete; receiveMs:{receiveMs}",
+                receiveSw.ElapsedMilliseconds);
+
             logger.LogDebug("ReceiveFileStream: FinalizeUploadAsync");
+            var finalizeSw = System.Diagnostics.Stopwatch.StartNew();
             var status = await driveUploadService.FinalizeUploadAsync(WebOdinContext);
+            logger.LogInformation(
+                "[UploadTiming] Request totals: receiveMs:{receiveMs} finalizeMs:{finalizeMs} totalMs:{totalMs}",
+                receiveSw.ElapsedMilliseconds - finalizeSw.ElapsedMilliseconds, finalizeSw.ElapsedMilliseconds,
+                receiveSw.ElapsedMilliseconds);
             return status;
         }
 

--- a/src/services/Odin.Services/Drives/DriveCore/Storage/PayloadFileReaderWriter.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/PayloadFileReaderWriter.cs
@@ -133,9 +133,14 @@ public class PayloadFileReaderWriter(
     public Task CopyPayloadFileAsync(string sourcePath, string targetPath, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        // [UploadTiming] Diagnostic: time the LOCAL long-term copy (comparison baseline vs the S3 backend).
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         try
         {
             fileReaderWriter.CopyPayloadFile(sourcePath, targetPath);
+            _logger.LogInformation(
+                "[UploadTiming] LOCAL long-term copy src:{src} dst:{dst} elapsedMs:{elapsedMs}",
+                sourcePath, targetPath, sw.ElapsedMilliseconds);
             return Task.CompletedTask;
         }
         catch (Exception e) when (e is not OperationCanceledException)

--- a/src/services/Odin.Services/Drives/DriveCore/Storage/PayloadS3ReaderWriter.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/PayloadS3ReaderWriter.cs
@@ -97,13 +97,29 @@ public class PayloadS3ReaderWriter(ILogger<PayloadS3ReaderWriter> logger, IS3Pay
 
     public async Task CopyPayloadFileAsync(string srcFilePath, string dstFilePath, CancellationToken cancellationToken = default)
     {
+        // [UploadTiming] Diagnostic: time the S3 upload INCLUDING retry/backoff (this is the suspected bottleneck).
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var attempts = 0;
         try
         {
             await TryRetry(async () =>
-                await s3PayloadsStorage.UploadFileAsync(srcFilePath, dstFilePath, cancellationToken), cancellationToken);
+            {
+                attempts++;
+                var attemptSw = System.Diagnostics.Stopwatch.StartNew();
+                await s3PayloadsStorage.UploadFileAsync(srcFilePath, dstFilePath, cancellationToken);
+                logger.LogInformation(
+                    "[UploadTiming] S3 upload attempt #{attempt} OK src:{src} dst:{dst} attemptMs:{attemptMs}",
+                    attempts, srcFilePath, dstFilePath, attemptSw.ElapsedMilliseconds);
+            }, cancellationToken);
+            logger.LogInformation(
+                "[UploadTiming] S3 upload TOTAL src:{src} dst:{dst} attempts:{attempts} totalMs:{totalMs}",
+                srcFilePath, dstFilePath, attempts, sw.ElapsedMilliseconds);
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {
+            logger.LogWarning(
+                "[UploadTiming] S3 upload FAILED src:{src} dst:{dst} attempts:{attempts} totalMs:{totalMs} error:{error}",
+                srcFilePath, dstFilePath, attempts, sw.ElapsedMilliseconds, e.Message);
             throw new PayloadReaderWriterException(e.Message, e);
         }
     }

--- a/src/services/Odin.Services/Drives/DriveCore/Storage/UploadStorageManager.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/UploadStorageManager.cs
@@ -39,9 +39,15 @@ namespace Odin.Services.Drives.DriveCore.Storage
         /// </summary>
         public async Task<uint> WriteUploadStream(InternalDriveFileId file, string extension, Stream stream)
         {
+            // [UploadTiming] Diagnostic: time the LOCAL staging write to prove local disk is fast vs S3 commit.
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             fileReaderWriter.CreateDirectory(_tenantPathManager.GetDriveUploadPath(file.DriveId));
             string path = _tenantPathManager.GetDriveUploadFilePath(file.DriveId, file.FileId, extension);
-            return await fileReaderWriter.WriteStreamAsync(path, stream);
+            var bytesWritten = await fileReaderWriter.WriteStreamAsync(path, stream);
+            logger.LogInformation(
+                "[UploadTiming] LOCAL stage write fileId:{fileId} ext:{ext} bytes:{bytes} elapsedMs:{elapsedMs}",
+                file.FileId, extension, bytesWritten, sw.ElapsedMilliseconds);
+            return bytesWritten;
         }
 
         /// <summary>

--- a/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/DriveStorageServiceBase.cs
@@ -1719,15 +1719,29 @@ namespace Odin.Services.Drives.FileSystem.Base
         private async Task CopyPayloadsAndThumbnailsToLongTermStorage(InternalDriveFileId originFile, InternalDriveFileId targetFile,
             List<PayloadDescriptor> descriptors, StorageDrive drive, string sourceFolderPath)
         {
+            // [UploadTiming] Diagnostic: time the whole commit-to-long-term loop (payloads uploaded sequentially here).
+            var totalSw = System.Diagnostics.Stopwatch.StartNew();
+            var payloadCount = descriptors?.Count ?? 0;
+            var thumbnailCount = descriptors?.Sum(d => d.Thumbnails?.Count() ?? 0) ?? 0;
+            _logger.LogInformation(
+                "[UploadTiming] Commit-to-long-term START fileId:{fileId} payloads:{payloads} thumbnails:{thumbnails}",
+                targetFile.FileId, payloadCount, thumbnailCount);
             try
             {
                 foreach (var descriptor in descriptors)
                 {
                     await CopyPayloadAndThumbnailsToLongTermStorage(originFile, targetFile, drive, descriptor, sourceFolderPath);
                 }
+
+                _logger.LogInformation(
+                    "[UploadTiming] Commit-to-long-term DONE fileId:{fileId} payloads:{payloads} thumbnails:{thumbnails} totalMs:{totalMs}",
+                    targetFile.FileId, payloadCount, thumbnailCount, totalSw.ElapsedMilliseconds);
             }
             catch
             {
+                _logger.LogWarning(
+                    "[UploadTiming] Commit-to-long-term FAILED fileId:{fileId} totalMs:{totalMs}",
+                    targetFile.FileId, totalSw.ElapsedMilliseconds);
                 await longTermStorageManager.TryHardDeleteListOfPayloadFiles(drive, targetFile.FileId, descriptors);
                 throw;
             }
@@ -1741,11 +1755,17 @@ namespace Odin.Services.Drives.FileSystem.Base
         {
             var payloadExtension = TenantPathManager.GetBasePayloadFileNameAndExtension(descriptor.Key, descriptor.Uid);
             var sourceFilePath = Path.Combine(sourceFolderPath, TenantPathManager.GetFilename(originFile.FileId, payloadExtension));
+
+            // [UploadTiming] Diagnostic: time this single payload's copy to long-term storage.
+            var payloadSw = System.Diagnostics.Stopwatch.StartNew();
             await longTermStorageManager.CopyPayloadToLongTermAsync(
                 drive,
                 targetFile.FileId,
                 descriptor,
                 sourceFilePath);
+            _logger.LogInformation(
+                "[UploadTiming] Payload copied to long-term fileId:{fileId} payloadKey:{key} elapsedMs:{elapsedMs}",
+                targetFile.FileId, descriptor.Key, payloadSw.ElapsedMilliseconds);
 
             foreach (var thumb in descriptor.Thumbnails ?? [])
             {
@@ -1753,8 +1773,13 @@ namespace Odin.Services.Drives.FileSystem.Base
                     descriptor.Key, descriptor.Uid, thumb.PixelWidth, thumb.PixelHeight);
 
                 var sourceThumbnail = Path.Combine(sourceFolderPath, TenantPathManager.GetFilename(originFile.FileId, thumbExt));
+                // [UploadTiming] Diagnostic: time this single thumbnail's copy to long-term storage.
+                var thumbSw = System.Diagnostics.Stopwatch.StartNew();
                 await longTermStorageManager.CopyThumbnailToLongTermAsync(drive, targetFile.FileId, sourceThumbnail, descriptor,
                     thumb);
+                _logger.LogInformation(
+                    "[UploadTiming] Thumbnail copied to long-term fileId:{fileId} payloadKey:{key} {w}x{h} elapsedMs:{elapsedMs}",
+                    targetFile.FileId, descriptor.Key, thumb.PixelWidth, thumb.PixelHeight, thumbSw.ElapsedMilliseconds);
             }
         }
 

--- a/src/services/Odin.Services/Drives/FileSystem/Base/Upload/FileSystemStreamWriterBase.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/Upload/FileSystemStreamWriterBase.cs
@@ -187,11 +187,18 @@ public abstract class FileSystemStreamWriterBase
     /// </summary>
     public async Task<UploadResult> FinalizeUploadAsync(IOdinContext odinContext)
     {
+        // [UploadTiming] Diagnostic: phase breakdown of the finalize step (metadata -> commit -> transit enqueue).
+        var phaseSw = System.Diagnostics.Stopwatch.StartNew();
+
         var (keyHeader, metadata, serverMetadata) = await UnpackMetadata(Package, odinContext);
 
         await this.ValidateUploadCoreAsync(Package, keyHeader, metadata, serverMetadata, odinContext);
 
         await this.ValidateUnpackedData(Package, keyHeader, metadata, serverMetadata, odinContext);
+
+        _logger.LogInformation(
+            "[UploadTiming] Finalize phase: metadata unpack + validation done fileId:{fileId} elapsedMs:{elapsedMs}",
+            Package.InternalFile.FileId, phaseSw.ElapsedMilliseconds);
 
         if (Package.IsUpdateOperation)
         {
@@ -258,7 +265,16 @@ public abstract class FileSystemStreamWriterBase
             await ProcessNewFileUpload(Package, keyHeader, metadata, serverMetadata, odinContext);
         }
 
+        // [UploadTiming] Diagnostic: time elapsed through the commit-to-storage phase (includes long-term/S3 copy).
+        _logger.LogInformation(
+            "[UploadTiming] Finalize phase: commit-to-storage done fileId:{fileId} cumulativeMs:{cumulativeMs}",
+            Package.InternalFile.FileId, phaseSw.ElapsedMilliseconds);
+
+        var transitSw = System.Diagnostics.Stopwatch.StartNew();
         Dictionary<string, TransferStatus> recipientStatus = await ProcessTransitInstructions(Package, odinContext);
+        _logger.LogInformation(
+            "[UploadTiming] Finalize phase: transit/outbox enqueue done fileId:{fileId} recipients:{recipients} transitMs:{transitMs} totalFinalizeMs:{totalFinalizeMs}",
+            Package.InternalFile.FileId, recipientStatus?.Count ?? 0, transitSw.ElapsedMilliseconds, phaseSw.ElapsedMilliseconds);
 
         var drive = await _driveManager.GetDriveAsync(Package.InternalFile.DriveId);
 


### PR DESCRIPTION
## Goal

Prove **where** the latency users perceive as "Finalizing…" on chat media upload actually goes. **Logging only — no behavior changes.**

The `POST /api/v2/drives/{driveId}/files` handler writes its response only after committing payloads to long-term storage. When that storage is S3, the commit runs synchronously inside the request, one file at a time, wrapped in a 5-attempt exponential-backoff retry (`PayloadS3ReaderWriter`), which can stack to ~120s. This branch instruments each step so we can confirm that from logs.

## What's instrumented

All emitted at **Information** level under the greppable tag **`[UploadTiming]`**.

| Where | Method | Captures |
|---|---|---|
| Controller | `V1DriveUploadControllerBase.ProcessNewFileUpload` | multipart receive+staging time vs finalize time vs request total |
| Finalize | `FileSystemStreamWriterBase.FinalizeUploadAsync` | phase breakdown: metadata/validation → commit-to-storage → transit enqueue |
| Commit loop | `DriveStorageServiceBase.CopyPayloadsAndThumbnailsToLongTermStorage` | total commit time + payload/thumbnail counts |
| Per file | `DriveStorageServiceBase.CopyPayloadAndThumbnailsToLongTermStorage` | per-payload and per-thumbnail copy time |
| Local stage | `UploadStorageManager.WriteUploadStream` | local staging write bytes + ms |
| **S3 commit** | `PayloadS3ReaderWriter.CopyPayloadFileAsync` | per-attempt S3 time, attempt count, total incl. retry/backoff |
| Local commit | `PayloadFileReaderWriter.CopyPayloadFileAsync` | local long-term copy time (baseline) |

## How to use

After an upload, grep logs for `[UploadTiming]`. Expectation if the hypothesis holds: local staging is fast, request total ≈ finalize ≈ commit ≈ S3 `totalMs`, and the `attempts:N` field reveals whether it's retry/backoff or raw transfer.

## Notes

- Build verified clean.
- Diagnostic only; intended to be reverted or gated once the data is collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)