### PR TITLE
Fix NRE in V7→V8 migration and upgrade identity master-key encryption up front

### DIFF
--- a/src/services/Odin.Services/Configuration/VersionUpgrade/Version7tov8/V7ToV8VersionMigrationService.cs
+++ b/src/services/Odin.Services/Configuration/VersionUpgrade/Version7tov8/V7ToV8VersionMigrationService.cs
@@ -105,6 +105,24 @@ namespace Odin.Services.Configuration.VersionUpgrade.Version7tov8
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // Identities whose access grant was established without the owner's master key
+                // (e.g. introduction-based connections) have no MasterKeyEncryptedKeyStoreKey, so
+                // re-granting would dereference a null key. We have the master key here, so attempt
+                // the same upgrade the circle-definition reconcile path performs. If it still can't be
+                // upgraded (e.g. no TempWeakKeyStoreKey to recover from), skip it rather than crash the
+                // batch; it will be reconciled later once the identity completes its upgrade.
+                if (identity.AccessGrant.RequiresMasterKeyEncryptionUpgrade())
+                {
+                    var upgraded = await circleNetworkService.TryUpgradeMasterKeyStoreKeyEncryptionAsync(identity, odinContext);
+                    if (!upgraded)
+                    {
+                        logger.LogWarning(
+                            "Skipping system circle reconciliation for Identity  {odinId}: access grant still requires master key encryption upgrade",
+                            identity.OdinId);
+                        continue;
+                    }
+                }
+
                 // Re-grant whichever system circles this identity is a member of so the new
                 // Moments drive grant is issued to confirmed and auto-connected identities alike
                 foreach (var circleId in SystemCircleConstants.AllSystemCircles)

--- a/src/services/Odin.Services/Configuration/VersionUpgrade/VersionUpgradeService.cs
+++ b/src/services/Odin.Services/Configuration/VersionUpgrade/VersionUpgradeService.cs
@@ -15,6 +15,7 @@ using Odin.Services.Configuration.VersionUpgrade.Version4tov5;
 using Odin.Services.Configuration.VersionUpgrade.Version5tov6;
 using Odin.Services.Configuration.VersionUpgrade.Version6tov7;
 using Odin.Services.Configuration.VersionUpgrade.Version7tov8;
+using Odin.Services.Membership.Connections;
 
 namespace Odin.Services.Configuration.VersionUpgrade;
 
