### PR TITLE
fix(notify): authenticate cross-site App WebSocket via subprotocol bearer

### DIFF
--- a/src/apps/Odin.Hosting/Authentication/YouAuth/YouAuthAuthenticationHandler.cs
+++ b/src/apps/Odin.Hosting/Authentication/YouAuth/YouAuthAuthenticationHandler.cs
@@ -80,7 +80,11 @@ namespace Odin.Hosting.Authentication.YouAuth
 
         private async Task<AuthenticateResult> HandleAppAuth(IOdinContext odinContext)
         {
-            if (!TryGetClientAuthToken(YouAuthConstants.AppCookieName, out var authToken, true))
+            // Header (BX0900) -> cookie -> WS subprotocol bearer. The subprotocol path lets a
+            // browser App WebSocket authenticate cross-site, where it can send neither the
+            // BX0900 header nor the SameSite cookie on the upgrade.
+            if (!TryGetClientAuthToken(YouAuthConstants.AppCookieName, out var authToken, true)
+                && !TryGetWebSocketBearerToken(out authToken))
             {
                 return AuthenticateResult.Fail("Invalid App Token");
             }
@@ -288,6 +292,39 @@ namespace Odin.Hosting.Authentication.YouAuth
             }
 
             return ClientAuthenticationToken.TryParse(clientAuthToken64, out clientAuthToken);
+        }
+
+        // Browsers can't set the BX0900 header or send the cross-site SameSite cookie on a WS
+        // upgrade, so the app token rides in a Sec-WebSocket-Protocol value prefixed with
+        // "odin.bearer." (kube-style subprotocol bearer). Must match the prefix used by the client
+        // and by V2NotificationSocketController.
+        private const string WsBearerPrefix = "odin.bearer.";
+
+        private bool TryGetWebSocketBearerToken(out ClientAuthenticationToken clientAuthToken)
+        {
+            clientAuthToken = null;
+            if (!Context.WebSockets.IsWebSocketRequest)
+            {
+                return false;
+            }
+
+            var bearer = Context.WebSockets.WebSocketRequestedProtocols
+                .FirstOrDefault(p => p.StartsWith(WsBearerPrefix, StringComparison.Ordinal));
+            if (bearer == null)
+            {
+                return false;
+            }
+
+            // Subprotocol values must be RFC 7230 tokens, so the base64 token is sent base64url-encoded.
+            var token64 = Base64UrlToBase64(bearer.Substring(WsBearerPrefix.Length));
+            return ClientAuthenticationToken.TryParse(token64, out clientAuthToken);
+        }
+
+        private static string Base64UrlToBase64(string base64Url)
+        {
+            var s = base64Url.Replace('-', '+').Replace('_', '/');
+            var padLen = (4 - s.Length % 4) % 4;
+            return padLen == 0 ? s : s + new string('=', padLen);
         }
     }
 }

--- a/src/apps/Odin.Hosting/Controllers/ClientToken/App/Notifications/AppNotificationSocketController.cs
+++ b/src/apps/Odin.Hosting/Controllers/ClientToken/App/Notifications/AppNotificationSocketController.cs
@@ -46,10 +46,17 @@ namespace Odin.Hosting.Controllers.ClientToken.App.Notifications
 
             try
             {
-                using var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync(new WebSocketAcceptContext
+                var acceptContext = new WebSocketAcceptContext { DangerousEnableCompression = true };
+
+                // Echo the app-level subprotocol so browsers accept the 101 when the client
+                // authenticated via the "odin.bearer." subprotocol instead of the cookie.
+                // Must match V2NotificationSocketController.
+                if (HttpContext.WebSockets.WebSocketRequestedProtocols.Contains("odin.notify.v1"))
                 {
-                    DangerousEnableCompression = true
-                });
+                    acceptContext.SubProtocol = "odin.notify.v1";
+                }
+
+                using var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync(acceptContext);
 
                 await _notificationHandler.EstablishConnection(webSocket, WebOdinContext, cancellationTokenSources.Token);
             }

--- a/tests/apps/Odin.Hosting.Tests/AppAPI/Notifications/NotificationsTest.cs
+++ b/tests/apps/Odin.Hosting.Tests/AppAPI/Notifications/NotificationsTest.cs
@@ -133,6 +133,96 @@ public class NotificationsTest
     }
 
     [Test]
