### PR TITLE
Add V2 peer read-by-GlobalTransitId endpoints (header/payload/thumbnail)

### DIFF
--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DrivePeerQueryController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Read/V2DrivePeerQueryController.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Mvc;
 using Odin.Core.Identity;
 using Odin.Hosting.Controllers.Base;
 using Odin.Hosting.UnifiedV2.Authentication.Policy;
+using Odin.Services.Drives;
+using Odin.Services.Drives.FileSystem.Base;
 using Odin.Services.Peer.Outgoing.Drive.Query;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -27,6 +29,14 @@ namespace Odin.Hosting.UnifiedV2.Drive.Read
         }
     }
 
+    /// <summary>
+    /// Reads a single file's existence, header, payload, and thumbnails from a drive hosted by another
+    /// (peer) identity, addressed by GlobalTransitId — the V2 "over peer" equivalent of the V1
+    /// <c>/api/apps/v1/transit/query/{header,payload,thumb}_byglobaltransitid</c> endpoints. All
+    /// shared-secret re-encryption is performed inside <see cref="PeerDriveQueryService"/>; this
+    /// controller only forwards the resulting streams/headers. Mirrors
+    /// <see cref="V2DrivePeerFileReadonlyController"/> (the by-fileId twin).
+    /// </summary>
     [ApiController]
     [Route(UnifiedApiRouteConstants.PeerByGtid)]
     [UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]
