### PR TITLE
Temporal verify: return newest-file modified timestamp

### DIFF
--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndex.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndex.cs
@@ -226,6 +226,39 @@ public class TableDriveMainIndex(
         return (-1, -1);
     }
 
+    // FileState.Active (the enum lives in Odin.Services, which this layer cannot reference upward).
+    private const int ActiveFileState = 1;
+
+    internal async Task<long> GetNewestModifiedAsync(Guid driveId, int fileSystemType)
+    {
+        await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();
+        await using var cmd = cn.CreateCommand();
+
+        // Newest server-set modified timestamp of an active file on the drive (0 when the drive has none).
+        cmd.CommandText =
+            """
+            SELECT CAST(COALESCE(MAX(modified), 0) AS BIGINT)
+            FROM drivemainindex
+            WHERE identityId=@identityId AND driveId=@driveId AND fileSystemType=@fileSystemType AND fileState=@fileState;
+            """;
+
+        cmd.AddParameter("@identityId", DbType.Binary, odinIdentity.IdentityId);
+        cmd.AddParameter("@driveId", DbType.Binary, driveId);
+        cmd.AddParameter("@fileSystemType", DbType.Int32, fileSystemType);
+        cmd.AddParameter("@fileState", DbType.Int32, ActiveFileState);
+
+        var modified = 0L;
+        await using (var rdr = await cmd.ExecuteReaderAsync())
+        {
+            if (await rdr.ReadAsync())
+            {
+                modified = rdr[0] == DBNull.Value ? 0 : (long)rdr[0];
+            }
+        }
+
+        return modified;
+    }
+
     internal async Task<long> GetTotalSizeAllDrivesAsync()
     {
         await using var cn = await _scopedConnectionFactory.CreateScopedConnectionAsync();

--- a/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCached.cs
+++ b/src/core/Odin.Core.Storage/Database/Identity/Table/TableDriveMainIndexCached.cs
@@ -191,6 +191,17 @@ public class TableDriveMainIndexCached : AbstractTableCaching
             GetDriveIdTags(driveId));
     }
 
+    public async Task<long> GetNewestModifiedAsync(Guid driveId, int fileSystemType, TimeSpan? ttl = null)
+    {
+        // Cached with the drive's tags, so an upload (which invalidates them) keeps this fresh.
+        return await Cache.GetOrSetAsync(
+            $"NewestModified:{driveId}:{fileSystemType}",
+            _ => _table.GetNewestModifiedAsync(driveId, fileSystemType),
+            ttl ?? DefaultTtl,
+            DefaultEntrySize,
+            GetDriveIdTags(driveId));
+    }
+
     //
 
     public async Task<long> GetTotalSizeAllDrivesAsync(TimeSpan? ttl = null)

--- a/src/services/Odin.Services/Drives/DriveCore/Query/DriveQuery.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Query/DriveQuery.cs
@@ -469,6 +469,11 @@ public class DriveQuery(
         return (count, size);
     }
 
+    public async Task<long> GetNewestModifiedAsync(Guid driveId, int fileSystemType)
+    {
+        return await tblDriveMainIndex.GetNewestModifiedAsync(driveId, fileSystemType);
+    }
+
     public async Task<DriveMainIndexRecord> GetByGlobalTransitIdAsync(Guid driveId, Guid globalTransitId)
     {
         var record = await tblDriveMainIndex.GetByGlobalTransitIdAsync(driveId, globalTransitId);

--- a/src/services/Odin.Services/Drives/DriveCore/Query/IDriveDatabaseManager.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Query/IDriveDatabaseManager.cs
@@ -74,6 +74,12 @@ namespace Odin.Services.Drives.DriveCore.Query
 
         Task<(Int64 fileCount, Int64 byteSize)> GetDriveSizeInfoAsync(StorageDrive drive);
 
+        /// <summary>
+        /// Returns the newest server-set modified timestamp (ms) of an active file on the drive for the given
+        /// file system type, or 0 when the drive has no such files.
+        /// </summary>
+        Task<long> GetNewestModifiedAsync(Guid driveId, int fileSystemType);
+
         Task<DriveMainIndexRecord> GetByGlobalTransitIdAsync(Guid driveId, Guid globalTransitId);
 
         Task<DriveMainIndexRecord> GetByClientUniqueIdAsync(Guid driveId, Guid uniqueId);

--- a/src/services/Odin.Services/Drives/FileSystem/Base/DriveQueryServiceBase.cs
+++ b/src/services/Odin.Services/Drives/FileSystem/Base/DriveQueryServiceBase.cs
@@ -56,6 +56,18 @@ namespace Odin.Services.Drives.FileSystem.Base
             };
         }
 
