### PR TITLE
Add recurring support to scheduled push notifications

### DIFF
--- a/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2ScheduledNotificationController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Notifications/V2ScheduledNotificationController.cs
@@ -27,7 +27,7 @@ namespace Odin.Hosting.UnifiedV2.Notifications
         {
             var caller = WebOdinContext.GetCallerOdinIdOrFail();
             var jobId = await scheduledNotificationService.ScheduleNotificationAsync(
-                caller, request.Options, request.SendAt, WebOdinContext);
+                caller, request.Options, request.SendAt, request.RecurrenceInterval, WebOdinContext);
 
             return new ScheduleNotificationResult { JobId = jobId };
         }
@@ -39,7 +39,7 @@ namespace Odin.Hosting.UnifiedV2.Notifications
         public async Task<IActionResult> UpdateSchedule(Guid jobId, [FromBody] ScheduleNotificationRequest request)
         {
             var updated = await scheduledNotificationService.UpdateScheduledNotificationAsync(
-                jobId, request.Options, request.SendAt, WebOdinContext);
+                jobId, request.Options, request.SendAt, request.RecurrenceInterval, WebOdinContext);
             if (!updated)
             {
                 return NotFound();

--- a/src/services/Odin.Services/AppNotifications/Push/Scheduled/ScheduleNotificationRequest.cs
+++ b/src/services/Odin.Services/AppNotifications/Push/Scheduled/ScheduleNotificationRequest.cs
@@ -19,6 +19,13 @@ public class ScheduleNotificationRequest
     /// When to send the notification (UTC, milliseconds since epoch).  A time in the past sends ASAP.
     /// </summary>
     public UnixTimeUtc SendAt { get; set; }
+
+    /// <summary>
+    /// If set, repeats the notification every <c>RecurrenceInterval</c> milliseconds after each
+    /// occurrence's intended send time, starting from <see cref="SendAt"/>.  Must be at least
+    /// <see cref="ScheduledNotificationService.MinRecurrenceInterval"/>.  Omit for a one-shot notification.
+    /// </summary>
+    public long? RecurrenceInterval { get; set; }
 }
 
 /// <summary>
@@ -66,4 +73,10 @@ public class ScheduledNotificationSummary
     /// The maximum number of attempts before the notification is given up on.
     /// </summary>
     public int MaxAttempts { get; set; }
+
+    /// <summary>
+    /// If set, this notification repeats every <c>RecurrenceInterval</c> milliseconds; null means it's
+    /// a one-shot notification.
+    /// </summary>
+    public long? RecurrenceInterval { get; set; }
 }