@@ -31,6 +32,7 @@ public class VersionUpgradeService(
     V7ToV8VersionMigrationService v8,
     IdentityDatabase db,
     OwnerAuthenticationService authService,
+    CircleNetworkService circleNetworkService,
     ILogger<VersionUpgradeService> logger)
 {
     private bool _isRunning;
@@ -63,6 +65,22 @@ public class VersionUpgradeService(
 
         try
         {
+            // Bring all connected identities up to the current master-key store-key encryption scheme
+            // before running any migration. Migrations that re-grant circles dereference the
+            // MasterKeyEncryptedKeyStoreKey, which is null on grants established without the owner's
+            // master key; upgrading up front lets the version ladder assume that invariant.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await using (var encTx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken))
+            {
+                _isRunning = true;
+                await circleNetworkService.UpgradeMasterKeyStoreKeyEncryptionForConnectedIdentitiesAsync(odinContext, cancellationToken);
+                encTx.Commit();
+            }
+
             if (currentVersion == 0)
             {
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);

--- a/src/services/Odin.Services/Configuration/VersionUpgrade/VersionUpgradeService.cs
+++ b/src/services/Odin.Services/Configuration/VersionUpgrade/VersionUpgradeService.cs
@@ -37,9 +37,12 @@ public class VersionUpgradeService(
 {
     private bool _isRunning;
 
+    // Prefix on every log line emitted by the upgrade flow so it can be traced through the log.
+    private const string LogTag = nameof(VersionUpgradeService) + ":";
+
     public async Task UpgradeAsync(VersionUpgradeJobData data, CancellationToken cancellationToken)
     {
-        logger.LogInformation($"Running Version Upgrade Process for {data.Tenant}");
+        logger.LogInformation(LogTag + " Running Version Upgrade Process for {tenant}", data.Tenant);
 
         var tokenBytes = AesCbc.Decrypt(data.EncryptedToken, tenantContext.TemporalEncryptionKey, data.Iv);
         var token = ClientAuthenticationToken.FromPortableBytes(tokenBytes);
@@ -77,8 +80,11 @@ public class VersionUpgradeService(
             await using (var encTx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken))
             {
                 _isRunning = true;
-                await circleNetworkService.UpgradeMasterKeyStoreKeyEncryptionForConnectedIdentitiesAsync(odinContext, cancellationToken);
+                var (upgraded, skipped) =
+                    await circleNetworkService.UpgradeMasterKeyStoreKeyEncryptionForConnectedIdentitiesAsync(odinContext, cancellationToken);
                 encTx.Commit();
+                logger.LogInformation(
+                    LogTag + " Master key encryption pre-pass complete: {upgraded} upgraded, {skipped} skipped", upgraded, skipped);
             }
 
             if (currentVersion == 0)
@@ -86,7 +92,7 @@ public class VersionUpgradeService(
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
 
                 _isRunning = true;
-                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
 
                 await v1.UpgradeAsync(odinContext, cancellationToken);
 
@@ -95,7 +101,7 @@ public class VersionUpgradeService(
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 
                 tx.Commit();
-                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
             }
 
             // do this after each version upgrade
@@ -109,7 +115,7 @@ public class VersionUpgradeService(
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
 
                 _isRunning = true;
-                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
 
                 await v2.UpgradeAsync(odinContext, cancellationToken);
 
@@ -118,7 +124,7 @@ public class VersionUpgradeService(
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 
                 tx.Commit();
-                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
             }
 
             // do this after each version upgrade
@@ -132,7 +138,7 @@ public class VersionUpgradeService(
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
 
                 _isRunning = true;
-                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
 
                 await v3.UpgradeAsync(odinContext, cancellationToken);
 
@@ -141,7 +147,7 @@ public class VersionUpgradeService(
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 
                 tx.Commit();
-                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
             }
 
             // do this after each version upgrade
@@ -155,7 +161,7 @@ public class VersionUpgradeService(
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
 
                 _isRunning = true;
-                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
 
                 await v4.UpgradeAsync(odinContext, cancellationToken);
 
@@ -165,7 +171,7 @@ public class VersionUpgradeService(
              
                 tx.Commit();
                 
-                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
             }
 
             if (data.TestMode)
@@ -179,7 +185,7 @@ public class VersionUpgradeService(
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
 
                 _isRunning = true;
-                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
 
                 await v5.UpgradeAsync(odinContext, cancellationToken);
 
@@ -188,7 +194,7 @@ public class VersionUpgradeService(
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 
                 tx.Commit();
-                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
             }
 
             if (currentVersion == 5)
@@ -196,7 +202,7 @@ public class VersionUpgradeService(
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
 
                 _isRunning = true;
-                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
 
                 await v6.UpgradeAsync(odinContext, cancellationToken);
 
@@ -205,7 +211,7 @@ public class VersionUpgradeService(
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 
                 tx.Commit();
-                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
             }
 
             // do this after each version upgrade
@@ -219,7 +225,7 @@ public class VersionUpgradeService(
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
 
                 _isRunning = true;
-                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
 
                 await v7.UpgradeAsync(odinContext, cancellationToken);
 
@@ -228,7 +234,7 @@ public class VersionUpgradeService(
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 
                 tx.Commit();
-                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
             }
 
             // do this after each version upgrade
@@ -242,7 +248,7 @@ public class VersionUpgradeService(
                 await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
 
                 _isRunning = true;
-                logger.LogInformation("Upgrading from v{currentVersion}", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
 
                 await v8.UpgradeAsync(odinContext, cancellationToken);
 
@@ -251,7 +257,7 @@ public class VersionUpgradeService(
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 
                 tx.Commit();
-                logger.LogInformation("Upgrading to v{currentVersion} successful", currentVersion);
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
             }
 
             // do this after each version upgrade
@@ -268,7 +274,7 @@ public class VersionUpgradeService(
         catch (Exception ex)
         {
             await tenantConfigService.SetVersionFailureInfoAsync(currentVersion + 1);
-            logger.LogError(ex, $"Upgrading from {currentVersion} failed.  Release Info: {Version.VersionText}");
+            logger.LogError(ex, LogTag + " Upgrading from v{currentVersion} failed. Release Info: {releaseInfo}", currentVersion, Version.VersionText);
         }
         finally
         {

--- a/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
+++ b/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
@@ -1293,6 +1293,51 @@ namespace Odin.Services.Membership.Connections
             return !refreshed.AccessGrant.RequiresMasterKeyEncryptionUpgrade();
         }
 
+        /// <summary>
+        /// Iterates all connected identities and upgrades the master-key store-key encryption for any that
+        /// still require it (i.e. their grant was established without the owner's master key). Intended to be
+        /// run once before version migrations so downstream migration logic can assume identities are upgraded.
+        /// Identities that cannot be upgraded (e.g. no TempWeakKeyStoreKey to recover from) are left as-is and
+        /// self-heal later via the lazy circle-definition reconcile path.
+        /// </summary>
+        public async Task UpgradeMasterKeyStoreKeyEncryptionForConnectedIdentitiesAsync(IOdinContext odinContext,
+            CancellationToken cancellationToken)
+        {
+            odinContext.Caller.AssertHasMasterKey();
+
+            var allIdentities = await GetConnectedIdentitiesAsync(int.MaxValue, null, odinContext);
+
+            var upgraded = 0;
+            var skipped = 0;
+            foreach (var identity in allIdentities.Results)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!identity.AccessGrant.RequiresMasterKeyEncryptionUpgrade())
+                {
+                    continue;
+                }
+
+                if (await TryUpgradeMasterKeyStoreKeyEncryptionAsync(identity, odinContext))
+                {
+                    upgraded++;
+                }
+                else
+                {
+                    skipped++;
+                    logger.LogWarning(
+                        "Identity {odinId} still requires master key encryption upgrade after attempt; leaving for lazy reconcile",
+                        identity.OdinId);
+                }
+            }
+
+            if (upgraded > 0 || skipped > 0)
+            {
+                logger.LogInformation(
+                    "Master key encryption upgrade pass complete: {upgraded} upgraded, {skipped} skipped", upgraded, skipped);
+            }
+        }
+
         private async Task<bool> UpgradeMasterKeyStoreKeyEncryptionIfNeededInternalAsync(IdentityConnectionRegistration identity,
             IOdinContext odinContext)
         {

--- a/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
+++ b/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
@@ -1298,10 +1298,11 @@ namespace Odin.Services.Membership.Connections
         /// still require it (i.e. their grant was established without the owner's master key). Intended to be
         /// run once before version migrations so downstream migration logic can assume identities are upgraded.
         /// Identities that cannot be upgraded (e.g. no TempWeakKeyStoreKey to recover from) are left as-is and
-        /// self-heal later via the lazy circle-definition reconcile path.
+        /// self-heal later via the lazy circle-definition reconcile path. Returns the number of identities
+        /// upgraded and skipped so the caller can log a summary in its own trace.
         /// </summary>
-        public async Task UpgradeMasterKeyStoreKeyEncryptionForConnectedIdentitiesAsync(IOdinContext odinContext,
-            CancellationToken cancellationToken)
+        public async Task<(int upgraded, int skipped)> UpgradeMasterKeyStoreKeyEncryptionForConnectedIdentitiesAsync(
+            IOdinContext odinContext, CancellationToken cancellationToken)
         {
             odinContext.Caller.AssertHasMasterKey();
 
@@ -1331,11 +1332,7 @@ namespace Odin.Services.Membership.Connections
                 }
             }
 
-            if (upgraded > 0 || skipped > 0)
-            {
-                logger.LogInformation(
-                    "Master key encryption upgrade pass complete: {upgraded} upgraded, {skipped} skipped", upgraded, skipped);
-            }
+            return (upgraded, skipped);
         }
 
         private async Task<bool> UpgradeMasterKeyStoreKeyEncryptionIfNeededInternalAsync(IdentityConnectionRegistration identity,

--- a/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
+++ b/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
@@ -1271,6 +1271,28 @@ namespace Odin.Services.Membership.Connections
             }
         }
 
+        /// <summary>
+        /// Attempts to upgrade the identity's master-key store-key encryption if it still requires it
+        /// (i.e. the grant was established without the owner's master key). Returns true when the identity
+        /// no longer requires the upgrade and is therefore safe to (re)grant circles to. Returns false when
+        /// the upgrade could not be completed (e.g. the identity has no <see cref="IdentityConnectionRegistration.TempWeakKeyStoreKey"/>
+        /// to recover from), in which case the caller should skip it and retry once the identity is upgraded.
+        /// </summary>
+        public async Task<bool> TryUpgradeMasterKeyStoreKeyEncryptionAsync(IdentityConnectionRegistration identity,
+            IOdinContext odinContext)
+        {
+            if (!identity.AccessGrant.RequiresMasterKeyEncryptionUpgrade())
+            {
+                return true;
+            }
+
+            await UpgradeMasterKeyStoreKeyEncryptionIfNeededInternalAsync(identity, odinContext);
+
+            // The upgrade writes to the db, so refetch to determine whether it actually took effect.
+            var refreshed = await GetIdentityConnectionRegistrationInternalAsync(identity.OdinId);
+            return !refreshed.AccessGrant.RequiresMasterKeyEncryptionUpgrade();
+        }
+
         private async Task<bool> UpgradeMasterKeyStoreKeyEncryptionIfNeededInternalAsync(IdentityConnectionRegistration identity,
             IOdinContext odinContext)
         {


### PR DESCRIPTION
## Problem

The V7→V8 migration crashed with a `NullReferenceException`:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at CircleNetworkService.GrantCircleAsync(...) line 429
   at V7ToV8VersionMigrationService.EnsureMomentsDriveIsConfiguredForConnectionCircles(...)
   at VersionUpgradeService.UpgradeAsync(...)
```

`EnsureMomentsDriveIsConfiguredForConnectionCircles` re-grants system circles for every connected identity. But identities whose access grant was established **without the owner's master key** (e.g. introduction-based connections) have a null `AccessGrant.MasterKeyEncryptedKeyStoreKey`. `GrantCircleAsync` then dereferences it (`...MasterKeyEncryptedKeyStoreKey.DecryptKeyClone(masterKey)`), throwing an NRE that took down the entire migration batch (single stacked transaction).

There's already an explicit predicate for this state — `AccessExchangeGrant.RequiresMasterKeyEncryptionUpgrade()` — and a lazy upgrade path (`UpgradeMasterKeyStoreKeyEncryptionIfNeededInternalAsync`) that recovers the keystore key from the ECC-encrypted `TempWeakKeyStoreKey` and re-encrypts it under the master key.

## Changes

**1. Guard + inline upgrade in the migration** (`204890eb2`)
- In `EnsureMomentsDriveIsConfiguredForConnectionCircles`, attempt the master-key store-key encryption upgrade before re-granting (the migration already holds the master key). Mirrors the established `UpdateCircleDefinitionAsync` pattern.
- Identities that still can't be upgraded (e.g. no `TempWeakKeyStoreKey`) are skipped with a warning instead of NRE'ing, and self-heal later via the lazy circle-definition reconcile path.
- Added public `CircleNetworkService.TryUpgradeMasterKeyStoreKeyEncryptionAsync` wrapping the existing internal upgrade and reporting whether the identity is safe to grant.

**2. Pipeline-level pre-pass** (`69f11c6bd`)
- Run a master-key encryption pass over all connected identities at the top of `VersionUpgradeService.UpgradeAsync`, before the version ladder, in its own committed transaction.
- Establishes the "identities are on the current encryption scheme" invariant for the whole pipeline — current and future migrations — rather than per-migration.
- Committed independently so the upgrade persists even if a later version migration fails and rolls back (it isn't version-specific).
- The inline guard from change 1 stays as defense-in-depth.
- Added `CircleNetworkService.UpgradeMasterKeyStoreKeyEncryptionForConnectedIdentitiesAsync`.

## Testing

- `dotnet build` clean.
- `VersionUpgradeTests` passes (1/1) — confirms the new `CircleNetworkService` dependency resolves via DI and the pre-pass runs cleanly without perturbing the existing error-log assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)