+        /// <summary>
+        /// Returns the newest server-set modified timestamp (ms) of an active file on the drive, or 0 when the
+        /// drive has no files. Intentionally NOT clamped to the temporal window — it's a single status timestamp
+        /// (never content) so a caller can detect e.g. that data updates have stopped. Requires temporal-or-full read.
+        /// </summary>
+        public async Task<long> GetNewestFileModified(Guid driveId, IOdinContext odinContext)
+        {
+            await AssertDriveIsValidAndActive(driveId, odinContext);
+            odinContext.PermissionsContext.AssertCanConditionalTemporalReadDrive(driveId);
+            return await _driveQuery.GetNewestModifiedAsync(driveId, (int)GetFileSystemType());
+        }
+
         public async Task<QueryModifiedResult> GetModified(Guid driveId, FileQueryParamsV1 qp, QueryModifiedResultOptions options,
             IOdinContext odinContext)
         {

--- a/src/services/Odin.Services/Drives/TemporalAccessStatus.cs
+++ b/src/services/Odin.Services/Drives/TemporalAccessStatus.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using Odin.Core.Time;
+
 namespace Odin.Services.Drives;
 
 /// <summary>
@@ -24,4 +26,12 @@ public class TemporalAccessStatus
     /// unconstrained read access (no time clamp). Only meaningful when <see cref="HasAccess"/> is true.
     /// </summary>
     public long? WindowSeconds { get; init; }
+
+    /// <summary>
+    /// Server-set modified timestamp of the newest file on the drive, or 0 when the drive has no files (or the
+    /// caller has no access). Lets a caller see the last data update — e.g. for a location drive, a parent can
+    /// tell that updates have stopped (location turned off) without reading any content. Not clamped to
+    /// <see cref="WindowSeconds"/>.
+    /// </summary>
+    public UnixTimeUtc NewestFileModified { get; init; }
 }

--- a/src/services/Odin.Services/Peer/Incoming/Drive/Query/PeerTemporalDriveQueryService.cs
+++ b/src/services/Odin.Services/Peer/Incoming/Drive/Query/PeerTemporalDriveQueryService.cs
@@ -49,11 +49,21 @@ namespace Odin.Services.Peer.Incoming.Drive.Query
             var hasAccess = perms.HasDrivePermission(driveId, DrivePermission.Read) ||
                             perms.HasDrivePermission(driveId, DrivePermission.ConditionalTemporalRead);
 
+            long? windowSeconds = null;
+            long newestFileModified = 0;
+            if (hasAccess)
+            {
+                windowSeconds = TemporalReadPolicy.ResolveWindowSeconds(odinContext, drive);
+                // Newest update on the drive so a caller can spot that data has stopped flowing (e.g. location off).
+                newestFileModified = await fileSystem.Query.GetNewestFileModified(driveId, odinContext);
+            }
+
             return new TemporalAccessStatus
             {
                 HasAccess = hasAccess,
                 TargetDrive = drive.TargetDriveInfo,
-                WindowSeconds = hasAccess ? TemporalReadPolicy.ResolveWindowSeconds(odinContext, drive) : null
+                WindowSeconds = windowSeconds,
+                NewestFileModified = new UnixTimeUtc(newestFileModified)
             };
         }
 

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/TemporalReadTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/TemporalReadTests.cs
@@ -41,13 +41,17 @@ public class TemporalReadTests : V2Fixture
         // Upload an "old" file, wait past the window, then a "fresh" file.
         var oldFileId = await UploadLocalAsync(frodo, drive, "old location");
         await Task.Delay((WindowSeconds + 3) * 1000);
+        var beforeFresh = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         var freshFileId = await UploadLocalAsync(frodo, drive, "fresh location");
 
-        // verify: Sam has temporal access; the reported window matches the drive ceiling.
+        // verify: Sam has temporal access; the reported window matches the drive ceiling, and the newest-file
+        // timestamp reflects the most recent upload (unclamped — it's the "last data update" signal).
         var verify = await sam.Drives.Peer.VerifyTemporalAccessAsync(frodo.Identity, drive.Alias);
         Assert.That(verify.IsSuccessStatusCode, Is.True, $"verify failed: {verify.StatusCode}");
         Assert.That(verify.Content!.HasAccess, Is.True);
         Assert.That(verify.Content.WindowSeconds, Is.EqualTo(WindowSeconds));
+        Assert.That(verify.Content.NewestFileModified.milliseconds, Is.GreaterThanOrEqualTo(beforeFresh - 2000),
+            "newest-file timestamp should reflect the most recent upload");
 
         // Temporal read of the fresh file succeeds...
         var fresh = await sam.Drives.Peer.TemporalGetFileHeaderAsync(frodo.Identity, drive.Alias, freshFileId);

--- a/tests/core/Odin.Core.Storage.Tests/Database/Identity/Abstractions/QueryBatchModifiedAfterTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/Database/Identity/Abstractions/QueryBatchModifiedAfterTests.cs
@@ -5,7 +5,9 @@ using System.Threading.Tasks;
 using Autofac;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
+using Odin.Core.Storage;
 using Odin.Core.Storage.Database.Identity.Abstractions;
+using Odin.Core.Storage.Database.Identity.Table;
 using Odin.Core.Storage.Factory;
 using Odin.Core.Time;
 using Odin.Core.Util;
