### PR TITLE
Remove unused HtmlSanitizer package to clear AngleSharp advisory

### DIFF
--- a/src/services/Odin.Services/Drives/DriveCore/Storage/Defragmenter.cs
+++ b/src/services/Odin.Services/Drives/DriveCore/Storage/Defragmenter.cs
@@ -12,7 +12,6 @@ using Odin.Services.Drives.DriveCore.Query;
 using Odin.Services.Drives.FileSystem.Base;
 using Odin.Services.Drives.Management;
 using Odin.Core.Storage.Database.Identity;
-using AngleSharp.Html;
 using Npgsql.Internal;
 
 namespace Odin.Services.Drives.DriveCore.Storage

--- a/src/services/Odin.Services/Odin.Services.csproj
+++ b/src/services/Odin.Services/Odin.Services.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Certes" Version="3.0.4" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.72" />
-    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />

--- a/src/services/Odin.Services/PublicPage/HomebasePublicPageService.cs
+++ b/src/services/Odin.Services/PublicPage/HomebasePublicPageService.cs
@@ -9,7 +9,6 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using AngleSharp.Io;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Odin.Core.Exceptions;
@@ -468,7 +467,7 @@ public class HomebasePublicPageService(
     private async Task WriteAsync(string content)
     {
         var context = httpContextAccessor.HttpContext;
-        context.Response.Headers[HeaderNames.ContentType] = MediaTypeNames.Text.Html;
+        context.Response.ContentType = MediaTypeNames.Text.Html;
         try
         {
             await context.Response.WriteAsync(content);


### PR DESCRIPTION
## Summary
- CI's "Check for Vulnerable Packages" step fails on every branch (including main since 84d50011e ran against the freshly published advisory) due to [GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg): mXSS in AngleSharp < 1.5.0, pulled transitively via `HtmlSanitizer 9.0.892` in Odin.Services.
- HtmlSanitizer pins AngleSharp to exactly `[0.17.1]` and no stable HtmlSanitizer release depends on a patched AngleSharp yet (only `9.1.968-beta` → AngleSharp 1.5.2), so the clean fix is removal: no code uses the sanitizer.
- The only code touching the transitive AngleSharp dependency was one dead `using AngleSharp.Html;` in `Defragmenter.cs` and a `HeaderNames.ContentType` lookup in `HomebasePublicPageService.cs` that silently resolved to `AngleSharp.Io.HeaderNames` — replaced with the equivalent `HttpResponse.ContentType` property.

## Test plan
- `dotnet build ./odin-core.sln` — clean
- `dotnet list ./odin-core.sln package --vulnerable --include-transitive` (the exact CI check) — no vulnerable packages in any project
- `ProfileAttributePublishingTests` (11) and `SpaFallbackTests` (10) pass, covering the HTML response path changed in HomebasePublicPageService

🤖 Generated with [Claude Code](https://claude.com/claude-code)