--- a/src/services/Odin.Services/AppNotifications/Push/Scheduled/ScheduledNotificationJob.cs
+++ b/src/services/Odin.Services/AppNotifications/Push/Scheduled/ScheduledNotificationJob.cs
@@ -88,6 +88,24 @@ public class ScheduledNotificationJob(
 
     //
 
+    /// <summary>
+    /// If <see cref="ScheduledNotificationJobData.RecurrenceInterval"/> is set, keeps this job recurring
+    /// by scheduling the next occurrence relative to the slot this one was meant to run for (rather than
+    /// wall-clock now, to avoid cadence drift if the runner was delayed).  Called by the engine after a
+    /// success, or after a failure that has exhausted all retry attempts.
+    /// </summary>
+    public override Task<DateTimeOffset?> OnCompletedAsync(JobCompletion completion)
+    {
+        if (Data.RecurrenceInterval is not { } interval)
+        {
+            return Task.FromResult<DateTimeOffset?>(null);
+        }
+
+        return Task.FromResult<DateTimeOffset?>(completion.ScheduledFor + TimeSpan.FromMilliseconds(interval));
+    }
+
+    //
+
     public override string SerializeJobData()
     {
         return OdinSystemSerializer.Serialize(Data);

--- a/src/services/Odin.Services/AppNotifications/Push/Scheduled/ScheduledNotificationJobData.cs
+++ b/src/services/Odin.Services/AppNotifications/Push/Scheduled/ScheduledNotificationJobData.cs
@@ -39,4 +39,10 @@ public class ScheduledNotificationJobData
     /// by the job's <c>RunAt</c>.
     /// </summary>
     public UnixTimeUtc SendAt { get; init; }
+
+    /// <summary>
+    /// If set, how long (in milliseconds) after each occurrence's intended send time to schedule the
+    /// next one.  Null means this is a one-shot notification.
+    /// </summary>
+    public long? RecurrenceInterval { get; init; }
 }

--- a/src/services/Odin.Services/AppNotifications/Push/Scheduled/ScheduledNotificationService.cs
+++ b/src/services/Odin.Services/AppNotifications/Push/Scheduled/ScheduledNotificationService.cs
@@ -37,14 +37,25 @@ public class ScheduledNotificationService(
     public const int MaxPendingPerTenant = 100;
 
     /// <summary>
+    /// Minimum allowed <see cref="ScheduleNotificationRequest.RecurrenceInterval"/>, in milliseconds.
+    /// Protects the shared system-wide job queue from a single recurring notification generating an
+    /// unbounded rate of claims (see <see cref="ScheduledNotificationJob"/>); this is the real protection
+    /// against sustained load, whereas <see cref="MaxPendingPerTenant"/> only bounds row count.
+    /// </summary>
+    public const long MinRecurrenceInterval = 5 * 60 * 1000; // 5 minutes
+
+    /// <summary>
     /// Schedules <paramref name="options"/> to be enqueued/pushed at <paramref name="sendAt"/>.
     /// A <paramref name="sendAt"/> in the past results in the notification being sent as soon as possible.
+    /// If <paramref name="recurrenceInterval"/> is set, the notification repeats every that many
+    /// milliseconds after each occurrence's intended send time, instead of running once.
     /// </summary>
-    /// <returns>The id of the scheduled job, which can be used to cancel it.</returns>
+    /// <returns>The id of the scheduled job, which can be used to cancel or update it.</returns>
     public async Task<Guid> ScheduleNotificationAsync(
         OdinId senderId,
         AppNotificationOptions? options,
         UnixTimeUtc sendAt,
+        long? recurrenceInterval,
         IOdinContext odinContext)
     {
         odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.SendPushNotifications);
@@ -54,13 +65,18 @@ public class ScheduledNotificationService(
             throw new OdinClientException("Notification options are required", OdinClientErrorCode.ArgumentError);
         }
 
-        var pendingCount = await CountPendingNotificationsAsync();
-        if (pendingCount >= MaxPendingPerTenant)
+        ValidateRecurrenceInterval(recurrenceInterval);
+
+        // Recurring notifications never age out of the shared queue on their own (they cycle back to
+        // Scheduled instead of expiring), so they count double against the tenant's own cap headroom.
+        var thisWeight = recurrenceInterval != null ? 2 : 1;
+        var pendingWeight = await CalculatePendingWeightAsync();
+        if (pendingWeight + thisWeight > MaxPendingPerTenant)
         {
             throw new OdinClientException(
-                $"Cannot schedule notification: this identity already has {pendingCount} pending scheduled " +
-                $"notifications, which is the maximum allowed ({MaxPendingPerTenant}). Cancel some existing " +
-                "scheduled notifications before scheduling more.",
+                $"Cannot schedule notification: this identity already has {pendingWeight} of {MaxPendingPerTenant} " +
+                "allowed pending scheduled notification slots (a recurring notification counts as 2). Cancel " +
+                "some existing scheduled notifications before scheduling more.",
                 OdinClientErrorCode.TooManyScheduledNotifications);
         }
 
@@ -73,6 +89,7 @@ public class ScheduledNotificationService(
             SenderId = senderId,
             Options = options,
             SendAt = sendAt,
+            RecurrenceInterval = recurrenceInterval,
             ScheduledByAppId = odinContext.Caller.OdinClientContext?.AppId?.Value,
         };
 
@@ -89,23 +106,25 @@ public class ScheduledNotificationService(
         });
 
         logger.LogInformation(
-            "Scheduled notification job {jobId} for tenant {tenant} to run at {runAt} (appId: {appId}, typeId: {typeId})",
-            jobId, tenant, runAt, options.AppId, options.TypeId);
+            "Scheduled notification job {jobId} for tenant {tenant} to run at {runAt} " +
+            "(appId: {appId}, typeId: {typeId}, recurring: {recurring})",
+            jobId, tenant, runAt, options.AppId, options.TypeId, recurrenceInterval != null);
 
         return jobId;
     }
 
     /// <summary>
