### PR TITLE
Serve anonymous fallback image for /pub/image when none published

### DIFF
--- a/src/apps/Odin.Hosting/Controllers/Anonymous/StaticFileController.cs
+++ b/src/apps/Odin.Hosting/Controllers/Anonymous/StaticFileController.cs
@@ -66,6 +66,11 @@ namespace Odin.Hosting.Controllers.Anonymous
 
             if (config == null)
             {
+                if (!string.IsNullOrEmpty(fallbackContent64) && !string.IsNullOrEmpty(fallbackContentType))
+                {
+                    return new FileContentResult(fallbackContent64.FromBase64(), fallbackContentType);
+                }
+
                 return NotFound();
             }
 

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Profile/ProfileAttributePublishingTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Profile/ProfileAttributePublishingTests.cs
@@ -162,14 +162,18 @@ public class ProfileAttributePublishingTests : V2Fixture
         using var client = Host.CreateClient();
         var imageBeforeResp = await client.GetAsync($"https://{Identities.Frodo}/pub/image");
         Assert.That(imageBeforeResp.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"actual {imageBeforeResp.StatusCode}");
+        var imageBeforeBytes = await imageBeforeResp.Content.ReadAsByteArrayAsync();
 
         var delete = await profile.DeleteAttributeAsync(created.Content!.Id, created.Content.VersionTag);
         Assert.That(delete.StatusCode, Is.EqualTo(HttpStatusCode.NoContent), $"actual {delete.StatusCode}");
 
         // Regression: deleting the only Anonymous-tier Photo attribute must clear /pub/image rather than
-        // leaving the previously-published bytes served forever.
+        // leaving the previously-published bytes served forever. With no image published, the endpoint
+        // falls back to the anonymous default image instead of the deleted content.
         var imageAfterResp = await client.GetAsync($"https://{Identities.Frodo}/pub/image");
-        Assert.That(imageAfterResp.StatusCode, Is.EqualTo(HttpStatusCode.NotFound), $"actual {imageAfterResp.StatusCode}");
+        Assert.That(imageAfterResp.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"actual {imageAfterResp.StatusCode}");
+        var imageAfterBytes = await imageAfterResp.Content.ReadAsByteArrayAsync();
+        Assert.That(imageAfterBytes, Is.Not.EqualTo(imageBeforeBytes));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- `GET /pub/image` (`StaticFileController.GetPublicImage`) already fell back to the embedded default JPEG (`StaticFileConstants.FallBackProfileImage`) when a static-file config row existed but the bytes were missing/empty.
- It did **not** fall back when the config row didn't exist at all (i.e. the identity never published a profile image), returning `404` instead.
- `SendStream` now checks for a fallback in that `config == null` branch too, so both "no file" and "empty content" cases serve the anonymous image.

## Test plan
- [x] `dotnet build src/apps/Odin.Hosting/Odin.Hosting.csproj`
- [ ] Manually hit `/pub/image` on an identity that has never published a profile image and confirm it returns the fallback JPEG instead of 404