### PR TITLE
Skip auto-connected identities in v0->v1 circle-grant fix

### DIFF
--- a/src/services/Odin.Services/Configuration/VersionUpgrade/Version0tov1/V0ToV1MigrationService.cs
+++ b/src/services/Odin.Services/Configuration/VersionUpgrade/Version0tov1/V0ToV1MigrationService.cs
@@ -304,6 +304,18 @@ namespace Odin.Services.Configuration.VersionUpgrade.Version0tov1
 
         private async Task FixIdentityAsync(IdentityConnectionRegistration icr, IOdinContext odinContext)
         {
+            // Skip auto-connected (unconfirmed) identities. Re-issuing their grants here goes through
+            // GrantCircleAsync, which refuses to grant additional circles to an auto-connected identity.
+            // An auto-connected identity that also holds another circle grant (an anomalous state seen in
+            // older data) would therefore throw and roll back the whole migration. These identities are
+            // introduced by the very feature this migration releases, so genuine v0 data has none; where
+            // they exist they were created by current code and already hold correct grants — nothing to fix.
+            if (icr.AccessGrant.CircleGrants.ContainsKey(SystemCircleConstants.AutoConnectionsCircleId))
+            {
+                logger.LogDebug("Skipping auto-connected identity {odinId} during circle-grant fix", icr.OdinId);
+                return;
+            }
+
             foreach (var circleGrant in icr.AccessGrant.CircleGrants)
             {
                 var circleId = circleGrant.Value.CircleId;

--- a/src/services/Odin.Services/Membership/Connections/AutoFixConnections.cs
+++ b/src/services/Odin.Services/Membership/Connections/AutoFixConnections.cs
@@ -42,6 +42,16 @@ namespace Odin.Services.Membership.Connections
 
         private async Task FixIdentityAsync(IdentityConnectionRegistration icr, IOdinContext odinContext)
         {
+            // Skip auto-connected (unconfirmed) identities. Re-issuing their grants goes through
+            // GrantCircleAsync, which refuses to grant additional circles to an auto-connected identity;
+            // one that also holds another circle grant (an anomalous state seen in older data) would throw
+            // and roll back the fix. They must be confirmed before their circle memberships can change.
+            if (icr.AccessGrant.CircleGrants.ContainsKey(SystemCircleConstants.AutoConnectionsCircleId))
+            {
+                logger.LogDebug("Skipping auto-connected identity {odinId} during circle-grant fix", icr.OdinId);
+                return;
+            }
+
             foreach (var circleGrant in icr.AccessGrant.CircleGrants)
             {
                 var circleId = circleGrant.Value.CircleId;


### PR DESCRIPTION
The v0->v1 migration's grant-regeneration pass (FixIdentityAsync) revoke- then-re-grants each circle an identity holds. GrantCircleAsync refuses to grant any circle to an identity still holding the AutoConnectionsCircle grant, so an auto-connected identity that also holds another circle grant (an anomalous state present in older data) throws and rolls back the entire upgrade.

Skip auto-connected (unconfirmed) identities in both grant-regeneration paths instead of weakening the GrantCircleAsync guard. Auto-connections are introduced by this migration, so genuine v0 data has none; where they exist they were created by current code and already hold correct grants.