-    /// Replaces the options and/or send time of a previously scheduled notification in place, keeping
-    /// the same job id.  Resets the job to a fresh Scheduled state (clearing any prior attempt count or
-    /// error), so it will run again even if it had already failed permanently.  Returns false if the job
-    /// no longer exists, or belongs to another app (owner can update any app's schedule; an app can only
-    /// update its own).
+    /// Replaces the options, send time, and/or recurrence of a previously scheduled notification in
+    /// place, keeping the same job id.  Resets the job to a fresh Scheduled state (clearing any prior
+    /// attempt count or error), so it will run again even if it had already failed permanently.  Returns
+    /// false if the job no longer exists, or belongs to another app (owner can update any app's schedule;
+    /// an app can only update its own).
     /// </summary>
     public async Task<bool> UpdateScheduledNotificationAsync(
         Guid jobId,
         AppNotificationOptions? options,
         UnixTimeUtc sendAt,
+        long? recurrenceInterval,
         IOdinContext odinContext)
     {
         odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.SendPushNotifications);
@@ -115,19 +134,23 @@ public class ScheduledNotificationService(
             throw new OdinClientException("Notification options are required", OdinClientErrorCode.ArgumentError);
         }
 
+        ValidateRecurrenceInterval(recurrenceInterval);
+
         var job = await jobManager.GetJobAsync<ScheduledNotificationJob>(jobId);
         if (job == null || job.Data.Tenant != odinContext.Tenant || !CanAccess(job.Data, odinContext))
         {
             return false;
         }
 
-        // Preserve identity/ownership fields from the original job; only Options and SendAt are updatable.
+        // Preserve identity/ownership fields from the original job; Options, SendAt, and
+        // RecurrenceInterval are updatable.
         job.Data = new ScheduledNotificationJobData
         {
             Tenant = job.Data.Tenant,
             SenderId = job.Data.SenderId,
             Options = options,
             SendAt = sendAt,
+            RecurrenceInterval = recurrenceInterval,
             ScheduledByAppId = job.Data.ScheduledByAppId,
         };
 
@@ -138,8 +161,9 @@ public class ScheduledNotificationService(
         if (updated)
         {
             logger.LogInformation(
-                "Rescheduled notification job {jobId} for tenant {tenant} to run at {runAt} (appId: {appId}, typeId: {typeId})",
-                jobId, job.Data.Tenant, runAt, options.AppId, options.TypeId);
+                "Rescheduled notification job {jobId} for tenant {tenant} to run at {runAt} " +
+                "(appId: {appId}, typeId: {typeId}, recurring: {recurring})",
+                jobId, job.Data.Tenant, runAt, options.AppId, options.TypeId, recurrenceInterval != null);
         }
 
         return updated;
