### PR TITLE
Rename LinkPreviewService to HomebasePublicPageService

### DIFF
--- a/src/apps/Odin.Hosting/Controllers/Anonymous/SEO/HomebaseSitemapController.cs
+++ b/src/apps/Odin.Hosting/Controllers/Anonymous/SEO/HomebaseSitemapController.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Odin.Hosting.Controllers.Base;
-using Odin.Services.LinkPreview;
+using Odin.Services.PublicPage;
 
 namespace Odin.Hosting.Controllers.Anonymous.SEO;
 

--- a/src/apps/Odin.Hosting/Controllers/Anonymous/SEO/HomebaseSsrController.cs
+++ b/src/apps/Odin.Hosting/Controllers/Anonymous/SEO/HomebaseSsrController.cs
@@ -6,10 +6,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Odin.Core.Exceptions;
 using Odin.Hosting.Controllers.Base;
-using Odin.Services.LinkPreview;
-using Odin.Services.LinkPreview.PersonMetadata.SchemaDotOrg;
-using Odin.Services.LinkPreview.Posts;
-using Odin.Services.LinkPreview.Profile;
+using Odin.Services.PublicPage;
+using Odin.Services.PublicPage.PersonMetadata.SchemaDotOrg;
+using Odin.Services.PublicPage.Posts;
+using Odin.Services.PublicPage.Profile;
 
 namespace Odin.Hosting.Controllers.Anonymous.SEO;
 

--- a/src/apps/Odin.Hosting/Controllers/Anonymous/SEO/LayoutBuilder.cs
+++ b/src/apps/Odin.Hosting/Controllers/Anonymous/SEO/LayoutBuilder.cs
@@ -6,8 +6,8 @@ using System.Web;
 using Microsoft.AspNetCore.Http;
 using Odin.Core.Serialization;
 using Odin.Services.Base;
-using Odin.Services.LinkPreview;
-using Odin.Services.LinkPreview.PersonMetadata.SchemaDotOrg;
+using Odin.Services.PublicPage;
+using Odin.Services.PublicPage.PersonMetadata.SchemaDotOrg;
 
 namespace Odin.Hosting.Controllers.Anonymous.SEO;
 

--- a/src/apps/Odin.Hosting/Controllers/Anonymous/StaticFileController.cs
+++ b/src/apps/Odin.Hosting/Controllers/Anonymous/StaticFileController.cs
@@ -15,7 +15,7 @@ using Odin.Services.Optimization.Cdn;
 using Odin.Services.Tenant;
 using Odin.Services.Util;
 using Odin.Core.Time;