@@ -70,11 +72,47 @@ namespace Odin.Core.Storage.Tests.Database.Identity.Abstractions
             ClassicAssert.AreEqual(3, fromM1.Count);
         }
 
+        [Test]
+        [TestCase(DatabaseType.Sqlite)]
+#if RUN_POSTGRES_TESTS
+        [TestCase(DatabaseType.Postgres)]
+#endif
+        public async Task GetNewestModified_ReturnsMaxModified_OrZeroWhenEmpty(DatabaseType databaseType)
+        {
+            await RegisterServicesAsync(databaseType);
+            await using var scope = Services.BeginLifetimeScope();
+            var metaIndex = scope.Resolve<MainIndexMeta>();
+            var tbl = scope.Resolve<TableDriveMainIndex>();
+
+            var driveId = Guid.NewGuid();
+            var fst = (int)FileSystemType.Standard;
+            var sender = SequentialGuid.CreateGuid().ToString();
+            var tag = SequentialGuid.CreateGuid();
+
+            // Empty drive -> 0.
+            ClassicAssert.AreEqual(0, await tbl.GetNewestModifiedAsync(driveId, fst));
+
+            var (_, m1) = await AddAsync(metaIndex, driveId, SequentialGuid.CreateGuid(), sender, tag);
+            await Task.Delay(8);
+            var (_, m2) = await AddAsync(metaIndex, driveId, SequentialGuid.CreateGuid(), sender, tag);
+
+            // Returns the newest modified.
+            ClassicAssert.AreEqual(m2.milliseconds, await tbl.GetNewestModifiedAsync(driveId, fst));
+            ClassicAssert.IsTrue(m2.milliseconds > m1.milliseconds);
+
+            // Different file system type on this drive -> 0 (no Comment files inserted).
+            ClassicAssert.AreEqual(0, await tbl.GetNewestModifiedAsync(driveId, (int)FileSystemType.Comment));
+
+            // Different drive -> 0.
+            ClassicAssert.AreEqual(0, await tbl.GetNewestModifiedAsync(Guid.NewGuid(), fst));
+        }
+
         private async Task<(UnixTimeUtc created, UnixTimeUtc modified)> AddAsync(MainIndexMeta metaIndex, Guid driveId, Guid fileId,
             string sender, Guid tag)
         {
             return await metaIndex.TestAddEntryPassalongToUpsertAsync(driveId, fileId, Guid.NewGuid(), 1, 1, sender, tag, null, 42,
-                userDate: new UnixTimeUtc(0), requiredSecurityGroup: 1, accessControlList: null, tagIdList: null, byteCount: 1);
+                userDate: new UnixTimeUtc(0), requiredSecurityGroup: 1, accessControlList: null, tagIdList: null, byteCount: 1,
+                fileState: 1); // Active
         }
 
         private async Task<List<Guid>> QueryAsync(QueryBatch queryBatch, Guid driveId,


### PR DESCRIPTION
## Summary

Enhances the temporal **`verify`** preflight so it also reports the **newest file's modified timestamp** on the drive. This gives a caller the *last data update* time without reading any content — e.g. for a location drive, a parent can spot that updates have stopped (location turned off by mistake) at a glance.

`TemporalAccessStatus` gains:

```csharp
public UnixTimeUtc NewestFileModified { get; init; }  // 0 when empty / no access
```

Populated only when `HasAccess` is true. Intentionally **not** clamped to the temporal window — it's a single status timestamp (never content), so "off for longer than the window" surfaces a real date rather than 0.

## How

- `TableDriveMainIndex.GetNewestModifiedAsync` — `SELECT MAX(modified)` over **active** files of the file-system type (0 when none). Exposed through the cached wrapper (cached with the drive's tags, so an upload — which invalidates them — keeps it fresh) and `IDriveDatabaseManager`/`DriveQuery`.
- `DriveQueryServiceBase.GetNewestFileModified` asserts temporal-or-full read; `PeerTemporalDriveQueryService.VerifyAccessAsync` sets the field when access is granted.

### On `MAX` vs `ORDER BY modified DESC LIMIT 1`
The only `modified` index is `Idx1 = (identityId, driveId, fileSystemType, requiredSecurityGroup, modified, rowId)` — `requiredSecurityGroup` sits between the equality prefix and `modified`, so neither form gets a clean seek-to-max; both scan the drive's files for that fs type. Given that, `MAX` is the better of the two (running max over the scan; `ORDER BY … LIMIT 1` would additionally need a sort the index can't satisfy). It's a bounded drive on a non-hot path, so sub-millisecond either way.

## Tests

- **DB unit** (`QueryBatchModifiedAfterTests.GetNewestModified…`): max across files, empty drive → 0, fs-type filter, other-drive → 0.
- **Integration** (`TemporalReadTests`): `verify.NewestFileModified` reflects the most recent upload.

## Client impact

Additive only — one new field on the `verify` response (`NewestFileModified`, `UnixTimeUtc` ms; `0` = empty/no access). No request or route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)