@@ -192,10 +216,13 @@ public class ScheduledNotificationService(
             {
                 JobId = record.id,
                 Options = data.Options,
-                SendAt = data.SendAt,
+                // record.nextRun is live and reflects the upcoming occurrence; data.SendAt is the
+                // originally requested time and goes stale once a recurring notification fires once.
+                SendAt = record.nextRun,
                 State = ((JobState)record.state).ToString(),
                 AttemptCount = record.runCount,
                 MaxAttempts = record.maxAttempts,
+                RecurrenceInterval = data.RecurrenceInterval,
             });
         }
 
@@ -213,12 +240,47 @@ public class ScheduledNotificationService(
     }
 
     /// <summary>
-    /// Counts this tenant's scheduled notification jobs, across all apps and job states, for the purpose
-    /// of enforcing <see cref="MaxPendingPerTenant"/>.
+    /// Rejects a recurrence interval that's set but below <see cref="MinRecurrenceInterval"/>. A floor
+    /// on the interval -- not the pending-count cap -- is what actually protects the shared job queue
+    /// from a single recurring notification generating an unbounded claim rate.
     /// </summary>
-    private async Task<int> CountPendingNotificationsAsync()
+    private static void ValidateRecurrenceInterval(long? recurrenceInterval)
+    {
+        if (recurrenceInterval is { } interval && interval < MinRecurrenceInterval)
+        {
+            throw new OdinClientException(
+                $"Recurrence interval must be at least {MinRecurrenceInterval}ms ({MinRecurrenceInterval / 1000}s).",
+                OdinClientErrorCode.ArgumentError);
+        }
+    }
+
+    /// <summary>
+    /// Weighs this tenant's scheduled notification jobs, across all apps and job states, for the purpose
+    /// of enforcing <see cref="MaxPendingPerTenant"/>.  A recurring notification counts as 2 -- unlike a
+    /// one-shot job it never ages out of the queue on its own, so it permanently occupies a slot.
+    /// </summary>
+    private async Task<int> CalculatePendingWeightAsync()
     {
         var records = await jobManager.GetJobsByIdentityIdAsync(tenantContext.DotYouRegistryId);
-        return records.Count(r => r.jobType == ScheduledNotificationJob.JobTypeId.ToString());
+
+        var weight = 0;
+        foreach (var record in records)
+        {
+            if (record.jobType != ScheduledNotificationJob.JobTypeId.ToString())
+            {
+                continue;
+            }
+
+            var isRecurring = false;
+            if (!string.IsNullOrEmpty(record.jobData))
+            {
+                var data = OdinSystemSerializer.Deserialize<ScheduledNotificationJobData>(record.jobData);
+                isRecurring = data?.RecurrenceInterval != null;
+            }
+
+            weight += isRecurring ? 2 : 1;
+        }
+
+        return weight;
     }
 }

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/ScheduledNotificationV2Client.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/ScheduledNotificationV2Client.cs
@@ -13,7 +13,8 @@ namespace Odin.Hosting.Tests._V2.ApiClient;
 
 public class ScheduledNotificationV2Client(OdinId identity, IApiClientFactory factory)
 {
-    public async Task<ApiResponse<ScheduleNotificationResult>> Schedule(AppNotificationOptions options, UnixTimeUtc sendAt)
+    public async Task<ApiResponse<ScheduleNotificationResult>> Schedule(
+        AppNotificationOptions options, UnixTimeUtc sendAt, long? recurrenceInterval = null)
     {
         var client = factory.CreateHttpClient(identity, out var sharedSecret);
         var svc = RefitCreator.RestServiceFor<IScheduledNotificationHttpClientV2>(client, sharedSecret);
@@ -21,10 +22,12 @@ public class ScheduledNotificationV2Client(OdinId identity, IApiClientFactory fa
         {
             Options = options,
             SendAt = sendAt,
+            RecurrenceInterval = recurrenceInterval,
         });
     }
 
-    public async Task<ApiResponse<HttpContent>> Update(Guid jobId, AppNotificationOptions options, UnixTimeUtc sendAt)
+    public async Task<ApiResponse<HttpContent>> Update(
+        Guid jobId, AppNotificationOptions options, UnixTimeUtc sendAt, long? recurrenceInterval = null)
     {
         var client = factory.CreateHttpClient(identity, out var sharedSecret);
         var svc = RefitCreator.RestServiceFor<IScheduledNotificationHttpClientV2>(client, sharedSecret);
@@ -32,6 +35,7 @@ public class ScheduledNotificationV2Client(OdinId identity, IApiClientFactory fa
         {
             Options = options,
             SendAt = sendAt,
+            RecurrenceInterval = recurrenceInterval,
         });
     }
 

--- a/tests/apps/Odin.Hosting.Tests/_V2/Tests/Notifications/ScheduledNotificationTests.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/Tests/Notifications/ScheduledNotificationTests.cs
@@ -447,6 +447,120 @@ public class ScheduledNotificationTests
     }
 
     /// <summary>
