### PR TITLE
Live Relay: ephemeral group data streaming

### DIFF
--- a/docs/live-relay-client-plan.md
+++ b/docs/live-relay-client-plan.md
@@ -1,0 +1,136 @@
+# Live Relay — chat-kmp Client Plan
+
+## Context
+
+The backend for **Live Relay** (generic, ephemeral, app-agnostic live data sharing — e.g. live GPS
+among connected friends) is implemented and merged-pending in PR
+[#1572](https://github.com/homebase-id/odin-core/pull/1572). Design: `docs/live-relay-plan.md`.
+Reference contract test (read this first):
+`tests/apps/Odin.Hosting.Tests/_V2/Tests/LiveRelay/LiveRelayShareGpsExampleTest.cs`.
+
+This plan covers the **chat-kmp client** side. Goal: a friend can share their live location with a
+chosen set of connected identities; recipients see it live on a map and instantly on (re)connect.
+Nothing is stored durably — "if you're offline, the data is just gone."
+
+> **This file is the handoff doc. On approval it is written to `docs/live-relay-client-plan.md` on
+> the `live-relay` branch and pushed (so it travels with the PR). The actual client implementation
+> should be done in a fresh session pointed at this doc + the example test.**
+
+---
+
+## Wire contract (already live on the server)
+
+**Send (hop 1, app → its own server)** — `POST /api/v2/live-relay`, app-authenticated, request body
+shared-secret-encrypted like every other V2 JSON POST:
+```json
+{ "channelKey": "<guid>", "recipients": ["sam.dotyou.cloud", ...], "blob": "<base64>" }
+```
+- `blob` is **opaque to the server** (GPS today, anything tomorrow). The app owns its meaning/encoding.
+- `appId` is **inferred server-side** from the app token — the client never sends it.
+- Response: `204 No Content`. Fire-and-forget — unreachable/non-connected recipients are silently dropped.
+
+**Receive (hop 3, server → client websocket)** — a `LiveRelay` client notification over the existing
+notification socket. Its `Data` payload:
+```json
+{ "senderOdinId": "frodo.dotyou.cloud", "channelKey": "<guid>", "blob": "<base64>", "receivedAt": 1718800000000 }
+```
+- `senderOdinId` is authoritative (server knows it from the peer cert). `receivedAt` = server-received
+  time (ms) — use for staleness on the map.
+- **Server enforces app isolation**: only sockets of the matching app receive it.
+- **Flush-on-connect is automatic**: on (re)connect/foreground the server pushes every retained
+  sender's last point for this app — the client sends nothing extra; just filter by open `channelKey`s.
+
+---
+
+## Permissions — no change needed
+
+The relay endpoint requires the calling app to have `UseTransitWrite` (backend key **210**). The chat
+app **already requests it** as `AppPermissionType.SendDataToOtherIdentitiesOnMyBehalf(210)` in
+`homebase-common/.../core/config/AppConfig.kt` (`appPermissions`) — same key it already uses to send
+files peer-to-peer. No new permission, no re-authorization. (Verify at runtime: the relay also needs
+ICR access to connected recipients, which the app already has via its connection grants.)
+
+---
+
+## Touch points (chat-kmp)
+
+All paths under `/home/seifert/odin/chat-kmp/`.
+
+**Receive**
+- `homebase-api/.../client/websockets/ClientNotificationType.kt` — add `liveRelay(6001)` (match the
+  backend enum value; existing values are explicit ints e.g. `fileAdded(101)`).
+- `homebase-api/.../client/websockets/OdinWebSocketClient.kt` — `dispatchNotification()` (~line 412):
+  add a `ClientNotificationType.liveRelay ->` case that deserializes `notification.data` into a new
+  DTO and `eventBus.emit(BackendEvent.LiveRelayReceived(...))`. Mirror the `introductionsReceived`
+  case (~lines 470–479).
+- `homebase-api/.../client/eventbus/BackendEvent.kt` — add `LiveRelayReceived(senderOdinId, channelKey,
+  blob, receivedAt)` (new `DataEvent`/category). Consumers collect from `eventBus`.
+
+**Send**
+- `homebase-api/.../client/OdinApiProviderBase.kt` — reuse `encryptedPostJson(url, token, jsonBody,
+  secret)` (~lines 396–425); responses auto-decrypt. Template provider:
+  `homebase-api/.../client/peer/PeerNotificationProvider.kt`.
+- New `LiveRelayProvider : OdinApiProviderBase` with `relay(channelKey, recipients, blob)` →
+  `POST /api/v2/live-relay`.
+
+**Connections (share picker)**
+- `homebase-api/.../client/connections/ConnectionNetworkProvider.kt` — `getConnected(count, cursor)`;
+  `ConnectionService` for cached lists.
+
+**Location capture / encoding (reuse)**
+- `homebase-common/.../core/location/tracking/LocationTracker.kt` — `start/setMode/stop`
+  (platform impls `.android/.apple/.jvm/.web`). Already background-capable.
+- `homebase-core/.../ui/screens/location/model/LocationTrackContent.kt` — `LocationTrackCodec`
+  (compact point encoding) as a template for the live-point blob.
+- `homebase-core/.../ui/screens/location/LocationTrackUploaderService.kt` — background send pattern
+  to mirror for the throttled live sender.
+- `homebase-common/.../core/config/AppConfig.kt` — `APP_ID = 2d78140138044b57b4aad8e4e2ef39f4`.
+
+---
+
+## Implementation steps
+
+1. **Receive plumbing**: `liveRelay(6001)` enum value → `BackendEvent.LiveRelayReceived` →
+   `dispatchNotification` case (decode Data, emit). Smallest, do first; unblocks UI work.
+2. **Send provider**: `LiveRelayProvider.relay(channelKey, recipients, blob)` over `encryptedPostJson`.
+3. **Live sender service**: while a share is active, take `LocationTracker` output, **throttle/coalesce
+   to a few-second cadence** (last-value-wins — not raw sensor rate), encode the live-point blob, and
+   call `relay(...)` to the channel's recipient set. Mirror `LocationTrackUploaderService`'s background
+   handling. Distinct from the durable hourly track files — this is ephemeral.
+4. **Session + picker**: a "live share" = a `channelKey` (GUID) + a recipient set chosen via
+   `getConnected()`. Persist active shares locally; tie to a conversation/group if desired.
+5. **Map / dashboard**: subscribe to `BackendEvent.LiveRelayReceived`; keep **last value per
+   `senderOdinId`** for channels the user has open; render position + `receivedAt` freshness.
+6. **Lifecycle**: start/stop the live sender with the share toggle and app foreground/background.
+
+---
+
+## Open decisions (resolve at the start of the client session)
+
+1. **Blob encoding & encryption.** The server sees the blob at each hop (it's "opaque", not
+   encrypted, unless the app encrypts it). Decide: (a) plaintext compact codec — simplest, fine if
+   server-visible-to-your-own-infra is acceptable; or (b) app-level E2E encryption with a per-channel
+   symmetric key shared among participants. **Recommend (a) for v1**, a trimmed `LocationTrackCodec`
+   point (lat/lon E5, heading, speed, ts); layer (b) later if needed.
+2. **Send cadence.** Pick the coalesce interval (e.g. 2–5s) and movement threshold; battery vs liveness.
+3. **Session/membership model.** Standalone "live share" sessions vs riding an existing group
+   conversation's membership. Determines who's on `recipients` and which `channelKey`s the watcher opens.
+4. **Multi-channel UI.** If a user is in several live shares, how the map disambiguates by `channelKey`.
+
+---
+
+## Verification
+
+- **Contract reference**: `LiveRelayShareGpsExampleTest.TwoFriendsShareLiveGps` (backend) shows the
+  exact request/response/notification shapes the client must match.
+- **Unit (KMP commonTest)**: live-point codec round-trip; `dispatchNotification` parses a `LiveRelay`
+  Data JSON into `BackendEvent.LiveRelayReceived` with the right fields.
+- **Manual, two identities (same app, connected)**: one shares → the other sees live updates on the
+  map; background the sharer (HTTP keeps flowing); kill+reopen the watcher → it immediately re-hydrates
+  to everyone's current position (flush-on-connect); stop sharing → updates cease.
+- **Negative**: share to a non-connected identity → no delivery, no client error.
+
+## Out of scope (client)
+
+- Group calling (WebRTC) — separate effort.
+- Server changes — backend is complete in PR #1572; this is client-only.

--- a/docs/live-relay-plan.md
+++ b/docs/live-relay-plan.md
@@ -1,0 +1,259 @@
+# Live Relay — Generic Ephemeral Group Streaming
+
+## Context
+
+We want a **generic, app-agnostic primitive** for sharing *live* ephemeral data among a group of
+already-connected identities, each running their own server. The motivating use case is 10 friends
+on vacation sharing live GPS for a week, but the server must treat the carried bytes as opaque (it
+happens to be GPS; it could be anything).
+
+> **Naming:** we avoid "payload"/"data" for the carried bytes — those collide with Homebase **file
+> payloads**. The opaque field is **`Blob`** throughout; types use a `LiveRelay` prefix.
+
+Design principles settled in discussion:
+- **Decentralized mesh, no relay/master.** Each participant is the authoritative publisher of their
+  own stream; the group is just a recipient list the sender holds. No leader election, no single
+  point of failure. (A future WebRTC *calling* feature will use a participant-relay — a deliberately
+  different data plane under the same session idea — out of scope here.)
+- **Ephemeral, last-value-wins state — not durable events.** No drive writes, no outbox, no
+  notification DB. "If you're offline, the data is just gone." A missed packet is harmless because
+  the next one supersedes it.
+- **Reuse the existing ephemeral publish lane.** `ITenantPubSub.PublishAsync` →
+  `AppNotificationDispatcher` → websocket already delivers events to clients with zero DB writes
+  (12 of 13 current notification types use it). We surface our opaque blob via a new
+  `IClientNotification` variant — same pattern as `NewFollowerNotification`.
+- **Multi-instance correct.** A tenant may be served by several server instances. The **live** path
+  is already cross-instance: `ITenantPubSub` uses Redis PUBLISH/SUBSCRIBE (`RedisPubSub`), so a blob
+  published on instance A reaches subscribed dispatchers on B/C and their local sockets. The only
+  cross-instance state we add — the **retained last-value store** — rides the transparent layer-2
+  cache (`ITenantLevel2Cache`: in-memory L1 + Redis L2, auto memory-only when Redis is off), as a
+  single per-app snapshot the server reads whole to auto-flush every sender's last point to a
+  newly-connecting client.
+
+### Three transport hops (all decided)
+
+1. **App → its own server** — **HTTP POST**. Chosen for **background reliability**: a week-long
+   share runs mostly backgrounded, where the OS tears down persistent sockets; discrete HTTP uploads
+   map onto iOS background `URLSession` / Android foreground-service/`WorkManager`. chat-kmp's
+   `LocationTrackUploaderService` already does background HTTP upload — mirror it.
+2. **Sender server → each recipient server** — **ephemeral fire-and-forget HTTP POST**, no outbox,
+   drop on failure. Mutual-TLS peer auth.
+3. **Recipient server → its connected clients** — **existing websocket publish lane**, with a new
+   per-AppId socket filter.
+
+### Authorization & routing (layers)
+
+- **Connection trust (sender identity):** the recipient server knows the sending server's identity
+  for certain from the mutual-TLS cert (`GetCallerOdinIdOrFail`). It accepts a blob only if that
+  sender is a **Connected** identity (`CircleNetworkService`). No server-side per-channel consent.
+- **App isolation (server-enforced):** the **AppId is inferred from the authenticated caller** on
+  hop 1 (the app cannot self-declare/spoof it), carried in the hop-2 envelope, and used on hop 3 to
+  deliver **only to sockets of apps with the matching AppId** — a chat GPS blob can never reach a
+  different Homebase app (e.g. a health app).
+- **Session routing (client):** the client filters by `channelKey` to route to the correct *open
+  share session*. Server enforces *which app*; client picks *which session*.
+- **Forwarded to the client with every blob:** the **sending server's OdinId** and the
+  **server-side received timestamp** (`ReceivedAt`, stamped at receipt) — so the client can show
+  freshness/staleness, especially for a blob flushed on connect.
+
+**AppId is free to obtain:** the app-token auth path (`AppRegistrationService.GetAppPermissionContextAsync`
+→ `ValidateClientAuthTokenAsync`, `:278–302`) already loads the `AppRegistration`/`AppClientRegistration`
+(`AppClientRegistration.AppId` / `CategoryId`). It's just not copied onto the context — surfacing it
+adds **no extra DB read**.
+
+---
+
+## Backend changes (odin-core)
+
+### New types
+
+| Type | Path | Role |
+|---|---|---|
+| `AppLiveRelayController` | `Controllers/ClientToken/App/Notifications/AppLiveRelayController.cs` | HOP 1 ingress. `[AuthorizeValidAppToken]`, `[HttpPost("relay")]`. Mirror `AppPeerNotificationController`. |
+| `LiveRelayRequest` | `src/services/Odin.Services/LiveRelay/` | DTO: `Guid ChannelKey`, `List<string> Recipients`, `string Blob` (opaque base64). **No AppId** — inferred server-side. |
+| `LiveRelayService` | `src/services/Odin.Services/LiveRelay/LiveRelayService.cs` | Sender fan-out. Extends `PeerServiceBase`; inject `ILifetimeScope`. Asserts `UseTransitWrite`; reads AppId from caller context. |
+| `ILiveRelayHttpClient` | `src/services/Odin.Services/LiveRelay/ILiveRelayHttpClient.cs` | Refit client for HOP 2. Mirror `IPeerAppNotificationHttpClient` in `IPeerReactionHttpClient.cs`. |
+| `LiveRelayPeerEnvelope` | `src/services/Odin.Services/LiveRelay/` | Wire DTO: `ChannelKey`, `Blob`, `AppId`. **No sender identity** (from cert). |
+| `PeerLiveRelayController` | `Controllers/PeerIncoming/LiveRelay/PeerLiveRelayController.cs` | HOP 2 ingress. `[Authorize(Policy = IsInOdinNetwork, AuthenticationSchemes = TransitCapiAuthScheme)]`. Mirror `PeerAppNotificationsPreAuthController`. |
+| `PeerLiveRelayReceiverService` | `src/services/Odin.Services/LiveRelay/PeerLiveRelayReceiverService.cs` | Recipient: connected-check → stamp `ReceivedAt` → retained store → publish. |
+| `LiveRelayRetainedStore` | `src/services/Odin.Services/LiveRelay/LiveRelayRetainedStore.cs` | **Per-tenant singleton** over **`ITenantLevel2Cache`** (transparent L1 + Redis L2; memory-only when Redis off). `Put(...)` RMWs a per-app snapshot under a per-app `SemaphoreSlim`; `GetAllForApp(appId)` reads it for auto-flush. |
+| `LiveRelayAppSnapshot` | `src/services/Odin.Services/LiveRelay/` | **Named record** cached once per app: `Dictionary<string, LiveRelayRetainedEntry> Entries` keyed `"{channelKey}:{senderDomain}"`. Enumerable in one read. |
+| `LiveRelayRetainedEntry` | `src/services/Odin.Services/LiveRelay/` | **Named record** (STJ-serializable): `string Blob`, `Guid AppId`, `Guid ChannelKey`, `string SenderDomain`, `long ReceivedAtMs`. |
+| `LiveRelayNotification` | `src/services/Odin.Services/AppNotifications/ClientNotifications/LiveRelayNotification.cs` | New `IClientNotification` + `IAppTargetedClientNotification`. Carries `SenderOdinId`, `ChannelKey`, `Blob`, `ReceivedAt`, `TargetAppId`. |
+| `IAppTargetedClientNotification` | `src/services/Odin.Services/AppNotifications/ClientNotifications/` | Marker: `IClientNotification` + `Guid TargetAppId { get; }`. Lets the dispatcher filter sockets by app. |
+
+### Surfacing AppId onto the context + socket
+
+- **`OdinClientContext.cs`** — add `public GuidId? AppId { get; set; }`; ensure `Clone()` copies it.
+- **`AppRegistrationService.GetAppPermissionContextAsync` (~`:253–267`)** — set `AppId = appReg.AppId`
+  on the `OdinClientContext` it builds (value already in scope; no extra lookup).
+- **`DeviceSocket.cs`** — add `public Guid? AppId { get; set; }`.
+- **`AppNotificationHandler.cs`** `EstablishConnectionRequest` handler (~`:241–279`) — after
+  `deviceSocket.DeviceOdinContext = odinContext.Clone()`, set
+  `deviceSocket.AppId = odinContext.Caller.OdinClientContext?.AppId`.
+
+### App-targeted delivery in the dispatcher
+
+- **`AppNotificationDispatcher.cs`** — in `PublishClientNotificationAsync`, if the notification is
+  `IAppTargetedClientNotification`, stamp `ClientNotificationMessage.TargetAppId` (new nullable
+  `Guid?`, default null = broadcast as today). In `WsPublishAsync(ClientNotificationMessage)`
+  (~`:145–155`), when `TargetAppId` is set, filter `sockets.Where(ds => ds.AppId == targetAppId)`
+  (mirrors the drive filter at `:183–185`); null → unchanged broadcast.
+- Add `SendRetainedToSocketAsync(DeviceSocket, IEnumerable<LiveRelayNotification>)` that serializes
+  like `PublishClientNotificationAsync` and calls `SendMessageAsync(socket, json, encrypt: true)`
+  directly to one socket (bypassing pub/sub, for flush-on-connect). `LiveRelayNotification` must
+  **not** be in the `shouldEncrypt` exclusion list.
+
+### Retained store — single `ITenantLevel2Cache` impl, per-app snapshot
+
+The store must be **enumerable** so the server can auto-flush on reconnect without the client naming
+anyone. `ITenantLevel2Cache` (FusionCache: in-memory L1 + Redis L2, **transparently memory-only when
+Redis is off**) handles single- vs multi-server for us — **one implementation, no InProc/Redis
+split**. It's pure key→value and can't list keys, so we pack all of an app's senders into **one
+snapshot value** that we can read whole.
+
+- **`LiveRelayRetainedStore`** — **per-tenant singleton**, injects `ITenantLevel2Cache` and holds a
+  `ConcurrentDictionary<Guid appId, SemaphoreSlim>` of async locks:
+  - **Key:** one entry per app, `liverelay:{appId}` → `LiveRelayAppSnapshot` whose
+    `Entries["{channelKey}:{senderDomain}"]` holds each sender's last `LiveRelayRetainedEntry`.
+  - **`Put`:** under the app's `SemaphoreSlim` — `GetOrDefaultAsync` snapshot → set this sender's slot
+    → `SetAsync(key, snapshot, TTL ~5 min)`. Last-value-wins; TTL auto-evicts (no leak, no timer). L2
+    enforces ≥2s TTL — fine. (A `SemaphoreSlim`, not `lock {}`, because the RMW spans `await`s.)
+  - **`GetAllForApp(appId)`:** one read → all senders; **filter stale by `ReceivedAtMs`** before use.
+  - Memory bounded by (channels × senders) per app — tiny for a friend group.
+- **Concurrency — resolved:**
+  - *Same instance* (incl. single-server / Redis-off): the per-app async lock fully serializes the
+    RMW → **no clobber**. This is the common deployment.
+  - *Across instances:* the FusionCache **Redis backplane is already enabled** whenever L2 is Redis
+    (`FusionCacheWrapperExtensions.cs:83–90`) — it invalidates each instance's L1 on write, so reads
+    aren't systematically stale. The only residual is a rare two-instance concurrent-write window,
+    which is self-healing (the clobbered sender reappears next tick). Acceptable for ephemeral
+    last-value data; no distributed lock or Redis-hash needed.
+
+### Flush-on-connect (hydration) — fully automatic, no client input
+
+- In `AppNotificationHandler`’s `EstablishConnectionRequest` handler, after `DeviceOdinContext`/
+  `AppId` are set and the handshake reply is sent: call `store.GetAllForApp(deviceSocket.AppId)`,
+  build one `LiveRelayNotification` per returned entry (preserving original `ReceivedAt`), and
+  `dispatcher.SendRetainedToSocketAsync(...)` to this single socket. The reconnecting/foregrounding
+  client immediately receives every sender's last data point and filters by its open `channelKey`s
+  client-side. **No `EstablishConnectionOptions` change, no client-supplied identity/channel lists.**
+
+### Other edits
+
+- **`ClientNotificationType.cs`** — add `LiveRelay = 6001`.
+- **`TenantServices.cs`**:
+  - Add `.As<INotificationHandler<LiveRelayNotification>>()` to the `AppNotificationHandler`
+    registration (~`:149–164`). **Most error-prone step — miss it and the notification publishes but
+    silently never reaches the websocket.**
+  - Register `LiveRelayService`, `PeerLiveRelayReceiverService` as `InstancePerLifetimeScope()`
+    (alongside `PeerAppNotificationService`, ~`:373`). Register `LiveRelayRetainedStore` as a
+    per-tenant **`SingleInstance()`** (it holds the per-app async locks); it injects
+    `ITenantLevel2Cache` (already registered via `AddTenantCaches`, `:395`) — no new DI extension.
+- **`PeerApiPathConstants.cs`** — add `LiveRelayV1`.
+
+### End-to-end flow (one packet)
+
+1. App POSTs `/api/apps/v1/notify/liverelay/relay` (app token) → `AppLiveRelayController` →
+   `LiveRelayService.RelayAsync`. Assert `UseTransitWrite`; **read `appId` from
+   `ctx.Caller.OdinClientContext.AppId`**; validate channel + recipients.
+2. **Fan-out:** per recipient,
+   `OdinHttpClientFactory.CreateClientAsync<ILiveRelayHttpClient>(recipient).Relay({ ChannelKey, Blob, AppId })`
+   (pattern: `SendPeerPushNotificationOutboxWorker.cs:65`). Try/catch per recipient: **log + drop**.
+   No outbox.
+3. Recipient `PeerLiveRelayController` (cert auth) → sender = `WebOdinContext.GetCallerOdinIdOrFail()`
+   → `PeerLiveRelayReceiverService.ReceiveAsync`.
+4. **Auth:** `GetIcrAsync(caller, ctx, overrideHack: true).IsConnected()` (pattern:
+   `PeerAppNotificationService.cs:62`). Reject if not connected.
+5. **Stamp + store:** `receivedAt = UnixTimeUtc.Now()`;
+   `store.Put(appId, channelKey, sender, entry)` → RMW the per-app `LiveRelayAppSnapshot` (overwrite
+   this sender's slot; last data point per sender) and `SetAsync` with ~5 min TTL.
+6. **Publish:** `mediator.Publish(new LiveRelayNotification { SenderOdinId = caller, ChannelKey,
+   Blob, ReceivedAt = receivedAt, TargetAppId = appId })` → `AppNotificationHandler.Handle` →
+   `PublishClientNotificationAsync` (stamps `TargetAppId`) → `ITenantPubSub.PublishAsync` (Redis,
+   cross-instance) → each instance’s `WsPublishAsync` → **only sockets with `AppId == appId`**,
+   encrypted per-socket.
+7. Client receives `ClientNotificationPayload`, decrypts, reads `{ senderOdinId, channelKey, blob,
+   receivedAt }`, **filters by `channelKey`**, renders. Zero matching sockets = no-op (entry still in
+   the store for TTL, flushed on next connect).
+
+### Parallelism / scoping
+
+- Fan-out: **parallel with child scopes** (avoids head-of-line blocking on an unreachable peer).
+  Pattern: `CircleNetworkIntroductionService.ProbeRecipientAsync` (`:249–271`) +
+  `PeerOutboxProcessorBackgroundService.ProcessItemThread` (`:119`). Per recipient:
+  `await using var childScope = _lifetimeScope.BeginLifetimeScope($"LiveRelay:{Guid.NewGuid()}")`,
+  resolve DB-touching services from it, swallow per-recipient errors. (Sequential `foreach` is an
+  acceptable fallback.)
+- Recipient auth, store write, and flush run in their own request/socket scope; the store is
+  thread-safe (Redis `IDatabase` / `ConcurrentDictionary`).
+
+### Gotchas
+
+- `Blob` is opaque base64 inside `GetClientData()` JSON — do **not** interpret or double-encrypt; the
+  websocket shared-secret encryption is applied generically by `SendMessageAsync`.
+- Never trust a sender id or AppId from a request **body** — sender from the cert
+  (`GetCallerOdinIdOrFail`); AppId inferred from the app token on hop 1, only then placed in the
+  hop-2 envelope by the trusted sender server.
+- `LiveRelayAppSnapshot`/`LiveRelayRetainedEntry` are STJ-serialized into the L2 cache — keep them
+  **named records** (no `ValueTuple`/anonymous types, per `CacheTypeGuard`); store `OdinId` as its
+  domain string. Filter stale slots on read by `ReceivedAtMs` (TTL bounds growth).
+- RMW is serialized by a per-app `SemaphoreSlim` (not `lock {}` — the RMW spans `await`s). The
+  FusionCache Redis backplane is already enabled with L2 Redis (`FusionCacheWrapperExtensions.cs:83`),
+  so L1 stays coherent across instances — no extra config needed.
+- `OdinClientContext.AppId` is on a widely-cloned type — keep it a plain nullable field; confirm
+  `Clone()` copies it.
+- `channelKey` = a per-share-session `Guid` the app generates; only participants know it. Chat AppId
+  is `2d781401-3804-4b57-b4aa-d8e4e2ef39f4` (`SystemAppConstants.ChatAppId`).
+
+---
+
+## Client changes (chat-kmp)
+
+- **Receive:** add `LiveRelay` to `ClientNotificationType` and a case in
+  `OdinWebSocketClient.dispatchNotification()` → emit a `BackendEvent`
+  (e.g. `LiveBlobReceived(senderId, channelKey, blob, receivedAt)`) on `EventBus`. Reuse AES-CBC
+  shared-secret decode. Use `receivedAt` for staleness; `senderId` is authoritative.
+- **Send:** new provider method (reuse `OdinApiProviderBase.post`) POSTing the encrypted blob to
+  `/notify/liverelay/relay` with `{channelKey, recipients, blob}` (no appId — server infers).
+  Drive from `LocationTracker`, **throttled/coalesced** to a few-second cadence (last-value-wins) —
+  not raw sensor rate. Mirror background-upload handling from `LocationTrackUploaderService`.
+- **Connect:** nothing extra to send — on (re)connect/foreground the server **automatically flushes**
+  every retained sender's last data point for this app; the client just filters by its open
+  `channelKey`s. (No `EstablishConnectionRequest` changes.)
+- **Share picker:** reuse `ConnectionNetworkProvider.getConnected()` / `ConnectionService`; generate
+  a `channelKey` GUID per share session.
+- **Map/dashboard:** consume `EventBus`, keep last-value per friend (`senderId`), show `receivedAt`
+  freshness; reuse GPS capture + `LocationTrackCodec` for compact blob encoding.
+
+---
+
+## Verification
+
+- **Unit (NUnit):**
+  - `LiveRelayRetainedStore` over an in-memory `ITenantLevel2Cache`: per-sender put/overwrite
+    (last-value-wins), multiple senders coexist in the snapshot, `GetAllForApp` returns all live
+    senders, stale slots filtered by `ReceivedAtMs`, snapshot round-trips through STJ.
+  - `LiveRelayNotification.GetClientData()`: JSON includes `senderOdinId`, `channelKey`, `blob`,
+    `receivedAt`; `Blob` byte-identical.
+  - Sender fan-out: mock `IOdinHttpClientFactory`; one `Relay` per recipient with inferred AppId in
+    the envelope; a throwing recipient is swallowed and doesn’t block others.
+- **Integration (`WebScaffold`, frodo + sam):**
+  1. Connect frodo↔sam; sam opens app websocket + `EstablishConnectionRequest`.
+  2. frodo POSTs relay `Recipients=[sam]` → sam’s socket gets a `LiveRelay` notif; decrypt; `Blob`
+     byte-identical; `senderOdinId == frodo`; `receivedAt` present/recent.
+  3. **App isolation:** a second sam socket under a *different* AppId must **not** receive it.
+  4. **Auth negative:** block/disconnect → relay rejected, no socket message.
+  5. **Auto-flush on connect:** relay while sam has no socket; sam then connects → frodo's last entry
+     is flushed immediately (no client-supplied list) with original `receivedAt`; after TTL → nothing.
+  6. **Zero sockets:** relay with no sam sockets → HTTP success, no error (store-only).
+- **Manual / multi-instance:** two hosting instances behind the tenant, two chat-kmp clients; confirm
+  a blob received on instance A reaches a client socketed to instance B (Redis pub/sub) and that a
+  client connecting to a *different* instance than the writer auto-flushes from the L2 snapshot.
+
+## Out of scope
+
+- WebRTC group calling (participant-relay data plane; separate effort).
+- Server-enforced per-channel consent (client gates the *session*; server enforces the *app*).
+- Promoting the send hop (HOP 1) to a websocket command — future optimization only if POST cadence
+  proves a bottleneck.

--- a/docs/live-relay-plan.md
+++ b/docs/live-relay-plan.md
@@ -69,7 +69,7 @@ adds **no extra DB read**.
 
 | Type | Path | Role |
 |---|---|---|
-| `AppLiveRelayController` | `Controllers/ClientToken/App/Notifications/AppLiveRelayController.cs` | HOP 1 ingress. `[AuthorizeValidAppToken]`, `[HttpPost("relay")]`. Mirror `AppPeerNotificationController`. |
+| `V2LiveRelayController` | `UnifiedV2/LiveRelay/V2LiveRelayController.cs` | HOP 1 ingress (V2 REST). `[UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]`, `[HttpPost]` at `/api/v2/live-relay`. |
 | `LiveRelayRequest` | `src/services/Odin.Services/LiveRelay/` | DTO: `Guid ChannelKey`, `List<string> Recipients`, `string Blob` (opaque base64). **No AppId** — inferred server-side. |
 | `LiveRelayService` | `src/services/Odin.Services/LiveRelay/LiveRelayService.cs` | Sender fan-out. Extends `PeerServiceBase`; inject `ILifetimeScope`. Asserts `UseTransitWrite`; reads AppId from caller context. |
 | `ILiveRelayHttpClient` | `src/services/Odin.Services/LiveRelay/ILiveRelayHttpClient.cs` | Refit client for HOP 2. Mirror `IPeerAppNotificationHttpClient` in `IPeerReactionHttpClient.cs`. |
@@ -154,7 +154,7 @@ snapshot value** that we can read whole.
 
 ### End-to-end flow (one packet)
 
-1. App POSTs `/api/apps/v1/notify/liverelay/relay` (app token) → `AppLiveRelayController` →
+1. App POSTs `/api/v2/live-relay` (V2 REST, app token) → `V2LiveRelayController` →
    `LiveRelayService.RelayAsync`. Assert `UseTransitWrite`; **read `appId` from
    `ctx.Caller.OdinClientContext.AppId`**; validate channel + recipients.
 2. **Fan-out:** per recipient,

--- a/src/apps/Odin.Hosting/Controllers/PeerIncoming/LiveRelay/PeerLiveRelayController.cs
+++ b/src/apps/Odin.Hosting/Controllers/PeerIncoming/LiveRelay/PeerLiveRelayController.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Odin.Hosting.Authentication.Peer;
+using Odin.Hosting.Controllers.Base;
+using Odin.Services.LiveRelay;
+using Odin.Services.Peer;
+
+namespace Odin.Hosting.Controllers.PeerIncoming.LiveRelay
+{
+    /// <summary>
+    /// Peer perimeter (hop 2 ingress): receives an opaque live data point from another identity's
+    /// server. Authenticated by the mutual-TLS peer cert; the data is retained (ephemerally) and
+    /// pushed to the matching app's connected sockets.
+    /// </summary>
+    [ApiController]
+    [Route(PeerApiPathConstants.LiveRelayV1)]
+    [Authorize(Policy = PeerPerimeterPolicies.IsInOdinNetwork, AuthenticationSchemes = PeerAuthConstants.TransitCapiAuthScheme)]
+    [ApiExplorerSettings(GroupName = "peer-v1")]
+    public class PeerLiveRelayController(PeerLiveRelayReceiverService receiverService) : OdinControllerBase
+    {
+        [HttpPost("relay")]
+        public async Task<PeerTransferResponse> Relay([FromBody] LiveRelayPeerEnvelope envelope)
+        {
+            return await receiverService.ReceiveAsync(envelope, WebOdinContext);
+        }
+    }
+}

--- a/src/apps/Odin.Hosting/TenantServices.cs
+++ b/src/apps/Odin.Hosting/TenantServices.cs
@@ -28,6 +28,7 @@ using Odin.Services.Drives.Management;
 using Odin.Services.Drives.Reactions;
 using Odin.Services.Drives.Statistics;
 using Odin.Services.EncryptionKeyService;
+using Odin.Services.LiveRelay;
 using Odin.Services.Mediator;
 using Odin.Services.Membership.CircleMembership;
 using Odin.Services.Membership.Circles;
@@ -117,6 +118,12 @@ public static class TenantServices
         cb.RegisterType<AppNotificationDispatcher>().AsSelf().SingleInstance();
         cb.RegisterType<PeerAppNotificationDispatcher>().AsSelf().SingleInstance();
 
+        // Per-tenant singleton: holds the per-app async locks that serialize the snapshot
+        // read-modify-write; state itself lives in the (Redis-backed) layer-2 cache.
+        cb.RegisterType<LiveRelayRetainedStore>().AsSelf().SingleInstance();
+        cb.RegisterType<LiveRelayService>().AsSelf().InstancePerLifetimeScope();
+        cb.RegisterType<PeerLiveRelayReceiverService>().AsSelf().InstancePerLifetimeScope();
+
         cb.RegisterType<ClientRegistrationStorage>().InstancePerLifetimeScope();
 
         cb.RegisterType<DriveQuery>().InstancePerLifetimeScope();
@@ -160,6 +167,7 @@ public static class TenantServices
             .As<INotificationHandler<ReactionPreviewUpdatedNotification>>()
             .As<INotificationHandler<AppNotificationAddedNotification>>()
             .As<INotificationHandler<ConnectionFinalizedNotification>>()
+            .As<INotificationHandler<LiveRelayNotification>>()
             .AsSelf()
             .InstancePerLifetimeScope();
 

--- a/src/apps/Odin.Hosting/UnifiedV2/LiveRelay/V2LiveRelayController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/LiveRelay/V2LiveRelayController.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Odin.Hosting.Controllers.Base;
+using Odin.Hosting.UnifiedV2.Authentication.Policy;
+using Odin.Services.LiveRelay;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Odin.Hosting.UnifiedV2.LiveRelay
+{
+    /// <summary>
+    /// App-initiated live data sharing (hop 1). The app POSTs an opaque data point ("share my live
+    /// GPS with these connected identities on this channel"); the server fans it out to each
+    /// recipient's peer perimeter, fire-and-forget. Nothing is stored durably.
+    /// </summary>
+    [ApiController]
+    [Route(UnifiedApiRouteConstants.LiveRelay)]
+    [UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]
+    [ApiExplorerSettings(GroupName = "v2")]
+    public class V2LiveRelayController(LiveRelayService liveRelayService) : OdinControllerBase
+    {
+        [HttpPost]
+        [SwaggerOperation(Tags = [SwaggerInfo.Notifications])]
+        public async Task<IActionResult> Relay([FromBody] LiveRelayRequest request)
+        {
+            await liveRelayService.RelayAsync(request, WebOdinContext);
+            return NoContent();
+        }
+    }
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/UnifiedApiRouteConstants.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/UnifiedApiRouteConstants.cs
@@ -15,6 +15,7 @@ public static class UnifiedApiRouteConstants
     public const string GroupReactionsByFileId = FilesRoot + "/{fileId:guid}/group-reactions";
     public const string ByUniqueId = FilesRoot + "/by-uid/{uid:guid}";
     public const string Notify = BasePath + "/notify/push";
+    public const string LiveRelay = BasePath + "/live-relay";
     public const string NotifySocket = BasePath + "/notify/ws-token";
     public const string NotifySocketWasm = BasePath + "/notify/ws-token-wasm";
     public const string Links = BasePath + "/links";

--- a/src/core/Odin.Core.Storage/Odin.Core.Storage.csproj
+++ b/src/core/Odin.Core.Storage/Odin.Core.Storage.csproj
@@ -12,6 +12,9 @@
     <!-- Direct reference to override the vulnerable transitive 3.0.308 from FusionCache (GHSA-hv8m-jj95-wg3x) -->
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
+    <!-- Direct reference to override the vulnerable transitive 2.1.10 from Microsoft.Data.Sqlite (GHSA-2m69-gcr7-jv3q).
+         The entire 2.1.x line is affected with no patch; the fix ships in the 3.x series. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="System.Runtime.Caching" Version="9.0.2" />

--- a/src/services/Odin.Services/AppNotifications/ClientNotifications/IAppTargetedClientNotification.cs
+++ b/src/services/Odin.Services/AppNotifications/ClientNotifications/IAppTargetedClientNotification.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Odin.Services.AppNotifications.ClientNotifications;
+
+/// <summary>
+/// An <see cref="IClientNotification"/> that should be delivered only to connected sockets whose
+/// authenticated app matches <see cref="TargetAppId"/>. Sockets of other apps (and unauthenticated
+/// sockets) never receive it. Notifications that do not implement this interface are broadcast to
+/// all sockets as before.
+/// </summary>
+public interface IAppTargetedClientNotification : IClientNotification
+{
+    Guid TargetAppId { get; }
+}

--- a/src/services/Odin.Services/AppNotifications/ClientNotifications/LiveRelayNotification.cs
+++ b/src/services/Odin.Services/AppNotifications/ClientNotifications/LiveRelayNotification.cs
@@ -1,0 +1,58 @@
+using System;
+using Odin.Core.Identity;
+using Odin.Core.Serialization;
+using Odin.Core.Time;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Mediator;
+
+namespace Odin.Services.AppNotifications.ClientNotifications;
+
+/// <summary>
+/// A single opaque live-relay data point delivered to an app's connected sockets. The server does
+/// not interpret <see cref="Blob"/> (it happens to be GPS, but could be anything). Delivered only
+/// to sockets whose app matches <see cref="TargetAppId"/>.
+/// </summary>
+public class LiveRelayNotification : MediatorNotificationBase, IClientNotification, IAppTargetedClientNotification
+{
+    public ClientNotificationType NotificationType { get; } = ClientNotificationType.LiveRelay;
+
+    public Guid NotificationTypeId { get; } = Guid.Parse("0d9a3f8e-2b6c-4d1a-9c5b-3e7f1a2b8c40");
+
+    /// <summary>
+    /// The identity that produced this data point (the sending server), known for certain from the
+    /// mutual-TLS cert on the peer hop.
+    /// </summary>
+    public OdinId SenderOdinId { get; init; }
+
+    /// <summary>
+    /// The share-session key the sender used. The client routes by this to the correct open session.
+    /// </summary>
+    public Guid ChannelKey { get; init; }
+
+    /// <summary>
+    /// Opaque, app-encrypted bytes (base64). Never interpreted by the server.
+    /// </summary>
+    public string Blob { get; init; }
+
+    /// <summary>
+    /// When the recipient server received this data point (ms since unix epoch). Lets the client
+    /// reason about freshness, especially for a point flushed on (re)connect.
+    /// </summary>
+    public UnixTimeUtc ReceivedAt { get; init; }
+
+    /// <summary>
+    /// The app this data is scoped to; only that app's sockets receive it.
+    /// </summary>
+    public Guid TargetAppId { get; init; }
+
+    public string GetClientData()
+    {
+        return OdinSystemSerializer.Serialize(new
+        {
+            SenderOdinId = this.SenderOdinId.DomainName,
+            ChannelKey = this.ChannelKey,
+            Blob = this.Blob,
+            ReceivedAt = this.ReceivedAt.milliseconds
+        });
+    }
+}

--- a/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationDispatcher.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationDispatcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Threading;
@@ -133,9 +134,32 @@ namespace Odin.Services.AppNotifications.WebSocket
             {
                 ShouldEncrypt = shouldEncrypt,
                 Json = json,
+                // App-targeted notifications are delivered only to sockets of the matching app;
+                // null means broadcast to all sockets (existing behaviour).
+                TargetAppId = (notification as IAppTargetedClientNotification)?.TargetAppId,
             };
 
             await _pubSub.PublishAsync(NotificationChannel, JsonEnvelope.Create(message));
+        }
+
+        //
+
+        /// <summary>
+        /// Serializes and sends a single client notification directly to one socket (bypassing
+        /// pub/sub). Used to flush retained state to a socket as it (re)connects.
+        /// </summary>
+        public Task SendClientNotificationToSocketAsync(
+            DeviceSocket deviceSocket,
+            IClientNotification notification,
+            CancellationToken cancellationToken = default)
+        {
+            var json = OdinSystemSerializer.Serialize(new
+            {
+                notification.NotificationType,
+                Data = notification.GetClientData()
+            });
+
+            return SendMessageAsync(deviceSocket, json, encrypt: true, cancellationToken);
         }
 
         //
@@ -144,7 +168,14 @@ namespace Odin.Services.AppNotifications.WebSocket
         // Dst: WebSocket
         private async Task WsPublishAsync(ClientNotificationMessage notification)
         {
-            var sockets = _deviceSocketCollection.GetAll().Values;
+            IEnumerable<DeviceSocket> sockets = _deviceSocketCollection.GetAll().Values;
+
+            // App-targeted notifications only reach sockets authenticated as that app.
+            if (notification.TargetAppId.HasValue)
+            {
+                sockets = sockets.Where(ds => ds.AppId == notification.TargetAppId.Value);
+            }
+
             foreach (var deviceSocket in sockets)
             {
                 await SendMessageAsync(
@@ -438,6 +469,9 @@ namespace Odin.Services.AppNotifications.WebSocket
         {
             public required bool ShouldEncrypt { get; init; }
             public required string Json { get; init; }
+
+            // When set, deliver only to sockets authenticated as this app; null = broadcast to all.
+            public Guid? TargetAppId { get; init; }
         }
 
         private class DriveNotificationMessage

--- a/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationHandler.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/AppNotificationHandler.cs
@@ -9,10 +9,13 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Odin.Core;
 using Odin.Core.Exceptions;
+using Odin.Core.Identity;
 using Odin.Core.Serialization;
+using Odin.Core.Time;
 using Odin.Services.AppNotifications.ClientNotifications;
 using Odin.Services.Base;
 using Odin.Services.Drives;
+using Odin.Services.LiveRelay;
 using Odin.Services.Mediator;
 using Odin.Services.Peer;
 using Odin.Services.Peer.Incoming.Drive.Transfer;
@@ -38,15 +41,18 @@ namespace Odin.Services.AppNotifications.WebSocket
         private readonly ILogger<AppNotificationHandler> _logger;
         private readonly AppNotificationDispatcher _dispatcher;
         private readonly PeerInboxProcessor _peerInboxProcessor;
+        private readonly LiveRelayRetainedStore _liveRelayRetainedStore;
 
         public AppNotificationHandler(
             ILogger<AppNotificationHandler> logger,
             AppNotificationDispatcher dispatcher,
-            PeerInboxProcessor peerInboxProcessor)
+            PeerInboxProcessor peerInboxProcessor,
+            LiveRelayRetainedStore liveRelayRetainedStore)
         {
             _logger = logger;
             _dispatcher = dispatcher;
             _peerInboxProcessor = peerInboxProcessor;
+            _liveRelayRetainedStore = liveRelayRetainedStore;
         }
 
         //
@@ -257,6 +263,9 @@ namespace Odin.Services.AppNotifications.WebSocket
 
                         deviceSocket.DeviceOdinContext = odinContext.Clone();
                         deviceSocket.Drives = drives;
+                        // Capture the app this socket is authenticated as, so app-scoped
+                        // notifications (e.g. live relay) are delivered only to its sockets.
+                        deviceSocket.AppId = odinContext.Caller.OdinClientContext?.AppId?.Value;
                     }
                     catch (OdinSecurityException e)
                     {
@@ -276,6 +285,11 @@ namespace Odin.Services.AppNotifications.WebSocket
                         OdinSystemSerializer.Serialize(response),
                         encrypt: true,
                         cancellationToken);
+
+                    // Hydrate the freshly-connected socket with the last live-relay data point from
+                    // every sender for this app, so a (re)connecting/foregrounding client immediately
+                    // sees current state without asking for anything.
+                    await FlushRetainedLiveRelayAsync(deviceSocket, cancellationToken);
                     break;
 
                 case SocketCommandType.ProcessTransitInstructions:
@@ -314,6 +328,40 @@ namespace Odin.Services.AppNotifications.WebSocket
                 NotificationType = notificationType,
                 Data = message,
             });
+        }
+
+        //
+
+        private async Task FlushRetainedLiveRelayAsync(DeviceSocket deviceSocket, CancellationToken cancellationToken)
+        {
+            var appId = deviceSocket.AppId;
+            if (!appId.HasValue)
+            {
+                return;
+            }
+
+            try
+            {
+                var entries = await _liveRelayRetainedStore.GetAllForAppAsync(appId.Value, cancellationToken);
+                foreach (var entry in entries)
+                {
+                    var notification = new LiveRelayNotification
+                    {
+                        SenderOdinId = new OdinId(entry.SenderDomain),
+                        ChannelKey = entry.ChannelKey,
+                        Blob = entry.Blob,
+                        ReceivedAt = new UnixTimeUtc(entry.ReceivedAtMs),
+                        TargetAppId = appId.Value
+                    };
+
+                    await _dispatcher.SendClientNotificationToSocketAsync(deviceSocket, notification, cancellationToken);
+                }
+            }
+            catch (Exception e)
+            {
+                // Hydration is best-effort; never let it break the socket handshake.
+                _logger.LogInformation(e, "Live relay flush-on-connect failed: {error}", e.Message);
+            }
         }
     }
 }

