### PR TITLE
Gate connection-management ops on ManageContacts instead of master key

### DIFF
--- a/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
+++ b/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
@@ -159,7 +159,7 @@ namespace Odin.Services.Membership.Connections
         /// </summary>
         public async Task<bool> DisconnectAsync(OdinId odinId, IOdinContext odinContext)
         {
-            odinContext.AssertCanManageConnections();
+            odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.ManageContacts);
 
             var info = await this.GetIcrAsync(odinId, odinContext);
             if (info is { Status: ConnectionStatus.Connected })
@@ -183,7 +183,7 @@ namespace Odin.Services.Membership.Connections
         /// </summary>
         public async Task<bool> BlockAsync(OdinId odinId, IOdinContext odinContext)
         {
-            odinContext.AssertCanManageConnections();
+            odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.ManageContacts);
 
             var info = await this.GetIcrAsync(odinId, odinContext);
 
@@ -248,7 +248,7 @@ namespace Odin.Services.Membership.Connections
         /// </summary>
         public async Task<bool> UnblockAsync(OdinId odinId, IOdinContext odinContext)
         {
-            odinContext.AssertCanManageConnections();
+            odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.ManageContacts);
 
             var info = await this.GetIcrAsync(odinId, odinContext);
             if (info.Status == ConnectionStatus.Blocked)

--- a/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
+++ b/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
@@ -187,7 +187,14 @@ namespace Odin.Services.Membership.Connections
 
             var info = await this.GetIcrAsync(odinId, odinContext);
 
-            //TODO: when you block a connection, you must also destroy exchange grant
+            // NOTE: blocking intentionally retains the AccessGrant rather than destroying it.
+            // A blocked identity is already denied everywhere because every auth path gates on
+            // connection status, not merely on token/grant validity: peer/transit via
+            // CreateTransitPermissionContextAsync's IsConnected() check, and guest/YouAuth via
+            // TryCreateConnectedYouAuthContextAsync (explicit Blocked short-circuit) and
+            // HomeAuthenticatorService's isConnected gate. Keeping the grant intact is what lets
+            // UnblockAsync restore the prior connection without a fresh connection request; revoking
+            // it here would force unblock to always fall through to ConnectionStatus.None.
 
             if (info.Status == ConnectionStatus.Connected)
             {

--- a/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkRequestService.cs
+++ b/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkRequestService.cs
@@ -639,7 +639,7 @@ namespace Odin.Services.Membership.Connections.Requests
         /// </summary>
         public Task DeleteSentRequest(OdinId recipient, IOdinContext odinContext)
         {
-            odinContext.AssertCanManageConnections();
+            odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.ManageContacts);
             return DeleteSentRequestInternalAsync(recipient);
         }
 
