### PR TITLE
Add WebSocket push events for connection and circle state changes

### DIFF
--- a/src/apps/Odin.Hosting/TenantServices.cs
+++ b/src/apps/Odin.Hosting/TenantServices.cs
@@ -160,6 +160,8 @@ public static class TenantServices
             .As<INotificationHandler<ReactionPreviewUpdatedNotification>>()
             .As<INotificationHandler<AppNotificationAddedNotification>>()
             .As<INotificationHandler<ConnectionFinalizedNotification>>()
+            .As<INotificationHandler<ConnectionChangedNotification>>()
+            .As<INotificationHandler<CircleDefinitionChangedNotification>>()
             .AsSelf()
             .InstancePerLifetimeScope();
 

--- a/src/services/Odin.Services/AppNotifications/ClientNotifications/CircleDefinitionChangedNotification.cs
+++ b/src/services/Odin.Services/AppNotifications/ClientNotifications/CircleDefinitionChangedNotification.cs
@@ -1,0 +1,46 @@
+using System;
+using Odin.Core.Serialization;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Mediator;
+
+namespace Odin.Services.AppNotifications.ClientNotifications
+{
+    public enum CircleDefinitionChangeType
+    {
+        Created = 1,
+        Updated = 2,
+        Deleted = 3,
+        Enabled = 4,
+        Disabled = 5
+    }
+
+    /// <summary>
+    /// Pushed to the owner's own sessions when a circle definition is created, renamed/re-permissioned (updated),
+    /// deleted, enabled, or disabled.  Lets other devices invalidate their cached circle definitions and re-fetch.
+    /// </summary>
+    public class CircleDefinitionChangedNotification : MediatorNotificationBase, IClientNotification
+    {
+        public ClientNotificationType NotificationType { get; } = ClientNotificationType.CircleDefinitionChanged;
+
+        public Guid NotificationTypeId { get; } = Guid.Parse("b7c3e6d2-1a48-4f9b-bc25-7e3a9d0f5c18");
+
+        /// <summary>
+        /// The circle definition that changed
+        /// </summary>
+        public Guid CircleId { get; init; }
+
+        /// <summary>
+        /// What changed about the circle definition
+        /// </summary>
+        public CircleDefinitionChangeType Change { get; init; }
+
+        public string GetClientData()
+        {
+            return OdinSystemSerializer.Serialize(new
+            {
+                CircleId = this.CircleId,
+                Change = this.Change.ToString()
+            });
+        }
+    }
+}

--- a/src/services/Odin.Services/AppNotifications/ClientNotifications/ConnectionChangedNotification.cs
+++ b/src/services/Odin.Services/AppNotifications/ClientNotifications/ConnectionChangedNotification.cs
@@ -1,0 +1,55 @@
+using System;
+using Odin.Core.Identity;
+using Odin.Core.Serialization;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Mediator;
+
+namespace Odin.Services.AppNotifications.ClientNotifications
+{
+    public enum ConnectionChangeType
+    {
+        Disconnected = 1,
+        Blocked = 2,
+        Unblocked = 3,
+        CircleGranted = 4,
+        CircleRevoked = 5
+    }
+
+    /// <summary>
+    /// Pushed to the owner's own sessions when an existing connection's state changes (disconnect/block/unblock)
+    /// or a circle is granted/revoked to that connection.  Lets other devices invalidate their cached connection
+    /// state and re-fetch the affected identity.
+    /// </summary>
+    public class ConnectionChangedNotification : MediatorNotificationBase, IClientNotification
+    {
+        public ClientNotificationType NotificationType { get; } = ClientNotificationType.ConnectionChanged;
+
+        public Guid NotificationTypeId { get; } = Guid.Parse("4f8d2a1c-9b3e-4c7a-8f21-2d6b5e9c1a40");
+
+        /// <summary>
+        /// The connection that changed
+        /// </summary>
+        public OdinId OdinId { get; init; }
+
+        /// <summary>
+        /// What changed about the connection
+        /// </summary>
+        public ConnectionChangeType Change { get; init; }
+
+        /// <summary>
+        /// The affected circle when <see cref="Change"/> is <see cref="ConnectionChangeType.CircleGranted"/> or
+        /// <see cref="ConnectionChangeType.CircleRevoked"/>; otherwise null.
+        /// </summary>
+        public Guid? CircleId { get; init; }
+
+        public string GetClientData()
+        {
+            return OdinSystemSerializer.Serialize(new
+            {
+                Identity = this.OdinId.DomainName,
+                Change = this.Change.ToString(),
+                CircleId = this.CircleId
+            });
+        }
+    }
+}

