### PR TITLE
Add v9->v10 migration granting ProfileDrive read to system circles

### DIFF
--- a/src/apps/Odin.Hosting/TenantServices.cs
+++ b/src/apps/Odin.Hosting/TenantServices.cs
@@ -75,6 +75,7 @@ using Odin.Services.Configuration.VersionUpgrade.Version5tov6;
 using Odin.Services.Configuration.VersionUpgrade.Version6tov7;
 using Odin.Services.Configuration.VersionUpgrade.Version7tov8;
 using Odin.Services.Configuration.VersionUpgrade.Version8tov9;
+using Odin.Services.Configuration.VersionUpgrade.Version9tov10;
 using Odin.Services.Security.Email;
 using Odin.Services.Security.Health;
 using Odin.Services.Security.PasswordRecovery.RecoveryPhrase;
@@ -374,6 +375,7 @@ public static class TenantServices
         cb.RegisterType<V6ToV7VersionMigrationService>().InstancePerLifetimeScope();
         cb.RegisterType<V7ToV8VersionMigrationService>().InstancePerLifetimeScope();
         cb.RegisterType<V8ToV9VersionMigrationService>().InstancePerLifetimeScope();
+        cb.RegisterType<V9ToV10VersionMigrationService>().InstancePerLifetimeScope();
 
         cb.RegisterType<VersionUpgradeService>().InstancePerLifetimeScope();
         cb.RegisterType<VersionUpgradeScheduler>().InstancePerLifetimeScope();