@@ -1067,7 +1067,7 @@ namespace Odin.Services.Membership.Connections.Requests
         /// </summary>
         public Task DeletePendingRequest(OdinId sender, IOdinContext odinContext)
         {
-            odinContext.AssertCanManageConnections();
+            odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.ManageContacts);
             return DeletePendingRequestInternal(sender);
         }
 

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/ConnectionManagementPermissionTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/ConnectionManagementPermissionTests.cs
@@ -1,0 +1,141 @@
+#nullable enable
+using System.Collections;
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core.Identity;
+using Odin.Hosting.Tests._V2.ApiClient;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Authorization.Permissions;
+using Odin.Services.Drives;
+
+namespace Odin.Hosting.Tests.V2.Ported.Connections;
+
+/// <summary>
+/// Verifies the authorization boundary on the connection-management operations whose service-layer
+/// gate was changed from owner+master-key (AssertCanManageConnections) to
+/// AssertHasPermission(PermissionKeys.ManageContacts):
+///   - Block        (CircleNetworkService.BlockAsync)
+///   - Disconnect   (CircleNetworkService.DisconnectAsync)
+///   - CancelOutgoing / DeleteSentRequest (CircleNetworkRequestService.DeleteSentRequest)
+///
+/// The permission assert runs at the top of each service method, before any state logic, and all
+/// three operations are no-op-safe (block-stranger -> Blocked, disconnect-when-not-connected -> 200,
+/// delete-nonexistent-sent-request -> 204). So we exercise the gate directly without establishing a
+/// connection: the only thing varying the outcome is the caller's permission set. Allowed callers
+/// get a 2xx (200 for block/disconnect, 204 for the request-delete); a caller lacking ManageContacts
+/// gets 403.
+/// </summary>
+public class ConnectionManagementPermissionTests : V2Fixture
+{
+    protected override string[] HostIdentities => [Identities.Frodo];
+
+    private static readonly OdinId Target = (OdinId)Identities.Sam;
+
+    // permissionKeys == null  => Owner caller (owner holds PermissionKeys.All, includes ManageContacts)
+    // permissionKeys != null  => App caller granted exactly those keys
+    public static IEnumerable AllowedCallers()
+    {
+        yield return new object[] { "Owner", default(int[])! };
+        yield return new object[] { "App[ManageContacts]", new[] { PermissionKeys.ManageContacts } };
+    }
+
+    public static IEnumerable DeniedCallers()
+    {
+        yield return new object[] { "App[ReadConnections]", new[] { PermissionKeys.ReadConnections } };
+        yield return new object[] { "App[none]", new int[0] };
+    }
+
+    private async Task<IV2Caller> BuildCallerAsync(OwnerSession owner, int[]? appPermissionKeys)
+    {
+        if (appPermissionKeys is null)
+        {
+            return owner;
+        }
+
+        // The app caller needs a drive grant to register against; the drive itself is irrelevant to
+        // these connection operations, so use a throwaway drive with no drive permission.
+        var drive = TargetDrive.NewTargetDrive();
+        await owner.Admin.CreateDrive(drive, "perm-test-drive", allowAnonymousReads: false);
+        return await AppSession.SetupAsync(owner, drive, DrivePermission.None, appPermissionKeys);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(AllowedCallers))]
+    public async Task Block_Allowed_WhenCallerHasManageContacts(string label, int[]? appPermissionKeys)
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var caller = await BuildCallerAsync(owner, appPermissionKeys);
+        var client = new V2ConnectionNetworkClient(caller.Identity, caller.Factory);
+
+        var response = await client.BlockAsync(Target);
+
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"{label}: expected 2xx, got {response.StatusCode}");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(DeniedCallers))]
+    public async Task Block_Forbidden_WhenCallerLacksManageContacts(string label, int[]? appPermissionKeys)
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var caller = await BuildCallerAsync(owner, appPermissionKeys);
+        var client = new V2ConnectionNetworkClient(caller.Identity, caller.Factory);
+
+        var response = await client.BlockAsync(Target);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden), $"{label}: got {response.StatusCode}");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(AllowedCallers))]
+    public async Task Disconnect_Allowed_WhenCallerHasManageContacts(string label, int[]? appPermissionKeys)
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var caller = await BuildCallerAsync(owner, appPermissionKeys);
+        var client = new V2ConnectionNetworkClient(caller.Identity, caller.Factory);
+
+        var response = await client.DisconnectAsync(Target);
+
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"{label}: expected 2xx, got {response.StatusCode}");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(DeniedCallers))]
+    public async Task Disconnect_Forbidden_WhenCallerLacksManageContacts(string label, int[]? appPermissionKeys)
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var caller = await BuildCallerAsync(owner, appPermissionKeys);
+        var client = new V2ConnectionNetworkClient(caller.Identity, caller.Factory);
+
+        var response = await client.DisconnectAsync(Target);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden), $"{label}: got {response.StatusCode}");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(AllowedCallers))]
+    public async Task CancelOutgoingRequest_Allowed_WhenCallerHasManageContacts(string label, int[]? appPermissionKeys)
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var caller = await BuildCallerAsync(owner, appPermissionKeys);
+        var client = new V2ConnectionRequestsClient(caller.Identity, caller.Factory);
+
+        var response = await client.CancelOutgoingRequestAsync(Target);
+
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"{label}: expected 2xx, got {response.StatusCode}");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(DeniedCallers))]
+    public async Task CancelOutgoingRequest_Forbidden_WhenCallerLacksManageContacts(string label, int[]? appPermissionKeys)
+    {
+        var owner = await LoginAsOwner(Identities.Frodo);
+        var caller = await BuildCallerAsync(owner, appPermissionKeys);
+        var client = new V2ConnectionRequestsClient(caller.Identity, caller.Factory);
+
+        var response = await client.CancelOutgoingRequestAsync(Target);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden), $"{label}: got {response.StatusCode}");
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IConnectionNetworkHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IConnectionNetworkHttpClientApiV2.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Odin.Hosting.Controllers;
 using Odin.Hosting.UnifiedV2;
 using Odin.Hosting.UnifiedV2.Connections;
 using Refit;