+    /// A recurrence interval below <see cref="ScheduledNotificationService.MinRecurrenceInterval"/> is
+    /// rejected on both Schedule and Update -- this floor, not the pending-count cap, is what actually
+    /// protects the shared job queue from a single recurring notification firing too often.
+    /// </summary>
+    [Test]
+    public async Task ScheduledNotification_RejectsRecurrenceIntervalBelowFloor()
+    {
+        var frodo = TestIdentities.Frodo;
+        var ownerFrodo = _scaffold.CreateOwnerApiClientRedux(frodo);
+
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerFrodo.DriveManager.CreateDrive(targetDrive, "Test Drive", "", false);
+
+        var callerContext = new OwnerTestCase(targetDrive);
+        await callerContext.Initialize(ownerFrodo);
+        var scheduleClient = new ScheduledNotificationV2Client(frodo.OdinId, callerContext.GetFactory());
+
+        var options = new AppNotificationOptions
+        {
+            AppId = Guid.NewGuid(),
+            TypeId = Guid.NewGuid(),
+            TagId = Guid.NewGuid(),
+            Silent = true
+        };
+        var sendAt = UnixTimeUtc.Now().AddHours(1);
+        var tooShortInterval = ScheduledNotificationService.MinRecurrenceInterval - 1;
+
+        // Rejected on Schedule.
+        var scheduleResponse = await scheduleClient.Schedule(options, sendAt, tooShortInterval);
+        ClassicAssert.AreEqual(HttpStatusCode.BadRequest, scheduleResponse.StatusCode);
+        ClassicAssert.AreEqual(OdinClientErrorCode.ArgumentError, WebScaffold.GetErrorCode(scheduleResponse.Error));
+
+        // A valid one-shot schedule, then rejected on Update too.
+        var validResponse = await scheduleClient.Schedule(options, sendAt);
+        ClassicAssert.IsTrue(validResponse.IsSuccessStatusCode, $"Schedule failed: {validResponse.StatusCode}");
+        var jobId = validResponse.Content.JobId;
+
+        var updateResponse = await scheduleClient.Update(jobId, options, sendAt, tooShortInterval);
+        ClassicAssert.AreEqual(HttpStatusCode.BadRequest, updateResponse.StatusCode);
+        ClassicAssert.AreEqual(OdinClientErrorCode.ArgumentError, WebScaffold.GetErrorCode(updateResponse.Error));
+
+        await scheduleClient.Cancel(jobId);
+    }
+
+    /// <summary>
+    /// A recurring notification is surfaced in the list with its interval, and counts as 2 against
+    /// <see cref="ScheduledNotificationService.MaxPendingPerTenant"/> instead of 1, since it never ages
+    /// out of the queue on its own the way a one-shot notification does.
+    /// </summary>
+    [Test]
+    public async Task ScheduledNotification_RecurringNotificationCountsDoubleAgainstTheCap()
+    {
+        var frodo = TestIdentities.Frodo;
+        var ownerFrodo = _scaffold.CreateOwnerApiClientRedux(frodo);
+
+        var targetDrive = TargetDrive.NewTargetDrive();
+        await ownerFrodo.DriveManager.CreateDrive(targetDrive, "Test Drive", "", false);
+
+        var callerContext = new OwnerTestCase(targetDrive);
+        await callerContext.Initialize(ownerFrodo);
+        var scheduleClient = new ScheduledNotificationV2Client(frodo.OdinId, callerContext.GetFactory());
+
+        var sendAt = UnixTimeUtc.Now().AddHours(6);
+
+        // Other tests sharing this identity may have left pending notifications behind; work out the
+        // current weight (one-shot = 1, recurring = 2) rather than assuming a clean slate.
+        var listBefore = await scheduleClient.List();
+        ClassicAssert.IsTrue(listBefore.IsSuccessStatusCode, $"List failed: {listBefore.StatusCode}");
+        var currentWeight = listBefore.Content?.Sum(e => e.RecurrenceInterval != null ? 2 : 1) ?? 0;
+
+        var scheduledJobIds = new List<Guid>();
+        try
+        {
+            var recurringResponse = await scheduleClient.Schedule(
+                new AppNotificationOptions { AppId = Guid.NewGuid(), TypeId = Guid.NewGuid(), TagId = Guid.NewGuid(), Silent = true },
+                sendAt,
+                ScheduledNotificationService.MinRecurrenceInterval);
+            ClassicAssert.IsTrue(recurringResponse.IsSuccessStatusCode, $"Schedule failed: {recurringResponse.StatusCode}");
+            var recurringJobId = recurringResponse.Content.JobId;
+            scheduledJobIds.Add(recurringJobId);
+
+            var listAfterRecurring = await scheduleClient.List();
+            var recurringEntry = listAfterRecurring.Content?.SingleOrDefault(e => e.JobId == recurringJobId);
+            ClassicAssert.IsNotNull(recurringEntry, "Recurring notification did not appear in the list");
+            ClassicAssert.AreEqual(ScheduledNotificationService.MinRecurrenceInterval, recurringEntry.RecurrenceInterval);
+
+            // Fill the remaining slots with one-shots (the recurring notification already took 2).
+            for (var i = currentWeight + 2; i < ScheduledNotificationService.MaxPendingPerTenant; i++)
+            {
+                var response = await scheduleClient.Schedule(
+                    new AppNotificationOptions { AppId = Guid.NewGuid(), TypeId = Guid.NewGuid(), TagId = Guid.NewGuid(), Silent = true },
+                    sendAt);
+                ClassicAssert.IsTrue(response.IsSuccessStatusCode, $"Schedule failed while filling the cap: {response.StatusCode}");
+                scheduledJobIds.Add(response.Content.JobId);
+            }
+
+            // One more is rejected -- proving the recurring notification's 2-slot weight was enforced.
+            var overCapResponse = await scheduleClient.Schedule(
+                new AppNotificationOptions { AppId = Guid.NewGuid(), TypeId = Guid.NewGuid(), TagId = Guid.NewGuid(), Silent = true },
+                sendAt);
+            ClassicAssert.AreEqual(HttpStatusCode.BadRequest, overCapResponse.StatusCode);
+            ClassicAssert.AreEqual(
+                OdinClientErrorCode.TooManyScheduledNotifications, WebScaffold.GetErrorCode(overCapResponse.Error));
+        }
+        finally
+        {
+            foreach (var jobId in scheduledJobIds)
+            {
+                await scheduleClient.Cancel(jobId);
+            }
+        }
+    }
+
+    /// <summary>
     /// Both Schedule and Update require notification options; a null payload is rejected with a client
     /// error rather than silently scheduling/updating with no content.
     /// </summary>