--- a/src/services/Odin.Services/AppNotifications/WebSocket/ClientNotificationType.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/ClientNotificationType.cs
@@ -29,6 +29,11 @@ public enum ClientNotificationType
     /// </summary>
     TemporalDriveAccessed = 5001,
     /// <summary>
+    /// An opaque live-relay data point (e.g. live GPS) pushed by a connected identity to an app.
+    /// Carries the sending identity, a channel key, the opaque blob, and the server-received time.
+    /// </summary>
+    LiveRelay = 6001,
+    /// <summary>
     /// Indicates the notification doesnt need this value.  Note: this implies we might be able to dorp this field all together
     /// </summary>
     Unused = 8001,

--- a/src/services/Odin.Services/AppNotifications/WebSocket/DeviceSocket.cs
+++ b/src/services/Odin.Services/AppNotifications/WebSocket/DeviceSocket.cs
@@ -25,6 +25,13 @@ public class DeviceSocket
     public Guid Key { get; init; }
     public System.Net.WebSockets.WebSocket? Socket { get; init; }
     public IOdinContext? DeviceOdinContext { get; set; }
+
+    /// <summary>
+    /// The app this socket is authenticated as, if any. Used to deliver app-scoped notifications
+    /// (e.g. live relay data) only to sockets belonging to the matching app.
+    /// </summary>
+    public Guid? AppId { get; set; }
+
     public List<Guid> Drives { get; set; } = [];
     public TimeSpan Timeout { get; init; } = DefaultTimeout;
 

