### PR TITLE
Fix link-preview SSR error noise and wasted payload reads

### DIFF
--- a/src/apps/Odin.Hosting/Controllers/Anonymous/SEO/HomebaseSsrController.cs
+++ b/src/apps/Odin.Hosting/Controllers/Anonymous/SEO/HomebaseSsrController.cs
@@ -106,7 +106,7 @@ public class HomebaseSsrController(
         }
 
         var (head, _) = await BuildHeadSection(suffix: "Posts", siteType: "website");
-        var (posts, _) = await channelContentService.GetChannelPosts(channelKey, WebOdinContext);
+        var (posts, _) = await channelContentService.GetChannelPosts(channelKey, WebOdinContext, includePayloadBody: false);
 
         var thisChannel = (await channelContentService.GetChannels(WebOdinContext)).FirstOrDefault(c => c.Slug == channelKey);
 

--- a/src/services/Odin.Services/LinkPreview/HomebaseSsrService.cs
+++ b/src/services/Odin.Services/LinkPreview/HomebaseSsrService.cs
@@ -396,7 +396,8 @@ public class HomebaseSsrService(
             odinContext,
             post.Content.UserDate,
             maxPosts: 10,
-            cancellationToken);
+            includePayloadBody: false, // "See More" list only needs caption/slug/date from the header
+            cancellationToken: cancellationToken);
 
         contentBuilder.AppendLine($"<hr/>");
         contentBuilder.AppendLine($"<h3>See More ({otherPosts.Count} posts)</h3>");

--- a/src/services/Odin.Services/LinkPreview/LinkPreviewService.cs
+++ b/src/services/Odin.Services/LinkPreview/LinkPreviewService.cs
@@ -43,6 +43,10 @@ public class LinkPreviewService(
         {
             await WriteEnhancedIndexAsync(indexFilePath, odinContext);
         }
+        catch (OperationCanceledException)
+        {
+            // Request aborted (client disconnected); nothing left to write.
+        }
         catch (Exception e)
         {
             logger.LogDebug("Total Failure creating link-preview.  Writing plain index: {message}", e.Message);
@@ -116,6 +120,11 @@ public class LinkPreviewService(
             logger.LogDebug(oce, "Failed to parse channel definition: {code}", oce.ErrorCode.ToString());
             return false;
         }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected (or the request was aborted) mid-render; not a failure.
+            throw;
+        }
         catch (Exception e)
         {
             logger.LogError(e, "Failed to parse channel definition");
@@ -168,6 +177,11 @@ public class LinkPreviewService(
             await WriteAsync(content);
             return true;
         }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected (or the request was aborted) mid-render; not a failure.
+            throw;
+        }
         catch (Exception e)
         {
             logger.LogError(e, "Failed to parse post");
@@ -189,7 +203,7 @@ public class LinkPreviewService(
         if (segments is { Length: 3 }) // we have the channel key
         {
             string channelKey = segments[2];
-            var (posts, _) = await channelContentService.GetChannelPosts(channelKey, odinContext);
+            var (posts, _) = await channelContentService.GetChannelPosts(channelKey, odinContext, includePayloadBody: false);
             var thisChannel = (await channelContentService.GetChannels(odinContext)).FirstOrDefault(c => c.Slug == channelKey);
 
             return (true, channelKey, thisChannel, posts);

--- a/src/services/Odin.Services/LinkPreview/Posts/HomebaseChannelContentService.cs
+++ b/src/services/Odin.Services/LinkPreview/Posts/HomebaseChannelContentService.cs
@@ -77,11 +77,16 @@ public class HomebaseChannelContentService(
         return results;
     }
 
+    /// <param name="includePayloadBody">
+    /// When true, each post's full-text body is loaded from its payload (an extra storage read per post).
+    /// List/preview callers that only render header fields (caption, slug, abstract, date) should pass false.
+    /// </param>
     public async Task<(List<ChannelPost> channelPosts, string cursor)> GetChannelPosts(
         string channelKey,
         IOdinContext odinContext,
         UnixTimeUtc? fromTimestamp = null,
         int maxPosts = 10,
+        bool includePayloadBody = true,
         CancellationToken cancellationToken = default)
     {
         var targetDrive = await GetChannelDrive(channelKey, odinContext);
@@ -110,7 +115,7 @@ public class HomebaseChannelContentService(
         foreach (var sr in batch.SearchResults)
         {
             // logger.LogDebug("The DSR content: [{c}]", sr.FileMetadata.AppData.Content);
-            var post = await ParsePostFile(sr, targetDrive, odinContext, cancellationToken);
+            var post = await ParsePostFile(sr, targetDrive, odinContext, cancellationToken, includePayloadBody);
             channelPosts.Add(post);
         }
 
@@ -290,7 +295,8 @@ public class HomebaseChannelContentService(
         SharedSecretEncryptedFileHeader postFile,
         TargetDrive channelDrive,
         IOdinContext odinContext,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool includePayloadBody = true)
     {
         async Task<PostContent> LoadBodyFromPayload(InternalDriveFileId fileId)
         {
@@ -331,7 +337,7 @@ public class HomebaseChannelContentService(
             }
             else
             {
-                if (postFile.FileMetadata.Payloads.Any(p => p.KeyEquals(PostFullTextPayloadKey)))
+                if (includePayloadBody && postFile.FileMetadata.Payloads.Any(p => p.KeyEquals(PostFullTextPayloadKey)))
                 {
                     var bodyFromPayload = await LoadBodyFromPayload(fileId);
                     content.Body = bodyFromPayload.Body;


### PR DESCRIPTION
Anonymous link-preview/SSR renders were logging client disconnects as errors and reading post body payloads they never use.

- Treat OperationCanceledException (RequestAborted) as a non-error in TryWritePostPreview/TryWriteChannelPreview/WriteIndexFileAsync instead of logging it via LogError, matching the existing pattern in ParsePostFile and WriteAsync.
- Add includePayloadBody flag to GetChannelPosts/ParsePostFile so list, channel, and "See More" views skip the per-post pst_text payload read (they only render header fields). Post-detail render drops from up to 11 payload reads to 1; channel list to 0.