--- a/tests/services/Odin.Services.Tests/AppNotifications/Push/Scheduled/ScheduledNotificationJobTests.cs
+++ b/tests/services/Odin.Services.Tests/AppNotifications/Push/Scheduled/ScheduledNotificationJobTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Odin.Services.AppNotifications.Push.Scheduled;
+using Odin.Services.JobManagement;
+
+namespace Odin.Services.Tests.AppNotifications.Push.Scheduled;
+
+// OnCompletedAsync is pure scheduling logic with no dependency on the tenant container or push
+// pipeline, so it's tested directly here rather than through a full background job run -- the
+// underlying reschedule mechanics (same job id, state reset, etc.) are already covered generically
+// in JobManagerTests (ItShouldRescheduleSuccessfulJobViaOnCompleted / ...FailedJobViaOnCompleted).
+public class ScheduledNotificationJobTests
+{
+    [Test]
+    public async Task OnCompletedAsync_ReturnsNull_WhenNotRecurring()
+    {
+        var job = new ScheduledNotificationJob(null!, NullLogger<ScheduledNotificationJob>.Instance)
+        {
+            Data = new ScheduledNotificationJobData { RecurrenceInterval = null }
+        };
+
+        var nextRun = await job.OnCompletedAsync(new JobCompletion(RunResult.Success, null, 1, DateTimeOffset.UtcNow));
+
+        Assert.That(nextRun, Is.Null);
+    }
+
+    [Test]
+    public async Task OnCompletedAsync_AnchorsNextRunOffScheduledFor_WhenRecurring()
+    {
+        var job = new ScheduledNotificationJob(null!, NullLogger<ScheduledNotificationJob>.Instance)
+        {
+            Data = new ScheduledNotificationJobData { RecurrenceInterval = 60_000 }
+        };
+
+        // ScheduledFor is deliberately in the past, as if the runner was delayed -- the next occurrence
+        // must anchor off the intended slot, not wall-clock now, or cadence drifts under load.
+        var scheduledFor = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var nextRun = await job.OnCompletedAsync(new JobCompletion(RunResult.Success, null, 1, scheduledFor));
+
+        Assert.That(nextRun, Is.EqualTo(scheduledFor.AddMilliseconds(60_000)));
+    }
+
+    [Test]
+    public async Task OnCompletedAsync_AlsoRecursAfterExhaustedFailure()
+    {
+        var job = new ScheduledNotificationJob(null!, NullLogger<ScheduledNotificationJob>.Instance)
+        {
+            Data = new ScheduledNotificationJobData { RecurrenceInterval = 60_000 }
+        };
+
+        var scheduledFor = DateTimeOffset.UtcNow;
+        var nextRun = await job.OnCompletedAsync(new JobCompletion(RunResult.Fail, "boom", 3, scheduledFor));
+
+        Assert.That(nextRun, Is.EqualTo(scheduledFor.AddMilliseconds(60_000)));
+    }
+}


### PR DESCRIPTION
## Summary
- Lets a scheduled push notification repeat on a fixed interval instead of firing once, reusing the job engine's existing `OnCompletedAsync` recurrence hook so the same job id keeps cycling rather than spawning a new job per occurrence.
- Enforces a 5-minute minimum recurrence interval on Schedule and Update — this floor (not the pending-count cap) is what protects the shared job queue from a single recurring notification generating an unbounded claim rate.
- A recurring notification counts as 2 against `MaxPendingPerTenant`, since unlike a one-shot job it never ages out of the queue on its own.
- `List` now reports the row's live `nextRun` instead of the originally requested send time, which only diverges once a recurring notification has fired at least once.

## Test plan
- [x] `ScheduledNotificationJobTests` — direct unit tests of `OnCompletedAsync` (null when not recurring, anchors off the intended slot rather than wall-clock now, also recurs after an exhausted failure)
- [x] `ScheduledNotificationTests` — recurrence interval below the floor rejected on both Schedule and Update; a recurring notification's interval is surfaced in `List` and counts double against the cap
- [x] Full solution build clean; all three affected test projects pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)