--- a/src/services/Odin.Services/Authorization/Apps/AppRegistrationService.cs
+++ b/src/services/Odin.Services/Authorization/Apps/AppRegistrationService.cs
@@ -262,6 +262,7 @@ namespace Odin.Services.Authorization.Apps
                             ClientIdOrDomain = appReg.Name,
                             CorsHostName = appReg.CorsHostName,
                             AccessRegistrationId = accessReg.Id,
+                            AppId = appReg.AppId,
                             DevicePushNotificationKey = null
                         })
                 };

--- a/src/services/Odin.Services/Base/OdinClientContext.cs
+++ b/src/services/Odin.Services/Base/OdinClientContext.cs
@@ -16,6 +16,12 @@ public class OdinClientContext : IGenericCloneable<OdinClientContext>
     /// </summary>
     public GuidId AccessRegistrationId { get; init; }
 
+    /// <summary>
+    /// The id of the app the caller is acting as, if the caller authenticated with an app token.
+    /// Null for owner/guest callers. Used to route app-scoped live data to the correct app's sockets.
+    /// </summary>
+    public GuidId AppId { get; init; }
+
     public Guid? DevicePushNotificationKey { get; init; }
 
     public string ClientIdOrDomain { get; set; }
@@ -26,6 +32,7 @@ public class OdinClientContext : IGenericCloneable<OdinClientContext>
         {
             CorsHostName = CorsHostName,
             AccessRegistrationId = AccessRegistrationId?.Clone(),
+            AppId = AppId?.Clone(),
             DevicePushNotificationKey = DevicePushNotificationKey,
             ClientIdOrDomain = ClientIdOrDomain
         };