--- a/src/services/Odin.Services/AppNotifications/WebSocket/ClientNotificationType.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/ClientNotificationType.cs
@@ -29,6 +29,14 @@ public enum ClientNotificationType
     /// </summary>
     TemporalDriveAccessed = 5001,
     /// <summary>
+    /// An existing connection's state changed (disconnect/block/unblock) or a circle was granted/revoked to it.
+    /// </summary>
+    ConnectionChanged = 5002,
+    /// <summary>
+    /// A circle definition was created, updated, deleted, enabled, or disabled.
+    /// </summary>
+    CircleDefinitionChanged = 5003,
+    /// <summary>
     /// Indicates the notification doesnt need this value.  Note: this implies we might be able to dorp this field all together
     /// </summary>
     Unused = 8001,

--- a/src/services/Odin.Services/Membership/CircleMembership/CircleMembershipService.cs
+++ b/src/services/Odin.Services/Membership/CircleMembership/CircleMembershipService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Odin.Core;
 using Odin.Core.Exceptions;
@@ -11,6 +12,7 @@ using Odin.Core.Storage.Database.Identity;
 using Odin.Core.Storage.Database.Identity.Table;
 using Odin.Core.Time;
 using Odin.Core.Util;
+using Odin.Services.AppNotifications.ClientNotifications;
 using Odin.Services.Authorization.Apps;
 using Odin.Services.Authorization.ExchangeGrants;
 using Odin.Services.Authorization.Permissions;
@@ -30,6 +32,7 @@ public class CircleMembershipService(
     CircleDefinitionService circleDefinitionService,
     ExchangeGrantService exchangeGrantService,
     ILogger<CircleMembershipService> logger,
+    IMediator mediator,
     IdentityDatabase db)
 {
     public async Task Temp_ReconcileCircleAndAppGrants()
@@ -290,6 +293,13 @@ public class CircleMembershipService(
     {
         odinContext.Caller.AssertHasMasterKey();
         await circleDefinitionService.CreateAsync(request);
+
+        await mediator.Publish(new CircleDefinitionChangedNotification
+        {
+            OdinContext = odinContext,
+            CircleId = request.Id,
+            Change = CircleDefinitionChangeType.Created,
+        });
     }
 
     /// <summary>
@@ -343,6 +353,13 @@ public class CircleMembershipService(
         circle.Disabled = true;
         circle.LastUpdated = UnixTimeUtc.Now().milliseconds;
         await circleDefinitionService.UpdateAsync(circle);
+
+        await mediator.Publish(new CircleDefinitionChangedNotification
+        {
+            OdinContext = odinContext,
+            CircleId = circleId.Value,
+            Change = CircleDefinitionChangeType.Disabled,
+        });
     }
 
     /// <summary>
@@ -356,6 +373,13 @@ public class CircleMembershipService(
         circle.Disabled = false;
         circle.LastUpdated = UnixTimeUtc.Now().milliseconds;
         await circleDefinitionService.UpdateAsync(circle);
+
+        await mediator.Publish(new CircleDefinitionChangedNotification
+        {
+            OdinContext = odinContext,
+            CircleId = circleId.Value,
+            Change = CircleDefinitionChangeType.Enabled,
+        });
     }
 
     /// <summary>

--- a/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
+++ b/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
@@ -13,6 +13,7 @@ using Odin.Core.Serialization;
 using Odin.Core.Storage.Concurrency;
 using Odin.Core.Storage.Database.Identity;
 using Odin.Core.Util;
+using Odin.Services.AppNotifications.ClientNotifications;
 using Odin.Services.AppNotifications.SystemNotifications;
 using Odin.Services.Authorization.Acl;
 using Odin.Services.Authorization.Apps;
@@ -172,6 +173,13 @@ namespace Odin.Services.Membership.Connections
                     OdinId = odinId,
                 });
 
+                await mediator.Publish(new ConnectionChangedNotification
+                {
+                    OdinContext = odinContext,
+                    OdinId = odinId,
+                    Change = ConnectionChangeType.Disconnected,
+                });
+
                 return true;
             }
 
@@ -208,6 +216,13 @@ namespace Odin.Services.Membership.Connections
                     OdinId = odinId,
                 });
 