@@ -12,4 +14,13 @@ public interface IConnectionNetworkHttpClientApiV2
 
     [Get(Root + "/circles/with-members")]
     Task<ApiResponse<List<CircleWithMembers>>> GetCirclesWithMembers(bool includeSystemCircle = true);
+
+    [Post(Root + "/block")]
+    Task<ApiResponse<HttpContent>> Block([Body] OdinIdRequest request);
+
+    [Post(Root + "/unblock")]
+    Task<ApiResponse<HttpContent>> Unblock([Body] OdinIdRequest request);
+
+    [Post(Root + "/disconnect")]
+    Task<ApiResponse<HttpContent>> Disconnect([Body] OdinIdRequest request);
 }

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IConnectionRequestsHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IConnectionRequestsHttpClientApiV2.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Threading.Tasks;
 using Odin.Hosting.UnifiedV2;
 using Odin.Services.Membership.Connections.Requests;
@@ -11,4 +12,7 @@ public interface IConnectionRequestsHttpClientApiV2
 
     [Post(Root + "/requests/auto-connect")]
     Task<ApiResponse<ConnectionRequestResult>> AutoConnect([Body] ConnectionRequestHeader header);
+
+    [Delete(Root + "/requests/outgoing/{recipientId}")]
+    Task<ApiResponse<HttpContent>> CancelOutgoingRequest(string recipientId);
 }

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/V2ConnectionNetworkClient.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/V2ConnectionNetworkClient.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Odin.Core.Identity;
+using Odin.Hosting.Controllers;
 using Odin.Hosting.Tests._Universal.ApiClient.Factory;
 using Odin.Hosting.UnifiedV2.Connections;
 using Refit;
@@ -14,5 +16,26 @@ public class V2ConnectionNetworkClient(OdinId identity, IApiClientFactory factor
         var client = factory.CreateHttpClient(identity, out var sharedSecret);
         var svc = RefitCreator.RestServiceFor<IConnectionNetworkHttpClientApiV2>(client, sharedSecret);
         return await svc.GetCirclesWithMembers(includeSystemCircle);
+    }
+
+    public async Task<ApiResponse<HttpContent>> BlockAsync(OdinId odinId)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IConnectionNetworkHttpClientApiV2>(client, sharedSecret);
+        return await svc.Block(new OdinIdRequest { OdinId = odinId });
+    }
+
+    public async Task<ApiResponse<HttpContent>> UnblockAsync(OdinId odinId)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IConnectionNetworkHttpClientApiV2>(client, sharedSecret);
+        return await svc.Unblock(new OdinIdRequest { OdinId = odinId });
+    }
+
+    public async Task<ApiResponse<HttpContent>> DisconnectAsync(OdinId odinId)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IConnectionNetworkHttpClientApiV2>(client, sharedSecret);
+        return await svc.Disconnect(new OdinIdRequest { OdinId = odinId });
     }
 }

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/V2ConnectionRequestsClient.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/V2ConnectionRequestsClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Threading.Tasks;
 using Odin.Core.Identity;
 using Odin.Hosting.Tests._Universal.ApiClient.Factory;