--- a/src/services/Odin.Services/LiveRelay/ILiveRelayHttpClient.cs
+++ b/src/services/Odin.Services/LiveRelay/ILiveRelayHttpClient.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Odin.Services.Peer;
+using Refit;
+
+namespace Odin.Services.LiveRelay;
+
+/// <summary>
+/// Server-to-server (hop 2) client: the sender's server fires a live data point at each recipient's
+/// peer perimeter, fire-and-forget. Mirrors <c>IPeerAppNotificationHttpClient</c>.
+/// </summary>
+public interface ILiveRelayHttpClient
+{
+    [Post(PeerApiPathConstants.LiveRelayV1 + "/relay")]
+    Task<ApiResponse<PeerTransferResponse>> Relay([Body] LiveRelayPeerEnvelope envelope, CancellationToken cancellationToken = default);
+}

--- a/src/services/Odin.Services/LiveRelay/LiveRelayPeerEnvelope.cs
+++ b/src/services/Odin.Services/LiveRelay/LiveRelayPeerEnvelope.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Odin.Services.LiveRelay;
+
+/// <summary>
+/// Server-to-server wire payload (hop 2). The sender identity is NOT carried here — the recipient
+/// learns it for certain from the mutual-TLS peer cert.
+/// </summary>
+public class LiveRelayPeerEnvelope
+{
+    public Guid ChannelKey { get; init; }
+
+    /// <summary>Opaque, app-encrypted bytes (base64). Never interpreted by the server.</summary>
+    public string Blob { get; init; }
+
+    /// <summary>The app the data is scoped to (inferred from the sender's app token on hop 1).</summary>
+    public Guid AppId { get; init; }
+}