@@ -42,6 +52,100 @@ namespace Odin.Hosting.UnifiedV2.Drive.Read
         {
             return await peerDriveQueryService.FileExistsOnRemoteByGlobalTransitId(
                 (OdinId)odinId, driveId, gtid, WebOdinContext);
+        }
+
+        [HttpGet("header")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
+        public async Task<IActionResult> GetFileHeader(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromRoute] Guid gtid)
+        {
+            AssertIsValidOdinId(odinId, out var id);
+
+            var result = await peerDriveQueryService.GetFileHeaderByGlobalTransitIdAsync(
+                id, ToGtidFile(driveId, gtid), GetHttpFileSystemResolver().GetFileSystemType(), WebOdinContext);
+
+            if (result == null)
+            {
+                return NotFound();
+            }
+
+            return new JsonResult(result);
+        }
+
+        // Full payload (Range header honored)
+        [HttpGet("payload/{payloadKey}")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
+        [NoSharedSecretOnRequest]
+        [NoSharedSecretOnResponse]
+        public Task<IActionResult> GetPayload(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromRoute] Guid gtid,
+            [FromRoute] string payloadKey)
+        {
+            return GetPayloadInternal(odinId, driveId, gtid, payloadKey, GetChunk(null, null));
+        }
+
+        // Ranged payload (route-based)
+        [HttpGet("payload/{payloadKey}/{start:int}/{length:int}")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
+        [NoSharedSecretOnRequest]
+        [NoSharedSecretOnResponse]
+        public Task<IActionResult> GetPayload(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromRoute] Guid gtid,
+            [FromRoute] string payloadKey,
+            [FromRoute] int start,
+            [FromRoute] int length)
+        {
+            return GetPayloadInternal(odinId, driveId, gtid, payloadKey, GetChunk(start, length));
+        }
+
+        [HttpGet("payload/{payloadKey}/thumb/{width}/{height}")]
+        [SwaggerOperation(Tags = [SwaggerInfo.FileRead])]
+        [NoSharedSecretOnRequest]
+        [NoSharedSecretOnResponse]
+        public async Task<IActionResult> GetThumbnail(
+            [FromRoute] string odinId,
+            [FromRoute] Guid driveId,
+            [FromRoute] Guid gtid,
+            [FromRoute] string payloadKey,
+            [FromRoute] int width,
+            [FromRoute] int height,
+            [FromQuery] bool directMatchOnly = false)
+        {
+            AssertIsValidOdinId(odinId, out var id);
+
+            var (encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb) =
+                await peerDriveQueryService.GetThumbnailByGlobalTransitIdAsync(id, ToGtidFile(driveId, gtid), payloadKey,
+                    width, height, directMatchOnly, GetHttpFileSystemResolver().GetFileSystemType(), WebOdinContext);
+
+            return HandlePeerThumbnailResponse(encryptedKeyHeader, isEncrypted, decryptedContentType, lastModified, thumb);
+        }
+
+        private async Task<IActionResult> GetPayloadInternal(string odinId, Guid driveId, Guid gtid, string payloadKey,
+            FileChunk chunk)
+        {
+            AssertIsValidOdinId(odinId, out var id);
+
+            var (encryptedKeyHeader, isEncrypted, payloadStream) =
+                await peerDriveQueryService.GetPayloadByGlobalTransitIdAsync(id, ToGtidFile(driveId, gtid), payloadKey,
+                    chunk, GetHttpFileSystemResolver().GetFileSystemType(), WebOdinContext);
+
+            return HandlePeerPayloadResponse(encryptedKeyHeader, isEncrypted, payloadStream);
+        }
+
+        // The remote resolves the drive by alias (matching the peer "exists" endpoints), so Type is left empty.
+        private static GlobalTransitIdFileIdentifier ToGtidFile(Guid driveId, Guid gtid)
+        {
+            return new GlobalTransitIdFileIdentifier
+            {
+                GlobalTransitId = gtid,
+                TargetDrive = new TargetDrive { Alias = driveId, Type = Guid.Empty }
+            };
         }
     }
 }

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerQueryByGtidContentTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Peer/PeerQueryByGtidContentTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Core;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Hosting.Tests.OwnerApi.ApiClient.Drive;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Hosting.Tests.V2.Peer;
+using Odin.Services.Authorization.Acl;
+using Odin.Services.Authorization.ExchangeGrants;
+using Odin.Services.Drives;
+using Odin.Services.Drives.FileSystem.Base;
+using Odin.Services.Drives.FileSystem.Base.Upload;
+
+namespace Odin.Hosting.Tests.V2.Ported.Peer;
+
+/// <summary>
+/// V2 "over peer" read of a file addressed by GlobalTransitId — the V2 equivalent of the V1
+/// <c>/api/apps/v1/transit/query/{header,payload,thumb}_byglobaltransitid</c> endpoints. Sibling of
+/// <see cref="PeerQueryAndContentTests"/> (which reads the same content by FileId).
+///
+/// Layout: <c>owner</c> (Sam) hosts the drive and uploads files locally; <c>member</c> (Frodo) is
+/// connected and granted Read on the owner's drive, then reads over peer by GlobalTransitId.
+/// </summary>
+[TestFixture]
+public class PeerQueryByGtidContentTests : V2Fixture
+{
+    private const int CommunityMessageFileType = 7020;
+
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task Member_CanGetHeaderAndPayloadAndThumbnailByGtidOverPeer()
+    {
+        var (member, owner, drive) = await SetupMemberCanReadOwnerDriveAsync();
+
+        var payload = SamplePayloadDefinitions.GetPayloadDefinitionWithThumbnail1();
+        var (_, gtid) = await OwnerUploadsFileAsync(owner, drive, payload);
+
+        // header
+        var header = await member.Drives.Peer.GetFileHeaderByGtidAsync(owner.Identity, drive.Alias, gtid);
+        Assert.That(header.IsSuccessStatusCode, Is.True, $"peer header-by-gtid failed: {header.StatusCode}");
+        Assert.That(header.Content!.FileMetadata.GlobalTransitId, Is.EqualTo(gtid));
+        Assert.That(header.Content!.FileMetadata.Payloads.Count(), Is.EqualTo(1));
+
+        // payload (unencrypted → bytes come back verbatim)
+        var payloadResponse = await member.Drives.Peer.GetPayloadByGtidAsync(owner.Identity, drive.Alias, gtid, payload.Key);
+        Assert.That(payloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), "peer payload-by-gtid should be 200");
+        var payloadBytes = await payloadResponse.Content!.ReadAsByteArrayAsync();
+        Assert.That(payloadBytes.ToBase64(), Is.EqualTo(payload.Content.ToBase64()), "payload content mismatch over peer");
+
+        // thumbnail
+        var thumb = payload.Thumbnails.Single();
+        var thumbResponse = await member.Drives.Peer.GetThumbnailByGtidAsync(
+            owner.Identity, drive.Alias, gtid, payload.Key, thumb.PixelWidth, thumb.PixelHeight);
+        Assert.That(thumbResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), "peer thumbnail-by-gtid should be 200");
+        var thumbBytes = await thumbResponse.Content!.ReadAsByteArrayAsync();
+        Assert.That(thumbBytes.ToBase64(), Is.EqualTo(thumb.Content.ToBase64()), "thumbnail content mismatch over peer");
+    }
+
+    [Test]
+    public async Task Member_ReadsRangedPayloadByGtidOverPeer()
+    {
+        var (member, owner, drive) = await SetupMemberCanReadOwnerDriveAsync();
+
+        var payload = SamplePayloadDefinitions.GetPayloadDefinition1();
+        var (_, gtid) = await OwnerUploadsFileAsync(owner, drive, payload);
+
+        const int start = 1;
+        const int length = 4;
+        var response = await member.Drives.Peer.GetPayloadByGtidAsync(
+            owner.Identity, drive.Alias, gtid, payload.Key, new FileChunk { Start = start, Length = length });
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"peer ranged payload-by-gtid failed: {response.StatusCode}");
+
+        var bytes = await response.Content!.ReadAsByteArrayAsync();
+        var expected = payload.Content.Skip(start).Take(length).ToArray();
+        Assert.That(bytes.Length, Is.EqualTo(expected.Length), "ranged read returned the wrong number of bytes");
+        Assert.That(ByteArrayUtil.EquiByteArrayCompare(bytes, expected), Is.True, "ranged payload slice mismatch over peer");
+    }
+
+    [Test]
+    public async Task Member_GetHeaderByGtidOverPeer_MissingFile_ReturnsNotFound()
+    {
+        var (member, owner, drive) = await SetupMemberCanReadOwnerDriveAsync();
+
+        var header = await member.Drives.Peer.GetFileHeaderByGtidAsync(owner.Identity, drive.Alias, Guid.NewGuid());
+        Assert.That(header.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    public async Task NotConnectedMember_GetHeaderByGtidOverPeer_IsRejected()
+    {
+        // Both identities exist and each has the drive, but no connection / grant exists.
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+
+        var drive = TargetDrive.NewTargetDrive();
+        await member.Admin.CreateDrive(drive, "member copy", allowAnonymousReads: false);
+        await owner.Admin.CreateDrive(drive, "owner copy", allowAnonymousReads: false);
+
+        var header = await member.Drives.Peer.GetFileHeaderByGtidAsync(owner.Identity, drive.Alias, Guid.NewGuid());
+        Assert.That(header.IsSuccessStatusCode, Is.False,
+            $"unconnected member should not be able to read the owner's drive; got {header.StatusCode}");
+    }
+
+    // -----------------------------------------------------------------------------------------
+
+    private async Task<(OwnerSession member, OwnerSession owner, TargetDrive drive)> SetupMemberCanReadOwnerDriveAsync()
+    {
+        var member = await LoginAsOwner(Identities.Frodo);
+        var owner = await LoginAsOwner(Identities.Sam);
+        // sender = member: the member is granted Read on the owner's (recipient's) drive.
+        var drive = await PeerFlow.CreatePeerDriveAsync(member, owner, DrivePermission.Read, "community",
+            allowAnonymousReads: false);
+        return (member, owner, drive);
+    }
+
+    // Owner uploads a file locally and we resolve its GlobalTransitId from the stored header
+    // (guaranteed populated server-side, independent of distribution).
+    private static async Task<(Guid fileId, Guid gtid)> OwnerUploadsFileAsync(
+        OwnerSession owner, TargetDrive drive, TestPayloadDefinition payload)
+    {
+        var metadata = SampleMetadataData.Create(fileType: CommunityMessageFileType, acl: AccessControlList.Connected);
+        var manifest = new UploadManifest
+        {
+            PayloadDescriptors = new List<TestPayloadDefinition> { payload }.ToPayloadDescriptorList().ToList()
+        };
+        var uploaded = await owner.Drives.Writer.CreateNewUnencryptedFile(
+            drive.Alias, metadata, manifest, new List<TestPayloadDefinition> { payload });
+        Assert.That(uploaded.IsSuccessStatusCode, Is.True, $"owner upload failed: {uploaded.StatusCode}");
+        var fileId = uploaded.Content!.FileId;
+
+        var header = await owner.Drives.Reader.GetFileHeaderAsync(drive.Alias, fileId);
+        Assert.That(header.IsSuccessStatusCode, Is.True, $"owner header read failed: {header.StatusCode}");
+        var gtid = header.Content!.FileMetadata.GlobalTransitId
+                   ?? throw new InvalidOperationException("stored file is expected to have a GlobalTransitId");
+        return (fileId, gtid);
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DrivePeerReaderV2Client.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DrivePeerReaderV2Client.cs
@@ -65,6 +65,37 @@ public class DrivePeerReaderV2Client(OdinId identity, IApiClientFactory factory)
         return await svc.GetThumbnail(peer.DomainName, driveId, fileId, payloadKey, width, height);
     }
 
+    // --- Read by GlobalTransitId ---
+
+    public async Task<ApiResponse<SharedSecretEncryptedFileHeader>> GetFileHeaderByGtidAsync(OdinId peer, Guid driveId, Guid gtid,
+        FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetFileHeaderByGtid(peer.DomainName, driveId, gtid);
+    }
+
+    public async Task<ApiResponse<HttpContent>> GetPayloadByGtidAsync(OdinId peer, Guid driveId, Guid gtid, string payloadKey,
+        FileChunk chunk = null, FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        if (chunk == null)
+        {
+            return await svc.GetPayloadByGtid(peer.DomainName, driveId, gtid, payloadKey);
+        }
+
+        return await svc.GetPayloadByGtid(peer.DomainName, driveId, gtid, payloadKey, chunk.Start, chunk.Length);
+    }
+
+    public async Task<ApiResponse<HttpContent>> GetThumbnailByGtidAsync(OdinId peer, Guid driveId, Guid gtid, string payloadKey,
+        int width, int height, FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetThumbnailByGtid(peer.DomainName, driveId, gtid, payloadKey, width, height);
+    }
+
     // --- Temporal (time-boxed) read API ---
 
     public async Task<ApiResponse<TemporalAccessStatus>> VerifyTemporalAccessAsync(OdinId peer, Guid driveId,

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerQueryHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerQueryHttpClientApiV2.cs
@@ -23,6 +23,37 @@ public interface IDrivePeerQueryHttpClientApiV2
         [AliasAs("driveId:guid")] Guid driveId,
         [AliasAs("gtid:guid")] Guid gtid);
 
+    [Get(UnifiedApiRouteConstants.PeerByGtid + "/header")]
+    Task<ApiResponse<SharedSecretEncryptedFileHeader>> GetFileHeaderByGtid(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("gtid:guid")] Guid gtid);
+
+    [Get(UnifiedApiRouteConstants.PeerByGtid + "/payload/{payloadKey}")]
+    Task<ApiResponse<HttpContent>> GetPayloadByGtid(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("gtid:guid")] Guid gtid,
+        [AliasAs("payloadKey")] string payloadKey);
+
+    [Get(UnifiedApiRouteConstants.PeerByGtid + "/payload/{payloadKey}/{start:int}/{length:int}")]
+    Task<ApiResponse<HttpContent>> GetPayloadByGtid(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("gtid:guid")] Guid gtid,
+        [AliasAs("payloadKey")] string payloadKey,
+        [AliasAs("start:int")] int start,
+        [AliasAs("length:int")] int length);
+
+    [Get(UnifiedApiRouteConstants.PeerByGtid + "/payload/{payloadKey}/thumb/{width}/{height}")]
+    Task<ApiResponse<HttpContent>> GetThumbnailByGtid(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("gtid:guid")] Guid gtid,
+        [AliasAs("payloadKey")] string payloadKey,
+        [AliasAs("width")] int width,
+        [AliasAs("height")] int height);
+
     [Post(UnifiedApiRouteConstants.PeerByDriveId + "/query-batch")]
     Task<ApiResponse<QueryBatchResponse>> QueryBatch(
         [AliasAs("odinId")] string odinId,


### PR DESCRIPTION
## Summary
Exposes the V1 peer "read a file over peer by GlobalTransitId" endpoints on the V2 API.

`V2DrivePeerQueryByGtidController` previously only had `exists`. This adds header, payload (full + ranged), and thumbnail reads over peer, addressed by GlobalTransitId — the V2 equivalent of the V1 `/api/apps/v1/transit/query/{header,payload,thumb}_byglobaltransitid` endpoints. It mirrors the by-fileId twin `V2DrivePeerFileReadonlyController` and reuses the already-defined `PeerByGtid` route and the existing `PeerDriveQueryService.*ByGlobalTransitIdAsync` methods — no new route constants or service methods.

### New endpoints
| V1 | New V2 |
|----|--------|
| `…/transit/query/header_byglobaltransitid` | `GET /api/v2/peer/{odinId}/drives/{driveId}/files/by-gtid/{gtid}/header` |
| `…/transit/query/payload_byglobaltransitid` | `GET …/by-gtid/{gtid}/payload/{payloadKey}` (+ `/{start}/{length}` for ranges) |
| `…/transit/query/thumb_byglobaltransitid` | `GET …/by-gtid/{gtid}/payload/{payloadKey}/thumb/{width}/{height}` (`?directMatchOnly=`) |

## Changes
- **Production:** `V2DrivePeerQueryController.cs` — header/payload/thumbnail-by-gtid actions on `V2DrivePeerQueryByGtidController`.
- **Test client:** `IDrivePeerQueryHttpClientApiV2` Refit declarations + `DrivePeerReaderV2Client` wrappers.
- **Tests:** new `PeerQueryByGtidContentTests` fixture — header/payload/thumbnail, ranged payload, missing-file 404, unconnected-member rejection.

## Notes / decisions
- Drive is resolved by alias (`Type = Guid.Empty`), matching the by-fileId and `exists` peer endpoints (V2 keys off `driveId` as the alias rather than V1's separate `alias`+`type`).
- `directMatchOnly` (gtid-specific in V1, no by-fileId analog) is an optional query param defaulting to `false`.
- Tests resolve the gtid from the owner's stored header rather than the upload result, so they don't depend on whether a non-distributed upload surfaces the gtid.

## Testing
`dotnet test` on the new `PeerQueryByGtidContentTests` fixture: **4/4 passing**. Full V2 test project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)