+                await mediator.Publish(new ConnectionChangedNotification
+                {
+                    OdinContext = odinContext,
+                    OdinId = odinId,
+                    Change = ConnectionChangeType.Blocked,
+                });
+
                 return true;
             }
 
@@ -224,6 +239,12 @@ namespace Odin.Services.Membership.Connections
                     OdinId = odinId,
                 });
 
+                await mediator.Publish(new ConnectionChangedNotification
+                {
+                    OdinContext = odinContext,
+                    OdinId = odinId,
+                    Change = ConnectionChangeType.Blocked,
+                });
 
                 return true;
             }
@@ -262,15 +283,16 @@ namespace Odin.Services.Membership.Connections
             {
                 bool isValid = info.AccessGrant?.IsValid() ?? false;
 
-                if (isValid)
-                {
-                    info.Status = ConnectionStatus.Connected;
-                    await this.SaveIcrAsync(info, odinContext);
-                    return true;
-                }
-
-                info.Status = ConnectionStatus.None;
+                info.Status = isValid ? ConnectionStatus.Connected : ConnectionStatus.None;
                 await this.SaveIcrAsync(info, odinContext);
+
+                await mediator.Publish(new ConnectionChangedNotification
+                {
+                    OdinContext = odinContext,
+                    OdinId = odinId,
+                    Change = ConnectionChangeType.Unblocked,
+                });
+
                 return true;
             }
 
@@ -453,6 +475,14 @@ namespace Odin.Services.Membership.Connections
 
             keyStoreKey.Wipe();
             await this.SaveIcrAsync(icr, odinContext);
+
+            await mediator.Publish(new ConnectionChangedNotification
+            {
+                OdinContext = odinContext,
+                OdinId = odinId,
+                CircleId = circleId.Value,
+                Change = ConnectionChangeType.CircleGranted,
+            });
         }
 
         /// <summary>
@@ -483,6 +513,14 @@ namespace Odin.Services.Membership.Connections
             }
 
             await this.SaveIcrAsync(icr, odinContext);
+
+            await mediator.Publish(new ConnectionChangedNotification
+            {
+                OdinContext = odinContext,
+                OdinId = odinId,
+                CircleId = circleId.Value,
+                Change = ConnectionChangeType.CircleRevoked,
+            });
         }
 
         public async Task<Dictionary<Guid, Dictionary<Guid, AppCircleGrant>>> CreateAppCircleGrantListWithSystemCircle(
@@ -591,6 +629,13 @@ namespace Odin.Services.Membership.Connections
 
             await circleMembershipService.UpdateAsync(circleDef, odinContext);
 
+            await mediator.Publish(new CircleDefinitionChangedNotification
+            {
+                OdinContext = odinContext,
+                CircleId = circleDef.Id.Value,
+                Change = CircleDefinitionChangeType.Updated,
+            });
+
             //TODO: determine how to handle invalidMembers - do we return to the UI?  do we remove from all circles?
         }
 
@@ -628,6 +673,13 @@ namespace Odin.Services.Membership.Connections
             }
 
             await circleMembershipService.DeleteAsync(circleId, odinContext);
+
+            await mediator.Publish(new CircleDefinitionChangedNotification
+            {
+                OdinContext = odinContext,
+                CircleId = circleId.Value,
+                Change = CircleDefinitionChangeType.Deleted,
+            });
         }
 
         public async Task Handle(DriveDefinitionAddedNotification notification, CancellationToken cancellationToken)

--- a/tests/apps/Odin.Hosting.Tests/_Universal/ApiClient/Connections/UniversalCircleNetworkApiClient.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/ApiClient/Connections/UniversalCircleNetworkApiClient.cs
@@ -69,6 +69,36 @@ public class UniversalCircleNetworkApiClient(OdinId identity, IApiClientFactory 
         }
     }
 