--- a/src/services/Odin.Services/LiveRelay/LiveRelayRequest.cs
+++ b/src/services/Odin.Services/LiveRelay/LiveRelayRequest.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Odin.Services.LiveRelay;
+
+/// <summary>
+/// App-initiated request (hop 1): "share this opaque live data point with these connected
+/// identities on this channel". The app does not declare its own AppId — it is inferred from the
+/// authenticated caller.
+/// </summary>
+public class LiveRelayRequest
+{
+    /// <summary>Per-share-session key the participants agreed on; only routing, never interpreted.</summary>
+    public Guid ChannelKey { get; init; }
+
+    /// <summary>The connected identities to share with.</summary>
+    public List<string> Recipients { get; init; } = new();
+
+    /// <summary>Opaque, app-encrypted bytes (base64). Never interpreted by the server.</summary>
+    public string Blob { get; init; }
+}

--- a/src/services/Odin.Services/LiveRelay/LiveRelayRetainedEntry.cs
+++ b/src/services/Odin.Services/LiveRelay/LiveRelayRetainedEntry.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace Odin.Services.LiveRelay;
+
+/// <summary>
+/// The last data point received from a single sender on a single channel. Serialized into the
+/// layer-2 cache, so it must be a plain named type (no tuples/anonymous types).
+/// </summary>
+public sealed class LiveRelayRetainedEntry
+{
+    public string Blob { get; init; }
+    public Guid AppId { get; init; }
+    public Guid ChannelKey { get; init; }
+    public string SenderDomain { get; init; }
+
+    /// <summary>Server-received time, ms since unix epoch.</summary>
+    public long ReceivedAtMs { get; init; }
+}
+
+/// <summary>
+/// All retained last-data-points for one app in one tenant, keyed by "{channelKey}:{senderDomain}".
+/// Stored as a single cache value so the whole set can be read in one shot for reconnect-flush.
+/// </summary>
+public sealed class LiveRelayAppSnapshot
+{
+    public Dictionary<string, LiveRelayRetainedEntry> Entries { get; init; } = new();
+}