--- a/src/services/Odin.Services/Configuration/VersionUpgrade/Version9tov10/V9ToV10VersionMigrationService.cs
+++ b/src/services/Odin.Services/Configuration/VersionUpgrade/Version9tov10/V9ToV10VersionMigrationService.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Odin.Core;
+using Odin.Core.Exceptions;
+using Odin.Core.Storage.Database.Identity;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Base;
+using Odin.Services.Drives;
+using Odin.Services.Drives.Management;
+using Odin.Services.Membership.Circles;
+using Odin.Services.Membership.Connections;
+
+namespace Odin.Services.Configuration.VersionUpgrade.Version9tov10
+{
+    /// <summary>
+    /// v9 → v10: ensures the system connection circles
+    /// (<see cref="SystemCircleConstants.ConfirmedConnectionsCircleId"/> and
+    /// <see cref="SystemCircleConstants.AutoConnectionsCircleId"/>) grant
+    /// <see cref="DrivePermission.Read"/> on the <see cref="SystemDriveConstants.ProfileDrive"/>, and
+    /// re-issues that grant to every already-connected identity.
+    ///
+    /// <para>
+    /// The point of the grant is the <b>storage key</b>: a Read grant is what causes
+    /// <see cref="DriveGrant.KeyStoreKeyEncryptedStorageKey"/> to be populated (the drive's storage key,
+    /// re-encrypted under the member's key-store key), which is what lets the connected identity
+    /// <i>decrypt</i> ProfileDrive data — not merely see the permission flag. Re-issuing the circle grant
+    /// regenerates that encrypted storage key from the drive for each member.
+    /// </para>
+    ///
+    /// <para>
+    /// The ProfileDrive is an <c>AllowAnonymousReads</c> drive, so a fresh install already receives this
+    /// grant automatically: <see cref="CircleNetworkService.HandleDriveAdded"/> adds a Read grant for
+    /// every anonymous drive to both system circles when the drive is created. This migration backfills
+    /// the same grant onto <b>existing</b> installs whose already-connected identities hold a circle-grant
+    /// snapshot that predates it (and therefore lacks the storage key). It adds the ProfileDrive Read
+    /// grant to each system circle definition if missing and calls
+    /// <see cref="CircleNetworkService.UpdateCircleDefinitionAsync"/>, which both persists the definition
+    /// and re-creates the circle grant — including the encrypted storage key — for every connected member.
+    /// </para>
+    /// </summary>
+    public class V9ToV10VersionMigrationService(
+        ILogger<V9ToV10VersionMigrationService> logger,
+        CircleNetworkService circleNetworkService,
+        CircleDefinitionService circleDefinitionService,
+        IdentityDatabase db,
+        IDriveManager driveManager)
+    {
+        public async Task UpgradeAsync(IOdinContext odinContext, CancellationToken cancellationToken)
+        {
+            odinContext.Caller.AssertHasMasterKey();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // The ProfileDrive is created up front by the EnsureSystemDrivesExist pre-pass in
+            // VersionUpgradeService, so it exists before the circle-definition grant is validated below.
+
+            await using var tx = await db.BeginStackedTransactionAsync(IsolationLevel.Unspecified, cancellationToken);
+
+            foreach (var circleId in SystemCircleConstants.AllSystemCircles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await EnsureProfileDriveReadGrantAsync(circleId, odinContext);
+            }
+
+            tx.Commit();
+        }
+
+        public async Task ValidateUpgradeAsync(IOdinContext odinContext, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var profileDrive = await driveManager.GetDriveAsync(SystemDriveConstants.ProfileDrive.Alias, false);
+            if (profileDrive == null)
+            {
+                throw new OdinSystemException("Profile drive not created");
+            }
+
+            // Every system circle definition must now grant Read on the ProfileDrive.
+            foreach (var circleId in SystemCircleConstants.AllSystemCircles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var def = await circleDefinitionService.GetCircleAsync(circleId);
+                if (def == null)
+                {
+                    throw new OdinSystemException($"System circle {circleId} not found");
+                }
+
+                if (!HasProfileDriveRead(def))
+                {
+                    throw new OdinSystemException($"System circle {circleId} does not grant Read on the ProfileDrive");
+                }
+            }
+
+            // Every connected identity who is a member of a system circle must now hold the ProfileDrive grant.
+            var allIdentities = await circleNetworkService.GetConnectedIdentitiesAsync(int.MaxValue, null, odinContext);
+            foreach (var identity in allIdentities.Results)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var circleId in SystemCircleConstants.AllSystemCircles)
+                {
+                    // Only validate identities who are members of this system circle.
+                    if (!identity.AccessGrant.CircleGrants.TryGetValue(circleId, out var circleGrant))
+                    {
+                        continue;
+                    }
+
+                    var driveGrant = circleGrant.KeyStoreKeyEncryptedDriveGrants
+                        .SingleOrDefault(g => g.PermissionedDrive.Drive == SystemDriveConstants.ProfileDrive);
+
+                    if (driveGrant == null)
+                    {
+                        throw new OdinSystemException("Drive grant for ProfileDrive not found");
+                    }
+
+                    if (!driveGrant.PermissionedDrive.Permission.HasFlag(DrivePermission.Read))
+                    {
+                        throw new OdinSystemException("ProfileDrive not granted read permission");
+                    }
+
+                    // The Read grant is only meaningful if it carries the encrypted storage key — that's
+                    // what lets the connected identity decrypt ProfileDrive data.
+                    if (driveGrant.KeyStoreKeyEncryptedStorageKey == null)
+                    {
+                        throw new OdinSystemException(
+                            $"ProfileDrive grant for identity {identity.OdinId} has no storage key; cannot decrypt drive data");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds the ProfileDrive Read grant to the given system circle definition if it is missing, then
+        /// re-issues the circle grant to every connected member via
+        /// <see cref="CircleNetworkService.UpdateCircleDefinitionAsync"/>. Calling it when the grant is
+        /// already present simply re-propagates the (unchanged) definition to members, so existing
+        /// identities whose snapshot predates the grant pick it up.
+        /// </summary>
+        private async Task EnsureProfileDriveReadGrantAsync(GuidId circleId, IOdinContext odinContext)
+        {
+            var def = await circleDefinitionService.GetCircleAsync(circleId);
+            if (def == null)
+            {
+                // EnsureSystemCirclesExistAsync runs as part of provisioning; a missing system circle here
+                // means the tenant isn't initialized. Nothing to backfill — skip rather than crash.
+                logger.LogWarning("System circle {circleId} not found; skipping ProfileDrive grant backfill", circleId);
+                return;
+            }
+
+            if (!HasProfileDriveRead(def))
+            {
+                logger.LogInformation("Granting ProfileDrive Read to system circle {circleId}", circleId);
+
+                var grants = def.DriveGrants?.ToList() ?? new List<DriveGrantRequest>();
+                grants.Add(new DriveGrantRequest
+                {
+                    PermissionedDrive = new PermissionedDrive
+                    {
+                        Drive = SystemDriveConstants.ProfileDrive,
+                        Permission = DrivePermission.Read
+                    }
+                });
+                def.DriveGrants = grants;
+            }
+
+            // Persists the definition and re-creates the circle grant for every connected member.
+            logger.LogDebug("Re-issuing system circle {circleId} grants to connected members", circleId);
+            await circleNetworkService.UpdateCircleDefinitionAsync(def, odinContext);
+        }
+
+        private static bool HasProfileDriveRead(CircleDefinition def)
+        {
+            return def.DriveGrants?.Any(g =>
+                g.PermissionedDrive.Drive == SystemDriveConstants.ProfileDrive &&
+                g.PermissionedDrive.Permission.HasFlag(DrivePermission.Read)) ?? false;
+        }
+    }
+}

--- a/src/services/Odin.Services/Configuration/VersionUpgrade/VersionUpgradeService.cs
+++ b/src/services/Odin.Services/Configuration/VersionUpgrade/VersionUpgradeService.cs
@@ -16,6 +16,7 @@ using Odin.Services.Configuration.VersionUpgrade.Version5tov6;
 using Odin.Services.Configuration.VersionUpgrade.Version6tov7;
 using Odin.Services.Configuration.VersionUpgrade.Version7tov8;
 using Odin.Services.Configuration.VersionUpgrade.Version8tov9;
+using Odin.Services.Configuration.VersionUpgrade.Version9tov10;
 using Odin.Services.Membership.Connections;
 
 namespace Odin.Services.Configuration.VersionUpgrade;
@@ -32,6 +33,7 @@ public class VersionUpgradeService(
     V6ToV7VersionMigrationService v7,
     V7ToV8VersionMigrationService v8,
     V8ToV9VersionMigrationService v9,
+    V9ToV10VersionMigrationService v10,
     IdentityDatabase db,
     OwnerAuthenticationService authService,
     CircleNetworkService circleNetworkService,
@@ -295,6 +297,29 @@ public class VersionUpgradeService(
                 await v9.UpgradeAsync(odinContext, cancellationToken);
 
                 await v9.ValidateUpgradeAsync(odinContext, cancellationToken);
+
+                currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
+
+                tx.Commit();
+                logger.LogInformation(LogTag + " Upgrading to v{currentVersion} successful", currentVersion);
+            }
+
+            // do this after each version upgrade
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (currentVersion == 9)
+            {
+                await using var tx = await db.BeginStackedTransactionAsync(cancellationToken: cancellationToken);
+
+                _isRunning = true;
+                logger.LogInformation(LogTag + " Upgrading from v{currentVersion}", currentVersion);
+
+                await v10.UpgradeAsync(odinContext, cancellationToken);
+
+                await v10.ValidateUpgradeAsync(odinContext, cancellationToken);
 
                 currentVersion = (await tenantConfigService.IncrementVersionAsync()).DataVersionNumber;
 

--- a/src/services/Odin.Services/Version.cs
+++ b/src/services/Odin.Services/Version.cs
@@ -11,7 +11,7 @@ public static class Version
     /// <summary>
     /// Indicates version information the current release (data structure version, code version, etc.)
     /// </summary>
-    public const int DataVersionNumber = 9;
+    public const int DataVersionNumber = 10;
 }
 
 // DO NOT CHANGE OR MOVE THIS FILE

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/V9ToV10ProfileDriveMigrationTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/V9ToV10ProfileDriveMigrationTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using NUnit.Framework;
+using Odin.Core;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Services.Authentication.Owner;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Base;
+using Odin.Services.Configuration.VersionUpgrade.Version9tov10;
+using Odin.Services.Drives;
+using Odin.Services.Membership.Circles;
+using Odin.Services.Membership.Connections;
+
+namespace Odin.Hosting.Tests.V2.Ported.Connections;
+
+/// <summary>
+/// Verifies the v9 → v10 migration: the system connection circles
+/// (<see cref="SystemCircleConstants.ConfirmedConnectionsCircleId"/> and
+/// <see cref="SystemCircleConstants.AutoConnectionsCircleId"/>) grant
+/// <see cref="DrivePermission.Read"/> on the <see cref="SystemDriveConstants.ProfileDrive"/>, and — the
+/// real goal — every connected member's circle grant ends up carrying the drive's <b>storage key</b>
+/// (<see cref="RedactedDriveGrant.HasStorageKey"/>) so they can decrypt ProfileDrive data.
+///
+/// A freshly provisioned identity already ships with the grant (anonymous-read drives are auto-granted
+/// to the system circles when created), so each test first <b>downgrades</b> the stored circle
+/// definitions to their pre-v10 shape — removing the ProfileDrive grant — before establishing the
+/// connection, so the member's snapshot lacks it. The migration then backfills it. The migration is
+/// driven directly out of the tenant scope under a real owner (master-key) context, the way
+/// <c>VersionUpgradeService</c> drives it in production.
+/// </summary>
+[TestFixture]
+public class V9ToV10ProfileDriveMigrationTests : V2Fixture
+{
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task V10_GrantsProfileDriveStorageKey_ToConnectedMember()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        var scope = Host.GetTenantScope(frodo.Identity.DomainName);
+        var ctx = await BuildOwnerContextAsync(scope, frodo);
+        var circleDefinitionService = scope.Resolve<CircleDefinitionService>();
+
+        // Reproduce the pre-v10 state: strip the ProfileDrive grant from the system circle definitions
+        // BEFORE connecting, so the member's circle-grant snapshot is issued without it.
+        await RemoveProfileDriveGrantAsync(circleDefinitionService, SystemCircleConstants.ConfirmedConnectionsCircleId);
+        await RemoveProfileDriveGrantAsync(circleDefinitionService, SystemCircleConstants.AutoConnectionsCircleId);
+
+        // Connect: Frodo (IdentityOwner origin) → Sam lands in Frodo's ConfirmedConnections circle.
+        await frodo.Connections.SendConnectionRequest(sam.Identity);
+        await sam.Connections.AcceptConnectionRequest(frodo.Identity);
+
+        // Precondition: Sam's confirmed-connections grant has no ProfileDrive grant (hence no storage key).
+        var before = await GetProfileDriveGrantAsync(frodo, sam, SystemCircleConstants.ConfirmedConnectionsCircleId);
+        Assert.That(before, Is.Null,
+            "precondition: the connected member should not yet have a ProfileDrive grant");
+
+        var migration = scope.Resolve<V9ToV10VersionMigrationService>();
+        await migration.UpgradeAsync(ctx, CancellationToken.None);
+        await migration.ValidateUpgradeAsync(ctx, CancellationToken.None);
+
+        // The member's ProfileDrive grant now exists and carries the storage key — i.e. they can decrypt.
+        var after = await GetProfileDriveGrantAsync(frodo, sam, SystemCircleConstants.ConfirmedConnectionsCircleId);
+        Assert.That(after, Is.Not.Null, "migration should grant the connected member ProfileDrive Read");
+        Assert.That(after!.PermissionedDrive.Permission.HasFlag(DrivePermission.Read), Is.True);
+        Assert.That(after.HasStorageKey, Is.True,
+            "the ProfileDrive grant must carry the storage key so the member can decrypt the data");
+    }
+
+    [Test]
+    public async Task V10_GrantsProfileDriveRead_ToSystemCircleDefinitions()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+
+        var scope = Host.GetTenantScope(frodo.Identity.DomainName);
+        var ctx = await BuildOwnerContextAsync(scope, frodo);
+        var circleDefinitionService = scope.Resolve<CircleDefinitionService>();
+
+        // Downgrade both system circles to their pre-v10 shape (no ProfileDrive grant).
+        await RemoveProfileDriveGrantAsync(circleDefinitionService, SystemCircleConstants.ConfirmedConnectionsCircleId);
+        await RemoveProfileDriveGrantAsync(circleDefinitionService, SystemCircleConstants.AutoConnectionsCircleId);
+
+        var confirmedBefore = await circleDefinitionService.GetCircleAsync(SystemCircleConstants.ConfirmedConnectionsCircleId);
+        var autoBefore = await circleDefinitionService.GetCircleAsync(SystemCircleConstants.AutoConnectionsCircleId);
+        Assert.That(HasProfileDriveRead(confirmedBefore), Is.False,
+            "precondition: confirmed-connections circle should not yet grant ProfileDrive Read");
+        Assert.That(HasProfileDriveRead(autoBefore), Is.False,
+            "precondition: auto-connections circle should not yet grant ProfileDrive Read");
+
+        var migration = scope.Resolve<V9ToV10VersionMigrationService>();
+        await migration.UpgradeAsync(ctx, CancellationToken.None);
+        // Second run must be a no-op (grant already present) and still validate.
+        await migration.UpgradeAsync(ctx, CancellationToken.None);
+        await migration.ValidateUpgradeAsync(ctx, CancellationToken.None);
+
+        var confirmedAfter = await circleDefinitionService.GetCircleAsync(SystemCircleConstants.ConfirmedConnectionsCircleId);
+        var autoAfter = await circleDefinitionService.GetCircleAsync(SystemCircleConstants.AutoConnectionsCircleId);
+        Assert.That(HasProfileDriveRead(confirmedAfter), Is.True,
+            "migration should grant ProfileDrive Read to the confirmed-connections circle");
+        Assert.That(HasProfileDriveRead(autoAfter), Is.True,
+            "migration should grant ProfileDrive Read to the auto-connections circle");
+
+        // The grant must not be duplicated by a repeated run.
+        Assert.That(confirmedAfter.DriveGrants.Count(g => g.PermissionedDrive.Drive == SystemDriveConstants.ProfileDrive), Is.EqualTo(1),
+            "ProfileDrive grant should appear exactly once after repeated migration runs");
+
+        // Existing drive grants are preserved (both circles ship with a ChatDrive grant).
+        Assert.That(confirmedAfter.DriveGrants.Any(g => g.PermissionedDrive.Drive == SystemDriveConstants.ChatDrive), Is.True,
+            "the existing ChatDrive grant on the confirmed-connections circle must be preserved");
+    }
+
+    private async Task<RedactedDriveGrant> GetProfileDriveGrantAsync(OwnerSession owner, OwnerSession member, GuidId circleId)
+    {
+        var info = await owner.Connections.GetConnectionInfo(member.Identity);
+        Assert.That(info.IsSuccessStatusCode, Is.True, "GetConnectionInfo should succeed");
+        Assert.That(info.Content!.Status, Is.EqualTo(ConnectionStatus.Connected), "the member should be connected");
+
+        var circleGrant = info.Content.AccessGrant.CircleGrants.SingleOrDefault(cg => cg.CircleId == circleId);
+        return circleGrant?.DriveGrants?.SingleOrDefault(g =>
+            g.PermissionedDrive.Drive == SystemDriveConstants.ProfileDrive);
+    }
+
+    private static async Task RemoveProfileDriveGrantAsync(CircleDefinitionService service, GuidId circleId)
+    {
+        var def = await service.GetCircleAsync(circleId);
+        def.DriveGrants = def.DriveGrants
+            .Where(g => g.PermissionedDrive.Drive != SystemDriveConstants.ProfileDrive)
+            .ToList();
+        await service.UpdateAsync(def, skipValidation: true);
+    }
+
+    private static bool HasProfileDriveRead(CircleDefinition circle)
+    {
+        return circle?.DriveGrants?.Any(g =>
+            g.PermissionedDrive.Drive == SystemDriveConstants.ProfileDrive &&
+            g.PermissionedDrive.Permission.HasFlag(DrivePermission.Read)) ?? false;
+    }
+
+    /// <summary>
+    /// Builds an owner context carrying the master key by replaying the production path used by
+    /// <c>VersionUpgradeService</c> (<see cref="OwnerAuthenticationService.UpdateOdinContextAsync"/>).
+    /// </summary>
+    private async Task<IOdinContext> BuildOwnerContextAsync(ILifetimeScope scope, OwnerSession owner)
+    {
+        var authService = scope.Resolve<OwnerAuthenticationService>();
+        var odinContext = new OdinContext
+        {
+            Tenant = default,
+            AuthTokenCreated = null,
+            Caller = null
+        };
+        var clientContext = new OdinClientContext
+        {
+            CorsHostName = null,
+            AccessRegistrationId = null,
+            DevicePushNotificationKey = null,
+            ClientIdOrDomain = null
+        };
+
+        await authService.UpdateOdinContextAsync(owner.Token, clientContext, odinContext);
+        odinContext.Caller.AssertHasMasterKey();
+        return odinContext;
+    }
+}


### PR DESCRIPTION
## What

Adds a `v9 → v10` version migration (`V9ToV10VersionMigrationService`) that ensures the system connection circles — `ConfirmedConnectionsCircleId` and `AutoConnectionsCircleId` — grant `Read` on the `ProfileDrive`, and re-issues that grant to every already-connected identity.

## Why

The point of the grant is the **storage key**. A `Read` grant is what causes `DriveGrant.KeyStoreKeyEncryptedStorageKey` to be populated (the drive's storage key, re-encrypted under the member's key-store key) — that's what lets a connected identity actually **decrypt** ProfileDrive data, not merely see the permission flag.

`ProfileDrive` is an `AllowAnonymousReads` drive, so fresh installs already receive this grant automatically: `CircleNetworkService.HandleDriveAdded` adds a Read grant for every anonymous drive to both system circles when the drive is created. This migration backfills the same grant onto **existing** installs whose already-connected identities hold a circle-grant snapshot predating it (and therefore lack the storage key).

## How

- Adds the ProfileDrive Read grant to each system circle definition if missing, then calls `CircleNetworkService.UpdateCircleDefinitionAsync` — the same path the anonymous-read handler uses — which persists the definition and regenerates the circle grant (including the encrypted storage key) for every connected member.
- `Version.DataVersionNumber`: `9 → 10`.
- Registers the service in `TenantServices` and wires it into the `VersionUpgradeService` upgrade ladder (`currentVersion == 9`).
- `ValidateUpgradeAsync` asserts the storage key is present on each connected member's ProfileDrive grant — not just the permission flag.

### Note on approach
This deliberately does **not** hardcode the grant into `SystemCircleConstants` (the pattern used by Lists/Moments in v7→v8 / v8→v9). For an anonymous-read drive that would (a) break fresh-identity provisioning ordering — system circles are created before drives, so the circle would reference a not-yet-existent ProfileDrive — and (b) produce a duplicate ProfileDrive grant alongside the existing `HandleDriveAdded` auto-grant.

## Tests

`V9ToV10ProfileDriveMigrationTests` (V2):
- `V10_GrantsProfileDriveStorageKey_ToConnectedMember` — strips the grant pre-connect, connects Sam into `ConfirmedConnections`, runs the migration, and asserts Sam's ProfileDrive grant ends up with `HasStorageKey == true` (concrete proof of decryptability).
- `V10_GrantsProfileDriveRead_ToSystemCircleDefinitions` — definition-level coverage + idempotency (no duplicate grant, existing grants preserved).

Both pass; the existing V8ToV9 migration suite is unaffected and `CircleConstants.cs` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)