### PR TITLE
Skip shared-secret decryption for any bodyless request

### DIFF
--- a/src/apps/Odin.Hosting/Middleware/SharedSecretEncryptionMiddleware.cs
+++ b/src/apps/Odin.Hosting/Middleware/SharedSecretEncryptionMiddleware.cs
@@ -292,15 +292,16 @@ namespace Odin.Hosting.Middleware
                 return false;
             }
 
-            if (context.Request.Method.ToUpper() == "POST")
+            // No body to decrypt: either Content-Length is explicitly 0 or absent (and no chunked body).
+            // Some clients (HTTP/2, ASP.NET TestServer) omit Content-Length on bodyless requests.
+            // Applies to every body-carrying verb, not just POST — a bodyless PUT/PATCH would otherwise
+            // fall through to DecryptRequest and fail parsing an empty stream as a SharedSecretEncryptedPayload.
+            // GET is excluded deliberately: its encrypted payload is the querystring, not the body.
+            if (context.Request.Method.ToUpper() != "GET"
+                && context.Request.Headers.ContentLength.GetValueOrDefault() == 0
+                && !context.Request.Headers.ContainsKey("Transfer-Encoding"))
             {
-                // No body to decrypt: either Content-Length is explicitly 0 or absent (and no chunked body).
-                // Some clients (HTTP/2, ASP.NET TestServer) omit Content-Length on bodyless POSTs.
-                if (context.Request.Headers.ContentLength.GetValueOrDefault() == 0
-                    && !context.Request.Headers.ContainsKey("Transfer-Encoding"))
-                {
-                    return false;
-                }
+                return false;
             }
 
             if (context.Request.Method.ToUpper() == "GET" && context.Request.QueryString.HasValue == false)

--- a/tests/apps/Odin.Hosting.Tests.V2/Hosting/SharedSecretBodylessRequestTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Hosting/SharedSecretBodylessRequestTests.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Hosting.Tests._Universal.ApiClient.Connections;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Hosting.UnifiedV2;
+
+namespace Odin.Hosting.Tests.V2.Hosting;
+
+/// <summary>
+/// <c>SharedSecretEncryptionMiddleware.ShouldDecryptRequest</c> skips decryption when the request
+/// carries no body at all. That exemption used to be POST-only, so a bodyless PUT/PATCH fell through
+/// to <c>DecryptRequest</c>, which tried to parse an empty stream as a <c>SharedSecretEncryptedPayload</c>
+/// and returned 400 <c>sharedSecretEncryptionIsInvalid</c> — making bodyless PUT endpoints
+/// (e.g. accept-incoming-connection-request) uncallable unless the client sent an encrypted empty payload.
+/// </summary>
+[TestFixture]
+public class SharedSecretBodylessRequestTests : V2Fixture
+{
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task BodylessPut_IsNotTreatedAsAnEncryptedPayload()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        var sendReq = await new UniversalCircleNetworkRequestsApiClient(sam.Identity, sam.Factory)
+            .SendConnectionRequest(frodo.Identity);
+        Assert.That(sendReq.IsSuccessStatusCode, Is.True, $"SendConnectionRequest failed: {sendReq.StatusCode}");
+
+        // Raw client rather than a Refit wrapper: this must be a genuinely bodyless PUT — no
+        // Content-Length, no serialized (and therefore encrypted) payload of any kind.
+        using var client = frodo.Factory.CreateHttpClient(frodo.Identity, out _);
+        var response = await client.PutAsync(
+            $"{UnifiedApiRouteConstants.Connections}/requests/incoming/{sam.Identity}", null);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent),
+            $"expected 204, got {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+    }
+}


### PR DESCRIPTION
Fixes #1605

## What broke

`SharedSecretEncryptionMiddleware.ShouldDecryptRequest` exempted bodyless **POST**s from decryption but
not PUT/PATCH. Those fell through to `DecryptRequest`, which tried to parse an empty stream as a
`SharedSecretEncryptedPayload` — `JsonException` → `OdinClientException(SharedSecretEncryptionIsInvalid)` →
400, before the action ever ran:

```
400 {"title":"Failed to decrypt shared secret payload.  Ensure you've provided a body of json
     formatted as SharedSecretEncryptedPayload","errorCode":"sharedSecretEncryptionIsInvalid"}
```

So a bodyless PUT was uncallable unless the client sent an encrypted empty payload it had no reason to send.
`PUT /api/v2/connections/requests/incoming/{senderId}` (accept incoming connection request) is the one live
example; every other bodyless PUT/PATCH is already exempt via `[NoSharedSecretOnRequest]`,
`_ignoredPathsForRequests`, or a System-level caller. Mostly this is a trap for the next one added.

## Change

Hoist the bodyless check out of the POST-only branch so it applies to every body-carrying verb:

```csharp
if (context.Request.Method.ToUpper() != "GET"
    && context.Request.Headers.ContentLength.GetValueOrDefault() == 0
    && !context.Request.Headers.ContainsKey("Transfer-Encoding"))
{
    return false;
}
```

**GET is excluded deliberately** — a GET is bodyless by definition, and its encrypted payload is the
querystring, not the body. Folding GET into a "no body → skip decryption" rule would silently stop
decrypting encrypted querystrings. The existing no-querystring GET early-outs still handle that case.

This also makes the `if (bytes.Length > 0)` hand-holding in the DELETE branch of `DecryptRequest`
redundant for the empty-body case; left in place rather than widening the change.

Nothing about auth or response encryption moves — authentication/authorization run in separate
middleware, and `ShouldEncryptResponse` is governed independently. The only behavioral change is that a
request which previously died with a misleading crypto 400 now reaches its action; an endpoint that
genuinely requires a body still rejects it via its own validation.

## Testing

- New `SharedSecretBodylessRequestTests` — issues a genuinely bodyless PUT (raw `HttpClient`, no Refit
  body serializer) against the V2 accept-incoming-request endpoint and expects 204. Verified it fails with
  the 400 above when the middleware change is reverted.
- Full `Odin.Hosting.Tests.V2` suite — 395 passed, 3 skipped, 0 failed.
- `Odin.Hosting.Tests` (V1 integration) could **not** be run locally: `WebScaffold` needs ports 8080/8443/4444
  and a local `Odin.Hosting` dev server was holding 4444, so the run aborted at fixture init with
  `AddressInUseException` rather than on anything in this diff. Needs CI (or a local re-run with those ports free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)