+    public async Task CanConnectToWebSocketWithSubprotocolBearerAuth()
+    {
+        var identity = TestIdentities.Samwise;
+        var appDrive = TargetDrive.NewTargetDrive();
+
+        //
+        // Create an app
+        //
+        Guid appId = Guid.NewGuid();
+        var testAppContext = await _scaffold.OldOwnerApi.SetupTestSampleApp(appId, identity,
+            canReadConnections: true,
+            targetDrive: appDrive,
+            driveAllowAnonymousReads: false);
+
+        //
+        // Create a device use the app
+        //
+        var ownerApiClient = _scaffold.CreateOwnerApiClientRedux(identity);
+        var (deviceClientAuthToken, deviceSharedSecret) = await ownerApiClient.AppManager.RegisterAppClient(appId);
+
+        //
+        // A browser can send neither the BX0900 header nor the cross-site SameSite cookie on a WS
+        // upgrade, so the app token rides in an "odin.bearer." subprotocol value instead. This is
+        // exactly what the js-lib WebsocketProvider sends: the BX0900 token string, made URL-safe
+        // (base64 -> base64url) so it is a valid Sec-WebSocket-Protocol token. No cookie attached.
+        //
+        var bearer = "odin.bearer." + deviceClientAuthToken.ToString()
+            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        ClientWebSocket socket = new ClientWebSocket();
+        socket.Options.AddSubProtocol("odin.notify.v1");
+        socket.Options.AddSubProtocol(bearer);
+        CancellationTokenSource tokenSource = new CancellationTokenSource();
+
+        //
+        // Connect to the socket
+        //
+        var uri = new Uri($"wss://{identity.OdinId}:{WebScaffold.HttpsPort}{AppApiPathConstantsV1.NotificationsV1}/ws");
+        await socket.ConnectAsync(uri, tokenSource.Token);
+
+        // The server must echo the negotiated subprotocol or a browser rejects the 101.
+        ClassicAssert.AreEqual("odin.notify.v1", socket.SubProtocol);
+
+        //
+        // Send a request indicating the drives (handshake1)
+        //
+        var request = new SocketCommand
+        {
+            Command = SocketCommandType.EstablishConnectionRequest,
+            Data = OdinSystemSerializer.Serialize(new EstablishConnectionOptions
+            {
+                Drives = [testAppContext.TargetDrive],
+            })
+        };
+
+        var ssp = SharedSecretEncryptedPayload.Encrypt(
+            OdinSystemSerializer.Serialize(request).ToUtf8ByteArray(),
+            deviceSharedSecret.ToSensitiveByteArray());
+        var sendBuffer = OdinSystemSerializer.Serialize(ssp).ToUtf8ByteArray();
+        await socket.SendAsync(new ArraySegment<byte>(sendBuffer), WebSocketMessageType.Text, true, tokenSource.Token);
+
+        //
+        // Wait for the reply
+        //
+        var receiveBuffer = new ArraySegment<byte>(new byte[1024 * 3]);
+        var receiveResult = await socket.ReceiveAsync(receiveBuffer, tokenSource.Token);
+        if (receiveResult.MessageType == WebSocketMessageType.Text)
+        {
+            var array = receiveBuffer.Array;
+            Array.Resize(ref array, receiveResult.Count);
+
+            var json = array.ToStringFromUtf8Bytes();
+            var n = OdinSystemSerializer.Deserialize<ClientNotificationPayload>(json);
+
+            ClassicAssert.IsTrue(n.IsEncrypted);
+            var decryptedResponse = SharedSecretEncryptedPayload.Decrypt(n.Payload, deviceSharedSecret.ToSensitiveByteArray());
+            var response = OdinSystemSerializer.Deserialize<EstablishConnectionResponse>(decryptedResponse);
+
+            ClassicAssert.IsNotNull(response);
+            ClassicAssert.IsTrue(response.NotificationType == ClientNotificationType.DeviceHandshakeSuccess);
+        }
+        else
+        {
+            Assert.Fail("Did not receive a valid handshake");
+        }
+
+        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+    }
+
+    [Test]
     [Ignore("work in progress")]
     public async Task CanReceiveFileAddedNotification()
     {


### PR DESCRIPTION
## Problem

A browser App WebSocket served cross-site to the identity (e.g. journal app on `journal.cloudx.run`, identity on a different registrable domain) can authenticate the notify socket through **neither** channel V1 currently supports:

- it can't set the `BX0900` header on a WS upgrade (browsers allow no custom headers on the handshake), and
- the `BX0900` cookie is `SameSite=Strict`, so it is never sent on the cross-site upgrade.

Result: the upgrade 401s and the client falls into an infinite reconnect loop.

## Fix

Accept the App token via a `Sec-WebSocket-Protocol` value — the only channel a browser can set on a WS handshake — exactly as the existing `V2NotificationSocketController` already does. The token rides in an `odin.bearer.<base64url>` subprotocol (kube-style subprotocol bearer); the server echoes the negotiated `odin.notify.v1` subprotocol on the 101.

This is **additive** to V1 auth. `[AuthorizeValidAppToken]` is preserved — the subprotocol is just a third token *source* after the header and cookie, and the token still flows through the unchanged `GetAppPermissionContextAsync` validation. Same-site Owner connections are untouched and keep the cookie path.

### Changes

- `YouAuthAuthenticationHandler.HandleAppAuth` — resolve the app token from header → cookie → `odin.bearer.` subprotocol (`TryGetWebSocketBearerToken` + `Base64UrlToBase64`, mirroring V2).
- `AppNotificationSocketController.Connect` — echo `odin.notify.v1` on accept when offered, so browsers accept the 101.
- `NotificationsTest.CanConnectToWebSocketWithSubprotocolBearerAuth` — new integration test: opens the App WS with the `odin.bearer.` subprotocol (no cookie), asserts the server echoes the subprotocol and the encrypted handshake completes with `DeviceHandshakeSuccess`. The existing cookie test still passes (no regression).

The base64↔base64url transform is lossless because `ClientAuthenticationToken.ToString()` is pure standard base64 and `TryParse` is its inverse; the char-swap is a copy of the proven V2 helper.

## Paired change

Requires the matching client change in **homebase-id/odin-js#872** (`WebsocketProvider.ts` sends the subprotocol and drops the now-pointless preauth POST). Neither half is useful without the other deployed.

Supersedes the earlier `SameSite=None;Partitioned` cookie approach — subprotocol auth has no third-party-cookie / CHIPS dependency a browser policy can break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