--- a/src/services/Odin.Services/LiveRelay/LiveRelayRetainedStore.cs
+++ b/src/services/Odin.Services/LiveRelay/LiveRelayRetainedStore.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Odin.Core.Identity;
+using Odin.Core.Storage.Cache;
+using Odin.Core.Time;
+
+namespace Odin.Services.LiveRelay;
+
+/// <summary>
+/// Holds the last live-relay data point per (channel, sender), per app, for a tenant. Ephemeral and
+/// last-value-wins — there is no durable storage. Backed by the transparent layer-2 cache
+/// (<see cref="ITenantLevel2Cache{T}"/>: in-memory L1 + Redis L2, memory-only when Redis is off),
+/// so any server instance can read the set to flush current state to a (re)connecting client.
+///
+/// Registered as a per-tenant singleton so the per-app <see cref="SemaphoreSlim"/> serializes the
+/// read-modify-write of a snapshot value within an instance. Across instances the FusionCache Redis
+/// backplane keeps L1 coherent; the only residual is a rare concurrent-write window, which is
+/// self-healing for last-value-wins data.
+/// </summary>
+public sealed class LiveRelayRetainedStore
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(5);
+
+    private readonly ITenantLevel2Cache<LiveRelayRetainedStore> _cache;
+    private readonly ConcurrentDictionary<Guid, SemaphoreSlim> _locks = new();
+
+    public LiveRelayRetainedStore(ITenantLevel2Cache<LiveRelayRetainedStore> cache)
+    {
+        _cache = cache;
+    }
+
+    public async Task PutAsync(
+        Guid appId,
+        Guid channelKey,
+        OdinId sender,
+        string blob,
+        UnixTimeUtc receivedAt,
+        CancellationToken cancellationToken = default)
+    {
+        var sem = _locks.GetOrAdd(appId, _ => new SemaphoreSlim(1, 1));
+        await sem.WaitAsync(cancellationToken);
+        try
+        {
+            var key = CacheKey(appId);
+            var snapshot = await _cache.GetOrDefaultAsync<LiveRelayAppSnapshot>(key, cancellationToken: cancellationToken)
+                           ?? new LiveRelayAppSnapshot();
+
+            PruneExpired(snapshot);
+
+            snapshot.Entries[SlotKey(channelKey, sender)] = new LiveRelayRetainedEntry
+            {
+                Blob = blob,
+                AppId = appId,
+                ChannelKey = channelKey,
+                SenderDomain = sender.DomainName,
+                ReceivedAtMs = receivedAt.milliseconds
+            };
+
+            await _cache.SetAsync(key, snapshot, Ttl, cancellationToken: cancellationToken);
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    /// <summary>
+    /// Returns every non-expired sender's last data point for the given app in this tenant.
+    /// </summary>
+    public async Task<List<LiveRelayRetainedEntry>> GetAllForAppAsync(
+        Guid appId,
+        CancellationToken cancellationToken = default)
+    {
+        var snapshot = await _cache.GetOrDefaultAsync<LiveRelayAppSnapshot>(
+            CacheKey(appId), cancellationToken: cancellationToken);
+
+        if (snapshot == null)
+        {
+            return new List<LiveRelayRetainedEntry>();
+        }
+
+        var cutoff = UnixTimeUtc.Now().milliseconds - (long)Ttl.TotalMilliseconds;
+        return snapshot.Entries.Values.Where(e => e.ReceivedAtMs >= cutoff).ToList();
+    }
+
+    private static void PruneExpired(LiveRelayAppSnapshot snapshot)
+    {
+        var cutoff = UnixTimeUtc.Now().milliseconds - (long)Ttl.TotalMilliseconds;
+        var stale = snapshot.Entries.Where(kvp => kvp.Value.ReceivedAtMs < cutoff).Select(kvp => kvp.Key).ToList();
+        foreach (var k in stale)
+        {
+            snapshot.Entries.Remove(k);
+        }
+    }
+
+    private static string CacheKey(Guid appId) => $"live-relay:{appId}";
+
+    private static string SlotKey(Guid channelKey, OdinId sender) => $"{channelKey}:{sender.DomainName}";
+}

--- a/src/services/Odin.Services/LiveRelay/LiveRelayService.cs
+++ b/src/services/Odin.Services/LiveRelay/LiveRelayService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.Extensions.Logging;
+using Odin.Core.Exceptions;
+using Odin.Core.Identity;
+using Odin.Services.Authorization.Permissions;
+using Odin.Services.Base;
+using Odin.Services.Configuration;
+using Odin.Services.Drives;
+using Odin.Services.Membership.Connections;
+using Odin.Services.Peer;
+using Odin.Services.Util;
+
+namespace Odin.Services.LiveRelay;
+
+/// <summary>
+/// Sender side (hops 1→2): fans an opaque live data point out to each connected recipient's peer
+/// perimeter, fire-and-forget. No outbox, no retry, no durable storage — if a recipient is
+/// unreachable the point is simply dropped (the next tick supersedes it).
+/// </summary>
+public class LiveRelayService : PeerServiceBase
+{
+    // Bound a hung/unreachable recipient so it can't stall the fan-out for the whole tick.
+    private static readonly TimeSpan PerRecipientTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly ILogger<LiveRelayService> _logger;
+    private readonly ILifetimeScope _lifetimeScope;
+
+    public LiveRelayService(
+        IOdinHttpClientFactory odinHttpClientFactory,
+        CircleNetworkService circleNetworkService,
+        FileSystemResolver fileSystemResolver,
+        OdinConfiguration odinConfiguration,
+        ILogger<LiveRelayService> logger,
+        ILifetimeScope lifetimeScope)
+        : base(odinHttpClientFactory, circleNetworkService, fileSystemResolver, odinConfiguration)
+    {
+        _logger = logger;
+        _lifetimeScope = lifetimeScope;
+    }
+
+    public async Task RelayAsync(LiveRelayRequest request, IOdinContext odinContext)
+    {
+        OdinValidationUtils.AssertNotNull(request, nameof(request));
+        OdinValidationUtils.AssertNotEmptyGuid(request.ChannelKey, nameof(request.ChannelKey));
+        OdinValidationUtils.AssertNotNullOrEmpty(request.Blob, nameof(request.Blob));
+        OdinValidationUtils.AssertValidRecipientList(request.Recipients, allowEmpty: false);
+
+        odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.UseTransitWrite);
+
+        var appId = odinContext.Caller.OdinClientContext?.AppId?.Value;
+        if (!appId.HasValue)
+        {
+            throw new OdinClientException("Live relay requires an app context");
+        }
+
+        var envelope = new LiveRelayPeerEnvelope
+        {
+            ChannelKey = request.ChannelKey,
+            Blob = request.Blob,
+            AppId = appId.Value
+        };
+
+        var recipients = request.Recipients.ToOdinIdList().Distinct().ToList();
+
+        // Fan out in parallel; each branch gets its own lifetime scope so concurrent DB access
+        // (ICR resolution) doesn't trip the per-scope ScopedConnectionFactory parallelism guard.
+        var tasks = recipients.Select(recipient => SendFireAndForgetAsync(recipient, envelope, odinContext));
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task SendFireAndForgetAsync(OdinId recipient, LiveRelayPeerEnvelope envelope, IOdinContext odinContext)
+    {
+        try
+        {
+            await using var childScope = _lifetimeScope.BeginLifetimeScope($"LiveRelay:{Guid.NewGuid()}");
+            var svc = childScope.Resolve<LiveRelayService>();
+            await svc.SendOneAsync(recipient, envelope, odinContext);
+        }
+        catch (Exception e)
+        {
+            // Fire-and-forget: an unreachable/erroring recipient is dropped, never surfaced.
+            _logger.LogDebug(e, "Live relay to {recipient} dropped: {error}", recipient, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Sends one envelope to one recipient. Public so a child-scoped instance can be invoked from
+    /// <see cref="SendFireAndForgetAsync"/>; not part of the external surface.
+    /// </summary>
+    public async Task SendOneAsync(OdinId recipient, LiveRelayPeerEnvelope envelope, IOdinContext odinContext)
+    {
+        var (_, client) = await CreateHttpClientAsync<ILiveRelayHttpClient>(recipient, odinContext);
+        using var cts = new CancellationTokenSource(PerRecipientTimeout);
+        await client.Relay(envelope, cts.Token);
+    }
+}

--- a/src/services/Odin.Services/LiveRelay/PeerLiveRelayReceiverService.cs
+++ b/src/services/Odin.Services/LiveRelay/PeerLiveRelayReceiverService.cs
@@ -1,0 +1,72 @@
+using System.Threading.Tasks;
+using MediatR;
+using Odin.Core.Exceptions;
+using Odin.Core.Time;
+using Odin.Services.AppNotifications.ClientNotifications;
+using Odin.Services.Base;
+using Odin.Services.Membership.Connections;
+using Odin.Services.Peer;
+using Odin.Services.Util;
+
+namespace Odin.Services.LiveRelay;
+
+/// <summary>
+/// Recipient side (hop 2 ingress): accepts an opaque live data point from a connected peer, retains
+/// the sender's last point in the (ephemeral) store, and publishes it to the matching app's
+/// connected sockets. Nothing durable is written.
+/// </summary>
+public class PeerLiveRelayReceiverService
+{
+    private readonly CircleNetworkService _circleNetworkService;
+    private readonly LiveRelayRetainedStore _store;
+    private readonly IMediator _mediator;
+
+    public PeerLiveRelayReceiverService(
+        CircleNetworkService circleNetworkService,
+        LiveRelayRetainedStore store,
+        IMediator mediator)
+    {
+        _circleNetworkService = circleNetworkService;
+        _store = store;
+        _mediator = mediator;
+    }
+
+    public async Task<PeerTransferResponse> ReceiveAsync(LiveRelayPeerEnvelope envelope, IOdinContext odinContext)
+    {
+        odinContext.Caller.AssertCallerIsAuthenticated();
+
+        OdinValidationUtils.AssertNotNull(envelope, nameof(envelope));
+        OdinValidationUtils.AssertNotEmptyGuid(envelope.ChannelKey, nameof(envelope.ChannelKey));
+        OdinValidationUtils.AssertNotEmptyGuid(envelope.AppId, nameof(envelope.AppId));
+        OdinValidationUtils.AssertNotNullOrEmpty(envelope.Blob, nameof(envelope.Blob));
+
+        var caller = odinContext.GetCallerOdinIdOrFail();
+
+        // Accept only from a connected identity. (overrideHack: the peer-transfer context lacks the
+        // ReadConnections permission; mirrors PeerAppNotificationService.)
+        var isConnected = (await _circleNetworkService.GetIcrAsync(caller, odinContext, overrideHack: true)).IsConnected();
+        if (!isConnected)
+        {
+            throw new OdinSecurityException("Caller not connected");
+        }
+
+        var receivedAt = UnixTimeUtc.Now();
+
+        await _store.PutAsync(envelope.AppId, envelope.ChannelKey, caller, envelope.Blob, receivedAt);
+
+        await _mediator.Publish(new LiveRelayNotification
+        {
+            SenderOdinId = caller,
+            ChannelKey = envelope.ChannelKey,
+            Blob = envelope.Blob,
+            ReceivedAt = receivedAt,
+            TargetAppId = envelope.AppId,
+            OdinContext = odinContext
+        });
+
+        return new PeerTransferResponse
+        {
+            Code = PeerResponseCode.AcceptedIntoInbox
+        };
+    }
+}

--- a/src/services/Odin.Services/Peer/PeerApiPathConstants.cs
+++ b/src/services/Odin.Services/Peer/PeerApiPathConstants.cs
@@ -7,6 +7,7 @@ public static class PeerApiPathConstants
     
     public const string SecurityV1 = HostV1 + "/security";
     public const string AppNotificationsV1 = HostV1 + "/security/notify";
+    public const string LiveRelayV1 = HostV1 + "/live-relay";
     public const string DriveV1 = HostV1 + "/drives";
     public const string FeedV1 = HostV1 + "/feed";
     public const string ReactionsV1 = HostV1 + "/reactions";

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/ILiveRelayHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/ILiveRelayHttpClientApiV2.cs
@@ -1,0 +1,16 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Odin.Hosting.UnifiedV2;
+using Odin.Services.LiveRelay;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+/// <summary>
+/// Client for the V2 live-relay endpoint (hop 1: app -> its own server).
+/// </summary>
+public interface ILiveRelayHttpClientApiV2
+{
+    [Post(UnifiedApiRouteConstants.LiveRelay)]
+    Task<ApiResponse<HttpContent>> Relay([Body] LiveRelayRequest request);
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/LiveRelay/LiveRelayShareGpsExampleTest.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/LiveRelay/LiveRelayShareGpsExampleTest.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core;
+using Odin.Core.Serialization;
+using Odin.Hosting.Authentication.YouAuth;
+using Odin.Hosting.Tests._V2.ApiClient;
+using Odin.Hosting.Tests._V2.ApiClient.Factory;
+using Odin.Services.Drives;
+using Odin.Services.LiveRelay;
+
+namespace Odin.Hosting.Tests._V2.Tests.LiveRelay;
+
+/// <summary>
+/// EXAMPLE / REFERENCE TEST — the end-to-end contract a client implements to share live GPS.
+///
+/// Two friends each run the same app (one shared appId). One opens the "live map" (a websocket to
+/// its own server) and the other shares GPS coordinates. The server treats the coordinate as an
+/// opaque <c>Blob</c> — it is the app that encodes/encrypts and decodes. Nothing is stored durably.
+///
+/// Client recipe demonstrated here:
+///   1) both identities run the same app (shared appId) and are connected
+///   2) recipient opens the notification websocket (authenticated as that app) and handshakes
+///   3) sender POSTs /api/v2/live-relay with { channelKey, recipients, blob }
+///   4) recipient receives a LiveRelay notification carrying { senderOdinId, channelKey, blob,
+///      receivedAt }, filters by the channelKey of its open session, decodes the blob, and draws it
+/// </summary>
+[TestFixture]
+public class LiveRelayShareGpsExampleTest
+{
+    private WebScaffold _scaffold;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = GetType().Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: new List<TestIdentity>
+        {
+            TestIdentities.Frodo,
+            TestIdentities.Samwise
+        });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _scaffold.RunAfterAnyTests();
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [TearDown]
+    public void TearDown() => _scaffold.AssertLogEvents();
+
+    // The opaque payload, from the app's point of view. In production this is end-to-end encrypted
+    // by the app before it leaves the device; the server never sees inside it.
+    private class GpsPoint
+    {
+        public double Lat { get; set; }
+        public double Lon { get; set; }
+    }
+
+    [Test]
+    public async Task TwoFriendsShareLiveGps()
+    {
+        var sharer = TestIdentities.Frodo;     // shares his location
+        var watcher = TestIdentities.Samwise;  // watches the live map
+
+        var ownerSharer = _scaffold.CreateOwnerApiClientRedux(sharer);
+        var ownerWatcher = _scaffold.CreateOwnerApiClientRedux(watcher);
+
+        // (1) Both run the same app and are connected friends.
+        var appId = Guid.NewGuid();
+        var sharerCircle = await LiveRelayTestHelpers.PrepareAppAccessAsync(ownerSharer, appId, TargetDrive.NewTargetDrive());
+        var watcherCircle = await LiveRelayTestHelpers.PrepareAppAccessAsync(ownerWatcher, appId, TargetDrive.NewTargetDrive());
+        await ownerSharer.Connections.SendConnectionRequest(watcher.OdinId, new List<GuidId> { sharerCircle });
+        await ownerWatcher.Connections.AcceptConnectionRequest(sharer.OdinId, new List<GuidId> { watcherCircle });
+
+        var (sharerAppToken, sharerAppSecret) = await ownerSharer.AppManager.RegisterAppClient(appId);
+        var (watcherAppToken, watcherAppSecret) = await ownerWatcher.AppManager.RegisterAppClient(appId);
+
+        // The session both apps agreed on (e.g. "our vacation trip"). The watcher renders only data
+        // for sessions it has open; the sharer puts everyone it wants to share with on Recipients.
+        var tripChannel = Guid.NewGuid();
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            // (2) Watcher opens the live map: connect the websocket as the app, then handshake.
+            using var socket = await LiveRelayTestHelpers.ConnectAppSocketAsync(watcher.OdinId, watcherAppToken, cts.Token);
+            await LiveRelayTestHelpers.DoHandshakeAsync(socket, watcherAppSecret, new List<TargetDrive>(), cts.Token);
+
+            // (3) Sharer encodes a GPS point (opaque to the server) and shares it on the channel.
+            var point = new GpsPoint { Lat = 51.5072, Lon = -0.1276 };
+            var blob = Convert.ToBase64String(OdinSystemSerializer.Serialize(point).ToUtf8ByteArray());
+
+            var factory = new ApiClientFactoryV2(YouAuthConstants.AppCookieName, sharerAppToken, sharerAppSecret);
+            var client = factory.CreateHttpClient(sharer.OdinId, out var sharedSecret);
+            var liveRelay = RefitCreator.RestServiceFor<ILiveRelayHttpClientApiV2>(client, sharedSecret);
+
+            var response = await liveRelay.Relay(new LiveRelayRequest
+            {
+                ChannelKey = tripChannel,
+                Recipients = new List<string> { watcher.OdinId.DomainName },
+                Blob = blob
+            });
+            Assert.That(response.IsSuccessStatusCode, Is.True, $"share failed: {response.StatusCode}");
+
+            // (4) Watcher receives it live and decodes the coordinate.
+            var received = await LiveRelayTestHelpers.WaitForLiveRelayAsync(socket, watcherAppSecret, TimeSpan.FromSeconds(20));
+            Assert.That(received, Is.Not.Null, "watcher did not receive the shared location");
+            Assert.That(received.ChannelKey, Is.EqualTo(tripChannel), "client routes by channel to the open session");
+            Assert.That(received.SenderOdinId, Is.EqualTo(sharer.OdinId.DomainName), "who is at this position");
+            Assert.That(received.ReceivedAt, Is.GreaterThan(0), "freshness for the map");
+
+            var decoded = OdinSystemSerializer.Deserialize<GpsPoint>(
+                Convert.FromBase64String(received.Blob).ToStringFromUtf8Bytes());
+            Assert.That(decoded.Lat, Is.EqualTo(point.Lat));
+            Assert.That(decoded.Lon, Is.EqualTo(point.Lon));
+
+            await LiveRelayTestHelpers.CloseQuietlyAsync(socket);
+        }
+        finally
+        {
+            await ownerSharer.Connections.DisconnectFrom(watcher.OdinId);
+            await ownerWatcher.Connections.DisconnectFrom(sharer.OdinId);
+        }
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/LiveRelay/LiveRelayTestHelpers.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/LiveRelay/LiveRelayTestHelpers.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Odin.Core;
+using Odin.Core.Identity;
+using Odin.Core.Serialization;
+using Odin.Hosting.Tests._Universal.ApiClient;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Hosting.UnifiedV2;
+using Odin.Services.AppNotifications.WebSocket;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Authorization.Permissions;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+
+namespace Odin.Hosting.Tests._V2.Tests.LiveRelay;
+
+/// <summary>
+/// Shared setup + websocket helpers for the live-relay tests. Mirrors the proven app peer-send
+/// pattern (PeerNotificationTests) and the V2 notification websocket pattern
+/// (V2NotificationSocketControllerTests).
+/// </summary>
+internal static class LiveRelayTestHelpers
+{
+    public const string BearerProtocolPrefix = "odin.bearer.";
+    public const string NegotiatedSubProtocol = "odin.notify.v1";
+
+    /// <summary>The client-facing shape of a LiveRelay notification's Data field.</summary>
+    public class LiveRelayClientData
+    {
+        public string SenderOdinId { get; set; }
+        public Guid ChannelKey { get; set; }
+        public string Blob { get; set; }
+        public long ReceivedAt { get; set; }
+    }
+
+    /// <summary>
+    /// Registers a drive + circle + an app (with UseTransitWrite) on the given identity, so the app
+    /// can both share over peer and be reached by connected identities. Returns the circle id to
+    /// grant when connecting. Both the sender and recipient must register the SAME appId.
+    /// </summary>
+    public static async Task<Guid> PrepareAppAccessAsync(OwnerApiClientRedux owner, Guid appId, TargetDrive targetDrive)
+    {
+        var circleId = Guid.NewGuid();
+
+        await owner.DriveManager.CreateDrive(targetDrive, "Live Relay Drive", "", false);
+        await owner.Network.CreateCircle(circleId, "Live Relay Participants", new PermissionSetGrantRequest
+        {
+            PermissionSet = new PermissionSet(PermissionKeys.ReadWhoIFollow) // just need a circle to connect into
+        });
+
+        var appPermissions = new PermissionSetGrantRequest
+        {
+            Drives = new List<DriveGrantRequest>
+            {
+                new()
+                {
+                    PermissionedDrive = new PermissionedDrive
+                    {
+                        Drive = targetDrive,
+                        Permission = DrivePermission.ReadWrite
+                    }
+                }
+            },
+            PermissionSet = new PermissionSet(PermissionKeys.UseTransitWrite)
+        };
+
+        var circles = new List<Guid> { circleId };
+        var circlePermissions = new PermissionSetGrantRequest
+        {
+            Drives = new List<DriveGrantRequest>
+            {
+                new()
+                {
+                    PermissionedDrive = new PermissionedDrive
+                    {
+                        Drive = targetDrive,
+                        Permission = DrivePermission.Write
+                    }
+                }
+            }
+        };
+
+        await owner.AppManager.RegisterApp(appId, appPermissions, circles, circlePermissions);
+        return circleId;
+    }
+
+    public static async Task<ClientWebSocket> ConnectAppSocketAsync(
+        OdinId identity,
+        ClientAuthenticationToken appToken,
+        CancellationToken cancellationToken)
+    {
+        var socket = new ClientWebSocket();
+        socket.Options.CollectHttpResponseDetails = true;
+        socket.Options.AddSubProtocol(NegotiatedSubProtocol);
+        socket.Options.AddSubProtocol(BearerProtocolPrefix + ToBase64Url(appToken.ToPortableBytes()));
+
+        var uri = new Uri($"wss://{identity}:{WebScaffold.HttpsPort}{UnifiedApiRouteConstants.NotifySocket}");
+        await socket.ConnectAsync(uri, cancellationToken);
+        return socket;
+    }
+
+    public static async Task<EstablishConnectionResponse> DoHandshakeAsync(
+        ClientWebSocket socket,
+        byte[] sharedSecret,
+        List<TargetDrive> subscribedDrives,
+        CancellationToken cancellationToken)
+    {
+        var command = new SocketCommand
+        {
+            Command = SocketCommandType.EstablishConnectionRequest,
+            Data = OdinSystemSerializer.Serialize(new EstablishConnectionOptions { Drives = subscribedDrives })
+        };
+
+        var encrypted = SharedSecretEncryptedPayload.Encrypt(
+            OdinSystemSerializer.Serialize(command).ToUtf8ByteArray(),
+            sharedSecret.ToSensitiveByteArray());
+
+        var sendBuffer = OdinSystemSerializer.Serialize(encrypted).ToUtf8ByteArray();
+        await socket.SendAsync(new ArraySegment<byte>(sendBuffer), WebSocketMessageType.Text, true, cancellationToken);
+
+        var frame = await ReadFrameAsync(socket, cancellationToken);
+        return DecryptClientNotification<EstablishConnectionResponse>(frame, sharedSecret);
+    }
+
+    /// <summary>
+    /// Reads websocket frames until one decodes to a LiveRelay notification, or returns null on
+    /// timeout/close. Skips any other notifications received in the meantime. The timeout does NOT
+    /// cancel the in-flight receive (which would abort the socket and break a clean close) — it just
+    /// stops waiting and leaves the pending receive to be drained by the subsequent close.
+    /// </summary>
+    public static async Task<LiveRelayClientData> WaitForLiveRelayAsync(
+        ClientWebSocket socket,
+        byte[] sharedSecret,
+        TimeSpan timeout)
+    {
+        var deadline = Task.Delay(timeout);
+        try
+        {
+            while (socket.State == WebSocketState.Open)
+            {
+                var frameTask = ReadFrameAsync(socket, CancellationToken.None);
+                var completed = await Task.WhenAny(frameTask, deadline);
+                if (completed != frameTask)
+                {
+                    // Timed out. Observe the still-pending receive's eventual exception so it
+                    // doesn't surface as unobserved when the socket is later closed/disposed.
+                    _ = frameTask.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+                    return null;
+                }
+
+                var frame = await frameTask;
+                if (frame == null)
+                {
+                    return null;
+                }
+
+                var notification = DecryptClientNotification<TestClientNotification>(frame, sharedSecret);
+                if (notification.NotificationType == ClientNotificationType.LiveRelay)
+                {
+                    return OdinSystemSerializer.Deserialize<LiveRelayClientData>(notification.Data);
+                }
+            }
+        }
+        catch (WebSocketException) { /* server closed */ }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Closes a socket without throwing if it is not in a closable state (e.g. a pending receive is
+    /// still outstanding from a timed-out wait).
+    /// </summary>
+    public static async Task CloseQuietlyAsync(ClientWebSocket socket)
+    {
+        try
+        {
+            if (socket.State == WebSocketState.Open)
+            {
+                await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+            }
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    private static async Task<byte[]> ReadFrameAsync(ClientWebSocket socket, CancellationToken cancellationToken)
+    {
+        var buffer = new ArraySegment<byte>(new byte[1024 * 8]);
+        using var ms = new MemoryStream();
+        WebSocketReceiveResult receiveResult;
+        do
+        {
+            receiveResult = await socket.ReceiveAsync(buffer, cancellationToken);
+            if (receiveResult.MessageType == WebSocketMessageType.Close)
+            {
+                return null;
+            }
+
+            ms.Write(buffer.Array!, buffer.Offset, receiveResult.Count);
+        } while (!receiveResult.EndOfMessage);
+
+        return ms.ToArray();
+    }
+
+    private static T DecryptClientNotification<T>(byte[] frameBytes, byte[] sharedSecret)
+    {
+        var json = frameBytes.ToStringFromUtf8Bytes();
+        var payload = OdinSystemSerializer.Deserialize<ClientNotificationPayload>(json);
+        if (payload.IsEncrypted)
+        {
+            var decrypted = SharedSecretEncryptedPayload.Decrypt(payload.Payload, sharedSecret.ToSensitiveByteArray());
+            return OdinSystemSerializer.Deserialize<T>(decrypted);
+        }
+
+        return OdinSystemSerializer.Deserialize<T>(payload.Payload);
+    }
+
+    public static string ToBase64Url(byte[] bytes)
+        => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/LiveRelay/V2LiveRelayTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/LiveRelay/V2LiveRelayTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core;
+using Odin.Hosting.Authentication.YouAuth;
+using Odin.Hosting.Tests._Universal.ApiClient.Owner;
+using Odin.Hosting.Tests._V2.ApiClient;
+using Odin.Hosting.Tests._V2.ApiClient.Factory;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Drives;
+using Odin.Services.LiveRelay;
+
+namespace Odin.Hosting.Tests._V2.Tests.LiveRelay;
+
+/// <summary>
+/// Coverage for the Live Relay primitive: app-initiated, ephemeral, last-value-wins data sharing
+/// between connected identities. Exercises delivery, server-enforced app isolation, automatic
+/// flush-on-(re)connect, and the not-connected guard.
+/// </summary>
+[TestFixture]
+public class V2LiveRelayTests
+{
+    private WebScaffold _scaffold;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var folder = GetType().Name;
+        _scaffold = new WebScaffold(folder);
+        _scaffold.RunBeforeAnyTests(testIdentities: new List<TestIdentity>
+        {
+            TestIdentities.Frodo,
+            TestIdentities.Samwise,
+            TestIdentities.Merry
+        });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _scaffold.RunAfterAnyTests();
+
+    [SetUp]
+    public void Setup()
+    {
+        _scaffold.ClearAssertLogEventsAction();
+        _scaffold.ClearLogEvents();
+    }
+
+    [TearDown]
+    public void TearDown() => _scaffold.AssertLogEvents();
+
+    [Test]
+    public async Task Relay_FromConnectedApp_IsDeliveredToRecipientAppSocket()
+    {
+        var frodo = TestIdentities.Frodo;
+        var sam = TestIdentities.Samwise;
+        var ownerFrodo = _scaffold.CreateOwnerApiClientRedux(frodo);
+        var ownerSam = _scaffold.CreateOwnerApiClientRedux(sam);
+
+        var appId = Guid.NewGuid();
+        var (frodoAppToken, frodoAppSecret, samAppToken, samAppSecret) =
+            await ConnectAndSetupAppAsync(ownerFrodo, ownerSam, frodo, sam, appId);
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var samSocket = await LiveRelayTestHelpers.ConnectAppSocketAsync(sam.OdinId, samAppToken, cts.Token);
+            await LiveRelayTestHelpers.DoHandshakeAsync(samSocket, samAppSecret, new List<TargetDrive>(), cts.Token);
+
+            var channelKey = Guid.NewGuid();
+            const string blob = "eyJsYXQiOjUxLjUsImxvbiI6LTAuMX0="; // opaque to the server
+
+            var relayResponse = await SendRelayAsync(frodo, frodoAppToken, frodoAppSecret,
+                channelKey, new List<string> { sam.OdinId.DomainName }, blob);
+            Assert.That(relayResponse.IsSuccessStatusCode, Is.True, $"relay failed: {relayResponse.StatusCode}");
+
+            var received = await LiveRelayTestHelpers.WaitForLiveRelayAsync(samSocket, samAppSecret, TimeSpan.FromSeconds(20));
+
+            Assert.That(received, Is.Not.Null, "recipient socket did not receive the live relay notification");
+            Assert.That(received.Blob, Is.EqualTo(blob), "blob must be byte-identical end to end");
+            Assert.That(received.ChannelKey, Is.EqualTo(channelKey));
+            Assert.That(received.SenderOdinId, Is.EqualTo(frodo.OdinId.DomainName), "sender identity is authoritative");
+            Assert.That(received.ReceivedAt, Is.GreaterThan(0), "server-received timestamp must be stamped");
+
+            await LiveRelayTestHelpers.CloseQuietlyAsync(samSocket);
+        }
+        finally
+        {
+            await DisconnectAsync(ownerFrodo, ownerSam, frodo, sam);
+        }
+    }
+
+    [Test]
+    public async Task Relay_IsNotDeliveredToSocketOfADifferentApp()
+    {
+        var frodo = TestIdentities.Frodo;
+        var sam = TestIdentities.Samwise;
+        var ownerFrodo = _scaffold.CreateOwnerApiClientRedux(frodo);
+        var ownerSam = _scaffold.CreateOwnerApiClientRedux(sam);
+
+        var appId = Guid.NewGuid();
+        var (frodoAppToken, frodoAppSecret, _, _) =
+            await ConnectAndSetupAppAsync(ownerFrodo, ownerSam, frodo, sam, appId);
+
+        // A second, unrelated app on Sam — its socket must never see the first app's data.
+        var otherAppId = Guid.NewGuid();
+        await LiveRelayTestHelpers.PrepareAppAccessAsync(ownerSam, otherAppId, TargetDrive.NewTargetDrive());
+        var (otherAppToken, otherAppSecret) = await ownerSam.AppManager.RegisterAppClient(otherAppId);
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var otherSocket = await LiveRelayTestHelpers.ConnectAppSocketAsync(sam.OdinId, otherAppToken, cts.Token);
+            await LiveRelayTestHelpers.DoHandshakeAsync(otherSocket, otherAppSecret, new List<TargetDrive>(), cts.Token);
+
+            var relayResponse = await SendRelayAsync(frodo, frodoAppToken, frodoAppSecret,
+                Guid.NewGuid(), new List<string> { sam.OdinId.DomainName }, "c29tZS1ncHM=");
+            Assert.That(relayResponse.IsSuccessStatusCode, Is.True);
+
+            var received = await LiveRelayTestHelpers.WaitForLiveRelayAsync(otherSocket, otherAppSecret, TimeSpan.FromSeconds(5));
+            Assert.That(received, Is.Null, "a different app's socket must not receive the relay (server-enforced app isolation)");
+
+            await LiveRelayTestHelpers.CloseQuietlyAsync(otherSocket);
+        }
+        finally
+        {
+            await DisconnectAsync(ownerFrodo, ownerSam, frodo, sam);
+        }
+    }
+
+    [Test]
+    public async Task Relay_WhileRecipientHasNoSocket_IsFlushedOnConnect()
+    {
+        var frodo = TestIdentities.Frodo;
+        var sam = TestIdentities.Samwise;
+        var ownerFrodo = _scaffold.CreateOwnerApiClientRedux(frodo);
+        var ownerSam = _scaffold.CreateOwnerApiClientRedux(sam);
+
+        var appId = Guid.NewGuid();
+        var (frodoAppToken, frodoAppSecret, samAppToken, samAppSecret) =
+            await ConnectAndSetupAppAsync(ownerFrodo, ownerSam, frodo, sam, appId);
+
+        try
+        {
+            var channelKey = Guid.NewGuid();
+            const string blob = "bGFzdC1rbm93bi1wb3NpdGlvbg==";
+
+            // Relay BEFORE Sam connects any socket — the point is retained, not lost.
+            var relayResponse = await SendRelayAsync(frodo, frodoAppToken, frodoAppSecret,
+                channelKey, new List<string> { sam.OdinId.DomainName }, blob);
+            Assert.That(relayResponse.IsSuccessStatusCode, Is.True);
+
+            // Give the recipient server a moment to land + retain the point.
+            await Task.Delay(500);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var samSocket = await LiveRelayTestHelpers.ConnectAppSocketAsync(sam.OdinId, samAppToken, cts.Token);
+            await LiveRelayTestHelpers.DoHandshakeAsync(samSocket, samAppSecret, new List<TargetDrive>(), cts.Token);
+
+            // No new relay is sent — the data must arrive purely via flush-on-connect.
+            var received = await LiveRelayTestHelpers.WaitForLiveRelayAsync(samSocket, samAppSecret, TimeSpan.FromSeconds(20));
+
+            Assert.That(received, Is.Not.Null, "retained point was not flushed to the newly-connected socket");
+            Assert.That(received.Blob, Is.EqualTo(blob));
+            Assert.That(received.ChannelKey, Is.EqualTo(channelKey));
+            Assert.That(received.SenderOdinId, Is.EqualTo(frodo.OdinId.DomainName));
+
+            await LiveRelayTestHelpers.CloseQuietlyAsync(samSocket);
+        }
+        finally
+        {
+            await DisconnectAsync(ownerFrodo, ownerSam, frodo, sam);
+        }
+    }
+
+    [Test]
+    public async Task Relay_ToNonConnectedIdentity_IsDroppedAndNotDelivered()
+    {
+        // Frodo and Merry are never connected. The relay must be silently dropped (fire-and-forget)
+        // and nothing must reach Merry's socket.
+        var frodo = TestIdentities.Frodo;
+        var merry = TestIdentities.Merry;
+        var ownerFrodo = _scaffold.CreateOwnerApiClientRedux(frodo);
+        var ownerMerry = _scaffold.CreateOwnerApiClientRedux(merry);
+
+        // Frodo needs the app (with UseTransitWrite) to call the endpoint; Merry needs the same app
+        // to authenticate a socket.
+        var appId = Guid.NewGuid();
+        await LiveRelayTestHelpers.PrepareAppAccessAsync(ownerFrodo, appId, TargetDrive.NewTargetDrive());
+        await LiveRelayTestHelpers.PrepareAppAccessAsync(ownerMerry, appId, TargetDrive.NewTargetDrive());
+        var (frodoAppToken, frodoAppSecret) = await ownerFrodo.AppManager.RegisterAppClient(appId);
+        var (merryAppToken, merryAppSecret) = await ownerMerry.AppManager.RegisterAppClient(appId);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var merrySocket = await LiveRelayTestHelpers.ConnectAppSocketAsync(merry.OdinId, merryAppToken, cts.Token);
+        await LiveRelayTestHelpers.DoHandshakeAsync(merrySocket, merryAppSecret, new List<TargetDrive>(), cts.Token);
+
+        // Fire-and-forget: even with an unreachable/non-connected recipient the call succeeds.
+        var relayResponse = await SendRelayAsync(frodo, frodoAppToken, frodoAppSecret,
+            Guid.NewGuid(), new List<string> { merry.OdinId.DomainName }, "c2hvdWxkLW5vdC1hcnJpdmU=");
+        Assert.That(relayResponse.IsSuccessStatusCode, Is.True, "relay must not fail the caller on a dropped recipient");
+
+        var received = await LiveRelayTestHelpers.WaitForLiveRelayAsync(merrySocket, merryAppSecret, TimeSpan.FromSeconds(5));
+        Assert.That(received, Is.Null, "data must not be delivered to a non-connected identity");
+
+        await LiveRelayTestHelpers.CloseQuietlyAsync(merrySocket);
+    }
+
+    //
+
+    private async Task<(ClientAuthenticationToken frodoAppToken, byte[] frodoAppSecret,
+            ClientAuthenticationToken samAppToken, byte[] samAppSecret)>
+        ConnectAndSetupAppAsync(
+            OwnerApiClientRedux ownerFrodo, OwnerApiClientRedux ownerSam,
+            TestIdentity frodo, TestIdentity sam, Guid appId)
+    {
+        // Same app on both identities (a single shared appId — e.g. the chat app).
+        var frodoCircleId = await LiveRelayTestHelpers.PrepareAppAccessAsync(ownerFrodo, appId, TargetDrive.NewTargetDrive());
+        var samCircleId = await LiveRelayTestHelpers.PrepareAppAccessAsync(ownerSam, appId, TargetDrive.NewTargetDrive());
+
+        await ownerFrodo.Connections.SendConnectionRequest(sam.OdinId, new List<GuidId> { frodoCircleId });
+        await ownerSam.Connections.AcceptConnectionRequest(frodo.OdinId, new List<GuidId> { samCircleId });
+
+        var (frodoAppToken, frodoAppSecret) = await ownerFrodo.AppManager.RegisterAppClient(appId);
+        var (samAppToken, samAppSecret) = await ownerSam.AppManager.RegisterAppClient(appId);
+
+        return (frodoAppToken, frodoAppSecret, samAppToken, samAppSecret);
+    }
+
+    private static async Task DisconnectAsync(
+        OwnerApiClientRedux ownerFrodo, OwnerApiClientRedux ownerSam, TestIdentity frodo, TestIdentity sam)
+    {
+        await ownerFrodo.Connections.DisconnectFrom(sam.OdinId);
+        await ownerSam.Connections.DisconnectFrom(frodo.OdinId);
+    }
+
+    private static async Task<Refit.IApiResponse> SendRelayAsync(
+        TestIdentity sender, ClientAuthenticationToken appToken, byte[] appSecret,
+        Guid channelKey, List<string> recipients, string blob)
+    {
+        var factory = new ApiClientFactoryV2(YouAuthConstants.AppCookieName, appToken, appSecret);
+        var client = factory.CreateHttpClient(sender.OdinId, out var sharedSecret);
+        var svc = RefitCreator.RestServiceFor<ILiveRelayHttpClientApiV2>(client, sharedSecret);
+        return await svc.Relay(new LiveRelayRequest
+        {
+            ChannelKey = channelKey,
+            Recipients = recipients,
+            Blob = blob
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Introduces **Live Relay** — a generic, app-agnostic primitive for sharing *live, ephemeral* data among a group of already-connected identities, each running their own server. The motivating use case is a group of friends sharing live GPS for a trip, but the server treats the carried bytes (`Blob`) as opaque.

This PR opens with the **design document** (`docs/live-relay-plan.md`) as the first file; implementation commits follow on this branch.

## Design at a glance

- **Decentralized mesh, no relay/master** — each participant publishes its own stream to a recipient list it holds. No leader election, no single point of failure.
- **Ephemeral, last-value-wins** — no drive writes, no outbox, no notification DB. "If you're offline, the data is just gone."
- **Three transport hops:**
  1. App → its own server: **HTTP POST** (background-reliable on mobile).
  2. Sender server → each recipient server: ephemeral fire-and-forget **HTTP POST** (no outbox, drop on failure), mutual-TLS peer auth.
  3. Recipient server → clients: the **existing websocket publish lane** (`ITenantPubSub` → `AppNotificationDispatcher`), with a new per-AppId socket filter.
- **Server-enforced app isolation** — the AppId is inferred from the authenticated caller and used to deliver only to matching-app sockets (a chat GPS blob never reaches a different Homebase app).
- **Sender identity + received timestamp** forwarded to clients with every blob.
- **Automatic reconnect-flush** — a per-tenant retained store (one `ITenantLevel2Cache` impl, per-app snapshot) lets any instance flush every sender's last data point to a (re)connecting client, with no client-supplied lists. Multi-instance correctness via the per-app `SemaphoreSlim` (same-instance) and the already-enabled FusionCache Redis backplane (cross-instance).

See `docs/live-relay-plan.md` for the full design, file-by-file plan, and test strategy.

## Out of scope

- WebRTC group calling (separate participant-relay data plane).
- Server-enforced per-channel consent (client gates the session; server enforces the app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)