@@ -13,5 +14,13 @@ public class V2ConnectionRequestsClient(OdinId identity, IApiClientFactory facto
         var client = factory.CreateHttpClient(identity, out var sharedSecret);
         var svc = RefitCreator.RestServiceFor<IConnectionRequestsHttpClientApiV2>(client, sharedSecret);
         return await svc.AutoConnect(header);
+    }
+
+    // DELETE /requests/outgoing/{recipientId} -> CircleNetworkRequestService.DeleteSentRequest
+    public async Task<ApiResponse<HttpContent>> CancelOutgoingRequestAsync(OdinId recipient)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<IConnectionRequestsHttpClientApiV2>(client, sharedSecret);
+        return await svc.CancelOutgoingRequest(recipient.DomainName);
     }
 }


### PR DESCRIPTION
## Summary

Five connection-management service methods required `AssertCanManageConnections()` (owner + master key). None of them use the master key **cryptographically** — it was purely an authorization gate. This relaxes them to `AssertHasPermission(PermissionKeys.ManageContacts)` so a `ManageContacts`-granted app can perform them. The owner still passes because the owner holds `PermissionKeys.All` (which includes `ManageContacts`).

Methods changed:
- `CircleNetworkService.DisconnectAsync`
- `CircleNetworkService.BlockAsync`
- `CircleNetworkService.UnblockAsync`
- `CircleNetworkRequestService.DeleteSentRequest`
- `CircleNetworkRequestService.DeletePendingRequest`

Left on the old owner+master-key gate (they genuinely consume the master key to build `MasterKeyEncryptedKeyStoreKey` / access grants):
- `CircleNetworkRequestService.SendConnectionRequestAsync`
- `CircleNetworkRequestService.HandleConnectionRequestInternalForIdentityOwnerAsync`

## Why this is safe

- The permission assert runs at the top of each method, before any state logic.
- None of the five pass master-key bytes into any encrypt/decrypt — verified each call path.
- The read side (`GetConnectedIdentities`, `GetBlockedProfiles`, etc.) already uses permission-key checks (`ReadConnections`/`ReadConnectionRequests`), so this aligns the write side with that model.

## Tests

`Odin.Hosting.Tests.V2/Ported/Connections/ConnectionManagementPermissionTests.cs` — covers Block + Disconnect + CancelOutgoingRequest (DeleteSentRequest) across a 4-way caller matrix:

| Caller | Block / Disconnect | CancelOutgoing |
|---|---|---|
| Owner | 200 | 204 |
| App w/ `ManageContacts` | 200 | 204 |
| App w/ `ReadConnections` only | 403 | 403 |
| App w/ no perms | 403 | 403 |

12 cases, all passing. Also adds the V2 client methods these tests needed (`block`/`unblock`/`disconnect` on `V2ConnectionNetworkClient`; cancel-outgoing on `V2ConnectionRequestsClient`).

## Block / exchange-grant TODO (resolved as docs)

`BlockAsync` previously carried `//TODO: when you block a connection, you must also destroy exchange grant`. Investigated and confirmed this is **not** an active hole: a `Blocked` identity is already denied on every auth path because they all gate on connection status, not just token/grant validity —

- peer/transit: `CreateTransitPermissionContextAsync` `IsConnected()` check
- YouAuth: `TryCreateConnectedYouAuthContextAsync` explicit `Blocked` short-circuit
- guest/Home: `HomeAuthenticatorService` `isConnected` gate

Retaining the grant is also deliberate: it's what lets `UnblockAsync` restore the prior connection without a fresh connection request. Revoking it on block would force unblock to always fall through to `None`. Replaced the TODO with a note documenting this; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)