-using Odin.Services.LinkPreview;
+using Odin.Services.PublicPage;
 
 namespace Odin.Hosting.Controllers.Anonymous
 {

--- a/src/apps/Odin.Hosting/Middleware/OdinContextMiddleware.cs
+++ b/src/apps/Odin.Hosting/Middleware/OdinContextMiddleware.cs
@@ -18,7 +18,7 @@ using Odin.Services.DataSubscription;
 using Odin.Services.Drives.Management;
 using Odin.Services.Tenant;
 using Odin.Hosting.Authentication.Peer;
-using Odin.Services.LinkPreview;
+using Odin.Services.PublicPage;
 using Odin.Services.Security.PasswordRecovery.Shamir;
 
 namespace Odin.Hosting.Middleware
@@ -269,7 +269,7 @@ namespace Odin.Hosting.Middleware
 
         private async Task LoadLinkPreviewContextAsync(HttpContext httpContext, IOdinContext odinContext)
         {
-            var linkPreviewService = httpContext.RequestServices.GetRequiredService<LinkPreviewService>();
+            var linkPreviewService = httpContext.RequestServices.GetRequiredService<HomebasePublicPageService>();
             if(!linkPreviewService.IsAllowedPath())
             {
                 return;

--- a/src/apps/Odin.Hosting/Middleware/SharedSecretEncryptionMiddleware.cs
+++ b/src/apps/Odin.Hosting/Middleware/SharedSecretEncryptionMiddleware.cs
@@ -21,7 +21,7 @@ using Odin.Hosting.Controllers.ClientToken.App;
 using Odin.Hosting.Controllers.ClientToken.Guest;
 using Odin.Hosting.Controllers.Home.Auth;
 using Odin.Hosting.UnifiedV2;
-using Odin.Services.LinkPreview;
+using Odin.Services.PublicPage;
 
 namespace Odin.Hosting.Middleware
 {

--- a/src/apps/Odin.Hosting/Startup.cs
+++ b/src/apps/Odin.Hosting/Startup.cs
@@ -30,7 +30,7 @@ using Odin.Hosting.Middleware;
 using Odin.Hosting.Middleware.Logging;
 using Odin.Hosting.Multitenant;
 using Odin.Services.Background;
-using Odin.Services.LinkPreview;
+using Odin.Services.PublicPage;
 using Odin.Core.Storage.Database.System;
 using Odin.Hosting.Extensions;
 using StackExchange.Redis;
@@ -396,7 +396,7 @@ public class Startup(IConfiguration configuration, IEnumerable<string> args)
                     {
                         context.Response.Headers.ContentType = MediaTypeNames.Text.Html;
 
-                        var svc = context.RequestServices.GetRequiredService<LinkPreviewService>();
+                        var svc = context.RequestServices.GetRequiredService<HomebasePublicPageService>();
                         var odinContext = context.RequestServices.GetRequiredService<IOdinContext>();
 
                         var indexFile = Path.Combine(publicPath, "index.html");

--- a/src/apps/Odin.Hosting/TenantServices.cs
+++ b/src/apps/Odin.Hosting/TenantServices.cs
@@ -60,14 +60,14 @@ using Odin.Services.Drives.DriveCore.Storage;
 using Odin.Services.Drives.Reactions.Redux.Group;
 using Odin.Services.Fingering;
 using Odin.Services.LinkMetaExtractor;
-using Odin.Services.LinkPreview;
+using Odin.Services.PublicPage;
 using Odin.Services.Peer.AppNotification;
 using Odin.Services.Membership.Connections.Verification;
 using Odin.Services.Peer.Incoming.Drive.Reactions.Group;
 using Odin.Services.Registry;
 using Odin.Services.Drives.FileSystem.Base;
-using Odin.Services.LinkPreview.Posts;
-using Odin.Services.LinkPreview.Profile;
+using Odin.Services.PublicPage.Posts;
+using Odin.Services.PublicPage.Profile;
 using Odin.Core.Storage.Database.Identity;
 using Odin.Services.Authorization;
 using Odin.Core.Storage.PubSub;
@@ -398,7 +398,7 @@ public static class TenantServices
 
         cb.RegisterType<WebfingerService>().As<IWebfingerService>().InstancePerLifetimeScope();
         cb.RegisterType<DidService>().As<IDidService>().InstancePerLifetimeScope();
-        cb.RegisterType<LinkPreviewService>().As<LinkPreviewService>().InstancePerLifetimeScope();
+        cb.RegisterType<HomebasePublicPageService>().As<HomebasePublicPageService>().InstancePerLifetimeScope();
         cb.RegisterType<LinkPreviewAuthenticationService>().As<LinkPreviewAuthenticationService>().InstancePerLifetimeScope();
 
 

--- a/src/services/Odin.Services/Profile/ProfilePublishService.cs
+++ b/src/services/Odin.Services/Profile/ProfilePublishService.cs
@@ -21,7 +21,7 @@ using Odin.Services.Drives.DriveCore.Query;
 using Odin.Services.Drives.DriveCore.Storage;
 using Odin.Services.Drives.FileSystem.Standard;
 using Odin.Services.Drives.Management;
-using Odin.Services.LinkPreview.PersonMetadata;
+using Odin.Services.PublicPage.PersonMetadata;
 using Odin.Services.Mediator;
 using Odin.Services.Optimization.Cdn;
 
@@ -30,7 +30,7 @@ namespace Odin.Services.Profile;
 /// <summary>
 /// Republishes the public, static-file artifacts derived from profile attributes -- <c>sitedata.json</c>,
 /// <c>public_image.json</c> (served at <c>/pub/image</c>) and <c>public_profile.json</c> (served at
-/// <c>/pub/profile</c>, consumed server-side by <see cref="Odin.Services.LinkPreview.Profile.HomebaseProfileContentService"/>)
+/// <c>/pub/profile</c>, consumed server-side by <see cref="Odin.Services.PublicPage.Profile.HomebaseProfileContentService"/>)
 /// -- whenever a profile attribute changes. This is the server-side counterpart of odin-js's
 /// <c>publishProfile</c>/<c>publishProfileImage</c>/<c>publishProfileCard</c>
 /// (<c>packages/libs/js-lib/src/public/file/*</c>), which only fire from the owner-app's UI mutation hooks.

--- a/src/services/Odin.Services/PublicPage/HomebasePublicPageService.cs
+++ b/src/services/Odin.Services/PublicPage/HomebasePublicPageService.cs
@@ -16,20 +16,20 @@ using Odin.Core.Exceptions;
 using Odin.Core.Serialization;
 using Odin.Core.Storage.Cache;
 using Odin.Services.Base;
-using Odin.Services.LinkPreview.PersonMetadata.SchemaDotOrg;
-using Odin.Services.LinkPreview.Posts;
-using Odin.Services.LinkPreview.Profile;
+using Odin.Services.PublicPage.PersonMetadata.SchemaDotOrg;
+using Odin.Services.PublicPage.Posts;
+using Odin.Services.PublicPage.Profile;
 
-namespace Odin.Services.LinkPreview;
+namespace Odin.Services.PublicPage;
 
-public class LinkPreviewService(
+public class HomebasePublicPageService(
     ISystemLevel1Cache globalCache,
-    ITenantLevel1Cache<LinkPreviewService> tenantCache,
+    ITenantLevel1Cache<HomebasePublicPageService> tenantCache,
     HomebaseProfileContentService profileContentService,
     HomebaseChannelContentService channelContentService,
     IHttpContextAccessor httpContextAccessor,
     HomebaseSsrService ssrService,
-    ILogger<LinkPreviewService> logger)
+    ILogger<HomebasePublicPageService> logger)
 {
     private const string IndexFileKey = "link-preview-service-index-file";
     private const string GenericLinkPreviewCacheKey = "link-preview-service-index-file";

--- a/src/services/Odin.Services/PublicPage/HomebaseSsrService.cs
+++ b/src/services/Odin.Services/PublicPage/HomebaseSsrService.cs
@@ -11,12 +11,12 @@ using Newtonsoft.Json;
 using Odin.Services.Authorization.Permissions;
 using Odin.Services.Base;
 using Odin.Services.DataSubscription.Follower;
-using Odin.Services.LinkPreview.PersonMetadata.SchemaDotOrg;
-using Odin.Services.LinkPreview.Posts;
-using Odin.Services.LinkPreview.Profile;
+using Odin.Services.PublicPage.PersonMetadata.SchemaDotOrg;
+using Odin.Services.PublicPage.Posts;
+using Odin.Services.PublicPage.Profile;
 using Odin.Services.Membership.Connections;
 
-namespace Odin.Services.LinkPreview;
+namespace Odin.Services.PublicPage;
 
 public class HomebaseSsrService(
     HomebaseProfileContentService profileContentService,

--- a/src/services/Odin.Services/PublicPage/LinkPreviewAuthenticationService.cs
+++ b/src/services/Odin.Services/PublicPage/LinkPreviewAuthenticationService.cs
@@ -10,7 +10,7 @@ using Odin.Services.Base;
 using Odin.Services.Drives;
 using Odin.Services.Drives.Management;
 
-namespace Odin.Services.LinkPreview;
+namespace Odin.Services.PublicPage;
 
 public class LinkPreviewAuthenticationService(IDriveManager driveManager, TenantContext tenantContext)
 {

--- a/src/services/Odin.Services/PublicPage/LinkPreviewDefaults.cs
+++ b/src/services/Odin.Services/PublicPage/LinkPreviewDefaults.cs
@@ -1,4 +1,4 @@
-namespace Odin.Services.LinkPreview;
+namespace Odin.Services.PublicPage;
 
 public static class LinkPreviewDefaults
 {

--- a/src/services/Odin.Services/PublicPage/MimeTypeHelper.cs
+++ b/src/services/Odin.Services/PublicPage/MimeTypeHelper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Odin.Services.LinkPreview;
+namespace Odin.Services.PublicPage;
 
 // via grok
 public static class MimeTypeHelper

--- a/src/services/Odin.Services/PublicPage/PersonMetadata/FrontEndProfile.cs
+++ b/src/services/Odin.Services/PublicPage/PersonMetadata/FrontEndProfile.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Odin.Services.LinkPreview.PersonMetadata;
+namespace Odin.Services.PublicPage.PersonMetadata;
 
 public class FrontEndProfile
 {

--- a/src/services/Odin.Services/PublicPage/PersonMetadata/SchemaDotOrg/AddressSchema.cs
+++ b/src/services/Odin.Services/PublicPage/PersonMetadata/SchemaDotOrg/AddressSchema.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Odin.Services.LinkPreview.PersonMetadata.SchemaDotOrg;
+namespace Odin.Services.PublicPage.PersonMetadata.SchemaDotOrg;
 
 public class AddressSchema
 {

--- a/src/services/Odin.Services/PublicPage/PersonMetadata/SchemaDotOrg/OrganizationSchema.cs
+++ b/src/services/Odin.Services/PublicPage/PersonMetadata/SchemaDotOrg/OrganizationSchema.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Odin.Services.LinkPreview.PersonMetadata.SchemaDotOrg;
+namespace Odin.Services.PublicPage.PersonMetadata.SchemaDotOrg;
 
 public class OrganizationSchema
 {

--- a/src/services/Odin.Services/PublicPage/PersonMetadata/SchemaDotOrg/PersonSchema.cs
+++ b/src/services/Odin.Services/PublicPage/PersonMetadata/SchemaDotOrg/PersonSchema.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 
-namespace Odin.Services.LinkPreview.PersonMetadata.SchemaDotOrg;
+namespace Odin.Services.PublicPage.PersonMetadata.SchemaDotOrg;
 
 public class PersonSchema
 {

--- a/src/services/Odin.Services/PublicPage/Posts/ChannelDefinition.cs
+++ b/src/services/Odin.Services/PublicPage/Posts/ChannelDefinition.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace Odin.Services.LinkPreview.Posts;
+namespace Odin.Services.PublicPage.Posts;
 
 public class ChannelDefinition
 {

--- a/src/services/Odin.Services/PublicPage/Posts/ChannelPost.cs
+++ b/src/services/Odin.Services/PublicPage/Posts/ChannelPost.cs
@@ -2,7 +2,7 @@ using System;
 using Odin.Core.Time;
 using Odin.Services.Drives;
 
-namespace Odin.Services.LinkPreview.Posts;
+namespace Odin.Services.PublicPage.Posts;
 
 public class ChannelPost
 {

--- a/src/services/Odin.Services/PublicPage/Posts/HomebaseChannelContentService.cs
+++ b/src/services/Odin.Services/PublicPage/Posts/HomebaseChannelContentService.cs
@@ -21,7 +21,7 @@ using Odin.Services.Drives.DriveCore.Query;
 using Odin.Services.Drives.FileSystem.Standard;
 using Odin.Services.Drives.Management;
 
-namespace Odin.Services.LinkPreview.Posts;
+namespace Odin.Services.PublicPage.Posts;
 
 /// <summary>
 /// Loads content from the /home app for channels, posts, articles. (duplicates logic from the Frontend,

--- a/src/services/Odin.Services/PublicPage/Posts/PlateRichTextParser.cs
+++ b/src/services/Odin.Services/PublicPage/Posts/PlateRichTextParser.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using System.Text.Json.Nodes;
 
-namespace Odin.Services.LinkPreview.Posts;
+namespace Odin.Services.PublicPage.Posts;
 
 public static class PlateRichTextParser
 {

--- a/src/services/Odin.Services/PublicPage/Posts/PostContent.cs
+++ b/src/services/Odin.Services/PublicPage/Posts/PostContent.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
 using Odin.Core.Time;
 
-namespace Odin.Services.LinkPreview.Posts;
+namespace Odin.Services.PublicPage.Posts;
 
 // Modeled after the Article and PostContent in odin-js
 // I only pulled in what is needed for link preview

--- a/src/services/Odin.Services/PublicPage/Posts/PrimaryMediaFile.cs
+++ b/src/services/Odin.Services/PublicPage/Posts/PrimaryMediaFile.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Odin.Services.LinkPreview.Posts;
+namespace Odin.Services.PublicPage.Posts;
 
 public class PrimaryMediaFile
 {

--- a/src/services/Odin.Services/PublicPage/Profile/AboutSection.cs
+++ b/src/services/Odin.Services/PublicPage/Profile/AboutSection.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Odin.Services.LinkPreview.Profile;
+namespace Odin.Services.PublicPage.Profile;
 
 public class AboutSection
 {

--- a/src/services/Odin.Services/PublicPage/Profile/ExperienceAttribute.cs
+++ b/src/services/Odin.Services/PublicPage/Profile/ExperienceAttribute.cs
@@ -1,4 +1,4 @@
-namespace Odin.Services.LinkPreview.Profile;
+namespace Odin.Services.PublicPage.Profile;
 
 public class ExperienceAttribute
 {

--- a/src/services/Odin.Services/PublicPage/Profile/HomebaseProfileContentService.cs
+++ b/src/services/Odin.Services/PublicPage/Profile/HomebaseProfileContentService.cs
@@ -14,12 +14,12 @@ using Odin.Services.Drives;
 using Odin.Services.Drives.DriveCore.Query;
 using Odin.Services.Drives.FileSystem.Standard;
 using Odin.Services.Drives.Management;
-using Odin.Services.LinkPreview.PersonMetadata;
-using Odin.Services.LinkPreview.PersonMetadata.SchemaDotOrg;
+using Odin.Services.PublicPage.PersonMetadata;
+using Odin.Services.PublicPage.PersonMetadata.SchemaDotOrg;
 using Odin.Services.Optimization.Cdn;
 using Odin.Services.Profile;
 
-namespace Odin.Services.LinkPreview.Profile;
+namespace Odin.Services.PublicPage.Profile;
 
 /// <summary>
 /// Loads information about this tenant and their profile information for server side rendering requirements

--- a/src/services/Odin.Services/PublicPage/Profile/ProfileBlock.cs
+++ b/src/services/Odin.Services/PublicPage/Profile/ProfileBlock.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace Odin.Services.LinkPreview.Profile;
+namespace Odin.Services.PublicPage.Profile;
 
 public class ProfileBlock
 {

--- a/src/services/Odin.Services/PublicPage/Profile/TypeDefinition.cs
+++ b/src/services/Odin.Services/PublicPage/Profile/TypeDefinition.cs
@@ -1,4 +1,4 @@
-namespace Odin.Services.LinkPreview;
+namespace Odin.Services.PublicPage;
 
 public class TypeDefinition
 {

--- a/src/services/Odin.Services/PublicPage/SsrUrlHelper.cs
+++ b/src/services/Odin.Services/PublicPage/SsrUrlHelper.cs
@@ -1,7 +1,7 @@
 
 using System;
 
-namespace Odin.Services.LinkPreview;
+namespace Odin.Services.PublicPage;
 
 public static class SsrUrlHelper
 {

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/ContactTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/ContactTests.cs
@@ -26,7 +26,7 @@ using Odin.Services.Drives;
 using Odin.Services.Drives.DriveCore.Query;
 using Odin.Services.Drives.DriveCore.Storage;
 using Odin.Services.Drives.FileSystem.Base.Upload;
-using Odin.Services.LinkPreview.Profile;
+using Odin.Services.PublicPage.Profile;
 using Odin.Services.Membership.Connections;
 using Odin.Services.Peer.Encryption;
 using Refit;


### PR DESCRIPTION
## Summary
- Rename `LinkPreviewService` → `HomebasePublicPageService`: the service renders the entire public index page for an identity (head/OG metadata, webfinger + DID discovery links, schema.org JSON-LD person data, and SSR `<noscript>` content), so "link preview" undersold what it does.
- Move namespace/directory `Odin.Services.LinkPreview` → `Odin.Services.PublicPage` (including `Posts`, `Profile`, `PersonMetadata` sub-namespaces) and update all call sites.
- No behavior change — pure rename, groundwork for an upcoming change where the service will check a `TenantContext` flag and render a plain placeholder page for tenants not allowed a public home page.

`LinkPreviewAuthenticationService` and `LinkPreviewDefaults` keep their names (they are genuinely link-preview concerns), and runtime cache-key strings are unchanged.

## Test plan
- `dotnet build ./odin-core.sln` — clean, 0 warnings / 0 errors
- Rename-only diff; existing test suites cover the touched call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)