+    public async Task<ApiResponse<HttpContent>> DeleteCircleDefinition(GuidId circleId)
+    {
+        var client = factory.CreateHttpClient(identity, out var ownerSharedSecret);
+        {
+            var svc = RefitCreator.RestServiceFor<IRefitUniversalCircleDefinition>(client, ownerSharedSecret);
+            var response = await svc.DeleteCircleDefinition(circleId);
+            return response;
+        }
+    }
+
+    public async Task<ApiResponse<HttpContent>> EnableCircleDefinition(GuidId circleId)
+    {
+        var client = factory.CreateHttpClient(identity, out var ownerSharedSecret);
+        {
+            var svc = RefitCreator.RestServiceFor<IRefitUniversalCircleDefinition>(client, ownerSharedSecret);
+            var response = await svc.EnableCircleDefinition(circleId);
+            return response;
+        }
+    }
+
+    public async Task<ApiResponse<HttpContent>> DisableCircleDefinition(GuidId circleId)
+    {
+        var client = factory.CreateHttpClient(identity, out var ownerSharedSecret);
+        {
+            var svc = RefitCreator.RestServiceFor<IRefitUniversalCircleDefinition>(client, ownerSharedSecret);
+            var response = await svc.DisableCircleDefinition(circleId);
+            return response;
+        }
+    }
+
     public async Task<ApiResponse<HttpContent>> GrantCircle(Guid circleId, OdinId odinId)
     {
         var client = factory.CreateHttpClient(identity, out var ownerSharedSecret);

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/CircleDefinitionNotificationTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/CircleDefinitionNotificationTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Odin.Core;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Services.AppNotifications.ClientNotifications;
+using Odin.Services.Authorization.Permissions;
+using Odin.Services.Base;
+
+namespace Odin.Hosting.Tests._Universal.AppNotifications;
+
+// Verifies that circle-definition mutations (create/update/enable/disable/delete) push a
+// CircleDefinitionChanged (5003) notification to the owner's own connected sessions, so other
+// devices can invalidate their cached circle definitions. Single identity: the WebSocket listener
+// is simply a second session of the same owner performing the mutation.
+public class CircleDefinitionNotificationTests
+{
+    private WebScaffold _scaffold;
+
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = MethodBase.GetCurrentMethod()!.DeclaringType!.Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: new List<TestIdentity> { TestIdentities.Frodo });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _scaffold.RunAfterAnyTests();
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [TearDown]
+    public void TearDown() => _scaffold.AssertLogEvents();
+
+    private static PermissionSetGrantRequest SimpleGrant() =>
+        new() { PermissionSet = new(PermissionKeys.AllowIntroductions) };
+
+    [Test]
+    public async Task CreateCircleDefinition_PushesCreatedToOwnerSessions()
+    {
+        var frodo = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+        var handler = new ConnectionCircleNotificationSocketHandler();
+        await handler.ConnectAsync(frodo);
+        try
+        {
+            var circleId = Guid.NewGuid();
+            var response = await frodo.Network.CreateCircle(circleId, "ws-create-circle", SimpleGrant());
+            ClassicAssert.IsTrue(response.IsSuccessStatusCode);
+
+            var evt = await handler.WaitForCircleDefinitionChange(
+                CircleDefinitionChangeType.Created, circleId, WaitTimeout);
+            ClassicAssert.IsNotNull(evt, "Expected a CircleDefinitionChanged{Created} notification");
+            ClassicAssert.AreEqual(circleId, evt.CircleId);
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task UpdateCircleDefinition_PushesUpdatedToOwnerSessions()
+    {
+        var frodo = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+
+        var circleId = Guid.NewGuid();
+        var createResponse = await frodo.Network.CreateCircle(circleId, "ws-update-circle", SimpleGrant());
+        ClassicAssert.IsTrue(createResponse.IsSuccessStatusCode);
+
+        var handler = new ConnectionCircleNotificationSocketHandler();
+        await handler.ConnectAsync(frodo);
+        try
+        {
+            var definition = (await frodo.Network.GetCircleDefinition(circleId)).Content;
+            ClassicAssert.IsNotNull(definition);
+            definition.Name = "ws-update-circle-renamed";
+
+            var updateResponse = await frodo.Network.UpdateCircleDefinition(definition);
+            ClassicAssert.IsTrue(updateResponse.IsSuccessStatusCode);
+
+            var evt = await handler.WaitForCircleDefinitionChange(
+                CircleDefinitionChangeType.Updated, circleId, WaitTimeout);
+            ClassicAssert.IsNotNull(evt, "Expected a CircleDefinitionChanged{Updated} notification");
+            ClassicAssert.AreEqual(circleId, evt.CircleId);
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task DisableAndEnableCircleDefinition_PushesDisabledThenEnabled()
+    {
+        var frodo = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+
+        var circleId = Guid.NewGuid();
+        var createResponse = await frodo.Network.CreateCircle(circleId, "ws-toggle-circle", SimpleGrant());
+        ClassicAssert.IsTrue(createResponse.IsSuccessStatusCode);
+
+        var handler = new ConnectionCircleNotificationSocketHandler();
+        await handler.ConnectAsync(frodo);
+        try
+        {
+            var disableResponse = await frodo.Network.DisableCircleDefinition(new GuidId(circleId));
+            ClassicAssert.IsTrue(disableResponse.IsSuccessStatusCode);
+
+            var disabled = await handler.WaitForCircleDefinitionChange(
+                CircleDefinitionChangeType.Disabled, circleId, WaitTimeout);
+            ClassicAssert.IsNotNull(disabled, "Expected a CircleDefinitionChanged{Disabled} notification");
+
+            var enableResponse = await frodo.Network.EnableCircleDefinition(new GuidId(circleId));
+            ClassicAssert.IsTrue(enableResponse.IsSuccessStatusCode);
+
+            var enabled = await handler.WaitForCircleDefinitionChange(
+                CircleDefinitionChangeType.Enabled, circleId, WaitTimeout);
+            ClassicAssert.IsNotNull(enabled, "Expected a CircleDefinitionChanged{Enabled} notification");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task DeleteCircleDefinition_PushesDeletedToOwnerSessions()
+    {
+        var frodo = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+
+        var circleId = Guid.NewGuid();
+        var createResponse = await frodo.Network.CreateCircle(circleId, "ws-delete-circle", SimpleGrant());
+        ClassicAssert.IsTrue(createResponse.IsSuccessStatusCode);
+
+        var handler = new ConnectionCircleNotificationSocketHandler();
+        await handler.ConnectAsync(frodo);
+        try
+        {
+            var deleteResponse = await frodo.Network.DeleteCircleDefinition(new GuidId(circleId));
+            ClassicAssert.IsTrue(deleteResponse.IsSuccessStatusCode);
+
+            var evt = await handler.WaitForCircleDefinitionChange(
+                CircleDefinitionChangeType.Deleted, circleId, WaitTimeout);
+            ClassicAssert.IsNotNull(evt, "Expected a CircleDefinitionChanged{Deleted} notification");
+            ClassicAssert.AreEqual(circleId, evt.CircleId);
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ConnectionChangeNotificationTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ConnectionChangeNotificationTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Odin.Core;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Services.AppNotifications.ClientNotifications;
+using Odin.Services.Authorization.Permissions;
+using Odin.Services.Base;
+
+namespace Odin.Hosting.Tests._Universal.AppNotifications;
+
+// Verifies that connection state changes (circle grant/revoke, block/unblock, disconnect) push a
+// ConnectionChanged (5002) notification to the owner's own connected sessions, carrying the affected
+// identity and (for circle grant/revoke) the circle id. Each test uses a distinct peer so the shared
+// server's connection state does not couple tests together.
+public class ConnectionChangeNotificationTests
+{
+    private WebScaffold _scaffold;
+
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = MethodBase.GetCurrentMethod()!.DeclaringType!.Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: new List<TestIdentity>
+        {
+            TestIdentities.Frodo,
+            TestIdentities.Samwise,
+            TestIdentities.Merry,
+            TestIdentities.Pippin
+        });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _scaffold.RunAfterAnyTests();
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [TearDown]
+    public void TearDown() => _scaffold.AssertLogEvents();
+
+    private static async Task Connect(OwnerApiClientRedux a, OwnerApiClientRedux b)
+    {
+        await a.Connections.SendConnectionRequest(b.OdinId, []);
+        await b.Connections.AcceptConnectionRequest(a.OdinId);
+    }
+
+    [Test]
+    public async Task GrantAndRevokeCircle_PushesConnectionChangedWithCircleId()
+    {
+        var frodo = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+        var sam = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Samwise);
+
+        await Connect(frodo, sam);
+
+        // Create the circle before opening the socket so its CircleDefinitionChanged{Created}
+        // doesn't share the capture window with the ConnectionChanged events under test.
+        var circleId = Guid.NewGuid();
+        var createResponse = await frodo.Network.CreateCircle(circleId, "ws-grant-circle",
+            new PermissionSetGrantRequest { PermissionSet = new(PermissionKeys.AllowIntroductions) });
+        ClassicAssert.IsTrue(createResponse.IsSuccessStatusCode);
+
+        var handler = new ConnectionCircleNotificationSocketHandler();
+        await handler.ConnectAsync(frodo);
+        try
+        {
+            var grantResponse = await frodo.Network.GrantCircle(circleId, sam.OdinId);
+            ClassicAssert.IsTrue(grantResponse.IsSuccessStatusCode,
+                $"Grant failed: {grantResponse.StatusCode}");
+
+            var granted = await handler.WaitForConnectionChange(
+                ConnectionChangeType.CircleGranted, sam.OdinId, WaitTimeout);
+            ClassicAssert.IsNotNull(granted, "Expected a ConnectionChanged{CircleGranted} notification");
+            ClassicAssert.AreEqual(circleId, granted.CircleId);
+
+            var revokeResponse = await frodo.Network.RevokeCircle(circleId, sam.OdinId);
+            ClassicAssert.IsTrue(revokeResponse.IsSuccessStatusCode);
+
+            var revoked = await handler.WaitForConnectionChange(
+                ConnectionChangeType.CircleRevoked, sam.OdinId, WaitTimeout);
+            ClassicAssert.IsNotNull(revoked, "Expected a ConnectionChanged{CircleRevoked} notification");
+            ClassicAssert.AreEqual(circleId, revoked.CircleId);
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task BlockAndUnblock_PushesConnectionChanged()
+    {
+        var frodo = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+        var merry = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Merry);
+
+        await Connect(frodo, merry);
+
+        var handler = new ConnectionCircleNotificationSocketHandler();
+        await handler.ConnectAsync(frodo);
+        try
+        {
+            var blockResponse = await frodo.Network.BlockConnection(merry.OdinId);
+            ClassicAssert.IsTrue(blockResponse.IsSuccessStatusCode);
+
+            var blocked = await handler.WaitForConnectionChange(
+                ConnectionChangeType.Blocked, merry.OdinId, WaitTimeout);
+            ClassicAssert.IsNotNull(blocked, "Expected a ConnectionChanged{Blocked} notification");
+            ClassicAssert.IsNull(blocked.CircleId);
+
+            var unblockResponse = await frodo.Network.UnblockConnection(merry.OdinId);
+            ClassicAssert.IsTrue(unblockResponse.IsSuccessStatusCode);
+
+            var unblocked = await handler.WaitForConnectionChange(
+                ConnectionChangeType.Unblocked, merry.OdinId, WaitTimeout);
+            ClassicAssert.IsNotNull(unblocked, "Expected a ConnectionChanged{Unblocked} notification");
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+
+    [Test]
+    public async Task Disconnect_PushesConnectionChanged()
+    {
+        var frodo = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Frodo);
+        var pippin = _scaffold.CreateOwnerApiClientRedux(TestIdentities.Pippin);
+
+        await Connect(frodo, pippin);
+
+        var handler = new ConnectionCircleNotificationSocketHandler();
+        await handler.ConnectAsync(frodo);
+        try
+        {
+            var disconnectResponse = await frodo.Network.DisconnectFrom(pippin.OdinId);
+            ClassicAssert.IsTrue(disconnectResponse.IsSuccessStatusCode);
+
+            var disconnected = await handler.WaitForConnectionChange(
+                ConnectionChangeType.Disconnected, pippin.OdinId, WaitTimeout);
+            ClassicAssert.IsNotNull(disconnected, "Expected a ConnectionChanged{Disconnected} notification");
+            ClassicAssert.IsNull(disconnected.CircleId);
+        }
+        finally
+        {
+            await handler.DisconnectAsync();
+        }
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ConnectionCircleNotificationSocketHandler.cs
+++ b/tests/apps/Odin.Hosting.Tests/_Universal/AppNotifications/ConnectionCircleNotificationSocketHandler.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Odin.Core.Serialization;
+using Odin.Hosting.Tests._Universal.ApiClient;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Services.AppNotifications.ClientNotifications;
+using Odin.Services.AppNotifications.WebSocket;
+
+namespace Odin.Hosting.Tests._Universal.AppNotifications;
+
+// Passive owner WebSocket listener that captures the connection/circle state-change notifications
+// (ConnectionChanged = 5002, CircleDefinitionChanged = 5003) pushed to the owner's own sessions.
+// Records every occurrence (no de-duplication) and parses the JSON-string Data payload so tests can
+// assert on the change kind plus the affected identity / circle id.
+public sealed class ConnectionCircleNotificationSocketHandler
+{
+    // Mirrors ConnectionChangedNotification.GetClientData()
+    public sealed class ConnectionChangedPayload
+    {
+        public string Identity { get; set; }
+        public string Change { get; set; }
+        public Guid? CircleId { get; set; }
+    }
+
+    // Mirrors CircleDefinitionChangedNotification.GetClientData()
+    public sealed class CircleDefinitionChangedPayload
+    {
+        public Guid CircleId { get; set; }
+        public string Change { get; set; }
+    }
+
+    private readonly TestOwnerWebSocketListener _listener = new();
+    private readonly ConcurrentQueue<ConnectionChangedPayload> _connectionEvents = new();
+    private readonly ConcurrentQueue<CircleDefinitionChangedPayload> _circleEvents = new();
+
+    public IReadOnlyList<ConnectionChangedPayload> ConnectionEvents => _connectionEvents.ToArray();
+    public IReadOnlyList<CircleDefinitionChangedPayload> CircleEvents => _circleEvents.ToArray();
+
+    public async Task ConnectAsync(OwnerApiClientRedux client)
+    {
+        _listener.NotificationReceived += OnNotificationReceived;
+
+        // Drive subscription is irrelevant for these client notifications (they fan out to every
+        // owner socket regardless of subscribed drives), so connect with an empty drive set.
+        await _listener.ConnectAsync(
+            client.Identity.OdinId,
+            client.GetTokenContext(),
+            new EstablishConnectionOptions { Drives = [] });
+    }
+
+    public Task DisconnectAsync() => _listener.DisconnectAsync();
+
+    private Task OnNotificationReceived(TestClientNotification notification)
+    {
+        switch (notification.NotificationType)
+        {
+            case ClientNotificationType.ConnectionChanged:
+                var cc = OdinSystemSerializer.Deserialize<ConnectionChangedPayload>(notification.Data);
+                if (cc != null)
+                {
+                    _connectionEvents.Enqueue(cc);
+                }
+
+                break;
+
+            case ClientNotificationType.CircleDefinitionChanged:
+                var cd = OdinSystemSerializer.Deserialize<CircleDefinitionChangedPayload>(notification.Data);
+                if (cd != null)
+                {
+                    _circleEvents.Enqueue(cd);
+                }
+
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Waits for a ConnectionChanged of the given kind for the given identity, or null on timeout.</summary>
+    public async Task<ConnectionChangedPayload> WaitForConnectionChange(
+        ConnectionChangeType change, string identity, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = ConnectionEvents.LastOrDefault(
+                e => e.Change == change.ToString() && string.Equals(e.Identity, identity, StringComparison.OrdinalIgnoreCase));
+            if (hit != null)
+            {
+                return hit;
+            }
+
+            await Task.Delay(50);
+        }
+
+        return null;
+    }
+
+    /// <summary>Waits for a CircleDefinitionChanged of the given kind for the given circle, or null on timeout.</summary>
+    public async Task<CircleDefinitionChangedPayload> WaitForCircleDefinitionChange(
+        CircleDefinitionChangeType change, Guid circleId, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var hit = CircleEvents.LastOrDefault(e => e.Change == change.ToString() && e.CircleId == circleId);
+            if (hit != null)
+            {
+                return hit;
+            }
+
+            await Task.Delay(50);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fan out two new IClientNotification types to the owner's own sessions so other devices/console don't go stale on changes made elsewhere:

- ConnectionChanged (5002): disconnect, block, unblock, circle grant/revoke on an existing connection; carries the affected identity and (for grant/revoke) the circle id.
- CircleDefinitionChanged (5003): circle definition create, update, delete, enable, disable; carries the circle id.

Published from CircleNetworkService (disconnect/block/unblock/grant/revoke, update/delete definition) and CircleMembershipService (create/enable/ disable definition; gains an IMediator dependency). The existing system notifications (ConnectionDeleted/ConnectionBlocked) are kept for cache cleanup and the new client-facing events are published additively.

Handlers in this codebase are registered per concrete notification type, so AppNotificationHandler is explicitly registered for the two new types in TenantServices; without this MediatR finds no handler and drops them.

Tests (Odin.Hosting.Tests/_Universal/AppNotifications): a WebSocket listener asserts each event reaches a second owner session with the correct change kind plus identity/circle id. Adds Delete/Enable/Disable circle-definition wrappers to UniversalCircleNetworkApiClient.