### PR TITLE
Sync a peer's published photo into its own contact payload

### DIFF
--- a/src/services/Odin.Services/Contacts/ContactEnrichmentService.cs
+++ b/src/services/Odin.Services/Contacts/ContactEnrichmentService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -15,7 +16,9 @@ using Odin.Services.Apps;
 using Odin.Services.Base;
 using Odin.Services.Drives;
 using Odin.Services.Drives.DriveCore.Query;
+using Odin.Services.Drives.DriveCore.Storage;
 using Odin.Services.Membership.Connections;
+using Odin.Services.Peer.Encryption;
 using Odin.Services.Peer.Outgoing.Drive.Query;
 
 namespace Odin.Services.Contacts;
@@ -68,11 +71,18 @@ public class ContactEnrichmentService(
 
         PeerContactContent content;
         ContactExtData extData = null;
+
+        // The peer's own photo. Null means "determined nothing this run" (leave the stored one alone);
+        // PeerContactImage.None means "no photo we can see" and drops it. Losing visibility — not
+        // connected, or a 403 — is a removal: we must not keep showing a gated photo we can no longer
+        // read. It never touches the user's own prfl_pic choice for this contact.
+        PeerContactImage peerImage = PeerContactImage.None;
+
         if (connected)
         {
             try
             {
-                (content, extData) = await BuildFromPeerProfileAsync(odinId, odinContext);
+                (content, extData, peerImage) = await BuildFromPeerProfileAsync(odinId, odinContext);
             }
             catch (OdinSecurityException)
             {
@@ -80,6 +90,7 @@ public class ContactEnrichmentService(
                 // due to an ICR-issue. Either way, fall back to the public profile.
                 logger.LogDebug("Enrich: 403 querying {odinId} ProfileDrive; falling back to public profile", odinId);
                 content = await TryBuildFromPublicProfileAsync(odinId);
+                peerImage = PeerContactImage.None;
             }
             catch (Exception e)
             {
@@ -95,20 +106,25 @@ public class ContactEnrichmentService(
         }
 
         var hasExtData = extData is { IsEmpty: false };
-        if (content == null && !hasExtData)
+        var hasImage = peerImage is { IsRemoval: false };
+        if (content == null && !hasExtData && !hasImage)
         {
+            // Nothing usable at all — don't merge, so we never conjure an empty contact for an identity
+            // that published nothing. Consequence: a peer who clears their *entire* profile keeps any
+            // peer photo we already hold; one who clears only the photo (still has a name) drops it on
+            // this same run.
             logger.LogDebug("Enrich: no profile data found for {odinId}; nothing to merge", odinId);
             return;
         }
 
-        // ext_data may be present even when no flat content fields were found; merge it onto a (possibly
-        // bare) content carrying just the odinId.
+        // ext_data / the photo may be present even when no flat content fields were found; merge onto a
+        // (possibly bare) content carrying just the odinId.
         content ??= new PeerContactContent();
         content.OdinId = odinId.DomainName;
-        await contactService.MergeAsync(content, ContactMergeSource.Enrichment, odinContext, extData);
+        await contactService.MergeAsync(content, ContactMergeSource.Enrichment, odinContext, extData, peerImage);
     }
 
-    private async Task<(PeerContactContent content, ContactExtData extData)> BuildFromPeerProfileAsync(
+    private async Task<(PeerContactContent content, ContactExtData extData, PeerContactImage peerImage)> BuildFromPeerProfileAsync(
         OdinId odinId, IOdinContext odinContext)
     {
         var request = new QueryBatchRequest
@@ -129,24 +145,35 @@ public class ContactEnrichmentService(
         var result = await peerDriveQueryService.GetBatchAsync(odinId, request, FileSystemType.Standard, odinContext);
         if (result?.SearchResults == null)
         {
-            return (null, null);
+            return (null, null, null);
         }
 
         // A peer can publish several attributes of the same type (e.g. a primary and a secondary
         // phone). Each carries an authored Priority (lower = preferred, matching odin-js); process in
         // ascending Priority order and keep the first non-empty value per field, so a higher-priority
         // attribute that happens to be empty never shadows a populated lower-priority one.
+        // The header rides along so the Photo attribute can be resolved to its payload afterwards.
         var attributes = result.SearchResults
-            .Select(h => (Tags: h.FileMetadata.AppData.Tags ?? new List<Guid>(), Block: TryGetAttributeBlock(h, odinContext)))
+            .Select(h => (Tags: h.FileMetadata.AppData.Tags ?? new List<Guid>(), Block: TryGetAttributeBlock(h, odinContext),
+                Header: h))
             .Where(x => x.Block?.Data != null)
             .OrderBy(x => x.Block.Priority ?? int.MaxValue)
             .ToList();
+
+        // The Photo attribute's image is a payload, not a content field — fetch it separately. The
+        // highest-priority photo the peer lets us see wins; a peer publishing both a public avatar and a
+        // richer connected-only one therefore gives us whichever their ACLs admit us to.
+        var peerImage = await TryFetchPeerImageAsync(odinId,
+            attributes.Where(x => x.Tags.Contains(ContactProfileAttributes.Photo))
+                .Select(x => (x.Block, x.Header))
+                .FirstOrDefault(),
+            odinContext);
 
         var content = new PeerContactContent();
         ContactExtData extData = null;
         var found = false;
 
-        foreach (var (tags, block) in attributes)
+        foreach (var (tags, block, _) in attributes)
         {
             var data = block.Data;
 
@@ -289,7 +316,169 @@ public class ContactEnrichmentService(
             }
         }
 
-        return (found ? content : null, extData);
+        return (found ? content : null, extData, peerImage);
+    }
+
+    /// <summary>
+    /// Resolves the peer's Photo attribute to its actual image bytes: the attribute header only carries a
+    /// pointer (<c>data.profileImageKey</c>) at a payload on the same file, so the payload — and every
+    /// thumbnail the peer published for it — is fetched over transit and decrypted with our shared
+    /// secret. Returns <see cref="PeerContactImage.None"/> when the peer publishes no photo we can see
+    /// (so a stale one gets cleared), and <c>null</c> when a fetch failed midway and the stored photo
+    /// should simply be left alone.
+    /// </summary>
+    private async Task<PeerContactImage> TryFetchPeerImageAsync(OdinId odinId,
+        (ProfileAttribute Block, SharedSecretEncryptedFileHeader Header) photo, IOdinContext odinContext)
+    {
+        if (photo.Block == null || photo.Header == null)
+        {
+            return PeerContactImage.None;
+        }
+
+        var payloadKey = Str(photo.Block.Data, ContactProfileAttributes.ProfileImageKeyField);
+        if (payloadKey == null)
+        {
+            logger.LogDebug("Enrich: {odinId} photo attribute has no {field}; treating as no photo",
+                odinId, ContactProfileAttributes.ProfileImageKeyField);
+            return PeerContactImage.None;
+        }
+
+        var descriptor = photo.Header.FileMetadata.Payloads?.FirstOrDefault(p => p.KeyEquals(payloadKey));
+        if (descriptor == null)
+        {
+            logger.LogDebug("Enrich: {odinId} photo attribute points at payload {key} which isn't on the file",
+                odinId, payloadKey);
+            return PeerContactImage.None;
+        }
+
+        if (descriptor.BytesWritten > ContactService.MaxPeerImageBytes)
+        {
+            logger.LogDebug("Enrich: {odinId} photo payload is {size} bytes, over the {cap} cap; skipping",
+                odinId, descriptor.BytesWritten, ContactService.MaxPeerImageBytes);
+            return PeerContactImage.None;
+        }
+
+        var file = new ExternalFileIdentifier
+        {
+            TargetDrive = SystemDriveConstants.ProfileDrive,
+            FileId = photo.Header.FileId
+        };
+
+        try
+        {
+            var (keyHeader, isEncrypted, payloadStream) = await peerDriveQueryService.GetPayloadStreamAsync(
+                odinId, file, payloadKey, null, FileSystemType.Standard, odinContext);
+
+            if (payloadStream == null)
+            {
+                return PeerContactImage.None;
+            }
+
+            byte[] image;
+            using (payloadStream)
+            {
+                image = await DecryptPeerPayloadAsync(payloadStream.Stream, keyHeader, isEncrypted, odinContext);
+            }
+
+            if (image is not { Length: > 0 })
+            {
+                return PeerContactImage.None;
+            }
+
+            if (image.Length > ContactService.MaxPeerImageBytes)
+            {
+                // The descriptor's BytesWritten is the *ciphertext* length; re-check the plaintext.
+                logger.LogDebug("Enrich: {odinId} decrypted photo is over the {cap} byte cap; skipping",
+                    odinId, ContactService.MaxPeerImageBytes);
+                return PeerContactImage.None;
+            }
+
+            var thumbnails = new List<PeerContactImageThumbnail>();
+            foreach (var thumb in descriptor.Thumbnails ?? [])
+            {
+                var bytes = await TryFetchPeerThumbnailAsync(odinId, file, payloadKey, thumb, odinContext);
+                if (bytes is { Length: > 0 })
+                {
+                    thumbnails.Add(new PeerContactImageThumbnail
+                    {
+                        PixelWidth = thumb.PixelWidth,
+                        PixelHeight = thumb.PixelHeight,
+                        ContentType = thumb.ContentType,
+                        Content = bytes
+                    });
+                }
+            }
+
+            return new PeerContactImage
+            {
+                Content = image,
+                ContentType = descriptor.ContentType,
+                Thumbnails = thumbnails
+            };
+        }
+        catch (OdinSecurityException)
+        {
+            // The attribute header was readable but the payload isn't — treat as no photo rather than
+            // failing the whole enrichment.
+            logger.LogDebug("Enrich: 403 fetching {odinId} photo payload; treating as no photo", odinId);
+            return PeerContactImage.None;
+        }
+        catch (Exception e)
+        {
+            // Transit hiccup partway through: leave whatever photo we already hold alone.
+            logger.LogInformation(e, "Enrich: could not fetch photo for {odinId}; leaving the stored photo unchanged", odinId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Best-effort fetch of one published thumbnail rendition. A rendition that fails is skipped — the
+    /// full-size image alone is still a usable result.
+    /// </summary>
+    private async Task<byte[]> TryFetchPeerThumbnailAsync(OdinId odinId, ExternalFileIdentifier file, string payloadKey,
+        ThumbnailDescriptor thumb, IOdinContext odinContext)
+    {
+        try
+        {
+            var (keyHeader, isEncrypted, _, _, stream) = await peerDriveQueryService.GetThumbnailAsync(
+                odinId, file, thumb.PixelWidth, thumb.PixelHeight, payloadKey, FileSystemType.Standard, odinContext);
+
+            if (stream == null)
+            {
+                return null;
+            }
+
+            await using (stream)
+            {
+                return await DecryptPeerPayloadAsync(stream, keyHeader, isEncrypted, odinContext);
+            }
+        }
+        catch (Exception e)
+        {
+            logger.LogDebug(e, "Enrich: skipping {w}x{h} thumbnail for {odinId}", thumb.PixelWidth, thumb.PixelHeight, odinId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads a peer payload/thumbnail stream and decrypts it. The peer query re-encrypts the payload's
+    /// key header to our shared secret and bakes the payload's own IV into it, so this is a straight
+    /// decrypt; an unencrypted (anonymous-tier) payload comes back as plaintext.
+    /// </summary>
+    private static async Task<byte[]> DecryptPeerPayloadAsync(Stream stream, EncryptedKeyHeader keyHeader,
+        bool isEncrypted, IOdinContext odinContext)
+    {
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        var bytes = ms.ToArray();
+
+        if (!isEncrypted || bytes.Length == 0)
+        {
+            return bytes;
+        }
+
+        var sharedSecret = odinContext.PermissionsContext.SharedSecretKey;
+        return keyHeader.DecryptAesToKeyHeader(ref sharedSecret).Decrypt(bytes);
     }
 
     private static bool HasAnyValue(ContactName name)

--- a/src/services/Odin.Services/Contacts/ContactProfileAttributes.cs
+++ b/src/services/Odin.Services/Contacts/ContactProfileAttributes.cs
@@ -66,8 +66,18 @@ internal static class ContactProfileAttributes
     /// <summary>Attribute types stored verbatim (keyed by type id) in the ext_data payload.</summary>
     public static readonly Guid[] ExtDataTypes = [Experience, Bio];
 
-    /// <summary>Everything the enrichment ProfileDrive query pulls in one shot.</summary>
-    public static readonly Guid[] QueryTypes = [.. TextTypes, .. ExtDataTypes, .. SocialTypes, Link];
+    /// <summary>
+    /// Everything the enrichment ProfileDrive query pulls in one shot. <see cref="Photo"/> is included
+    /// but is deliberately not in <see cref="TextTypes"/> — its value is a drive payload, not a content
+    /// field, so it is handled separately (see <c>ContactEnrichmentService.TryFetchPeerImageAsync</c>).
+    /// </summary>
+    public static readonly Guid[] QueryTypes = [.. TextTypes, .. ExtDataTypes, .. SocialTypes, Link, Photo];
+
+    /// <summary>
+    /// The Photo attribute's data field naming the payload key its image is stored under (the attribute
+    /// header carries the pointer, never the bytes).
+    /// </summary>
+    public const string ProfileImageKeyField = ProfileAttributeFields.ProfileImageKey;
 
     // Field keys within an attribute's Data dictionary — aliases to the shared source of truth
     // (ProfileAttributeFields), so the reader here and the writer (ProfileAttributeService) cannot drift.

--- a/src/services/Odin.Services/Contacts/ContactService.cs
+++ b/src/services/Odin.Services/Contacts/ContactService.cs
@@ -44,6 +44,21 @@ public class ContactService(
     public const string ProfileImagePayloadKey = "prfl_pic";
 
     /// <summary>
+    /// Payload key for the <b>peer's own</b> published photo, synced by
+    /// <see cref="ContactEnrichmentService"/> (see <see cref="PeerContactImage"/>). Held separately from
+    /// <see cref="ProfileImagePayloadKey"/> — the user's chosen photo for this contact — so neither can
+    /// clobber the other and a client can fall back from one to the other. Must satisfy
+    /// <c>^[a-z0-9_]{8,10}$</c>.
+    /// </summary>
+    public const string PeerImagePayloadKey = "peer_pic";
+
+    /// <summary>
+    /// Max size (bytes) of a synced peer photo. Mirrors the cap the profile service enforces when a photo
+    /// attribute is authored, so a peer cannot push more at us than they could store themselves.
+    /// </summary>
+    public const int MaxPeerImageBytes = 2 * 1024 * 1024;
+
+    /// <summary>
     /// Max size (UTF-8 bytes) of a single per-app data blob (<c>appData[appId]</c>). The blob rides inline
     /// in the contact JSON returned by every list query, so it is kept small; bulk data belongs in a payload.
     /// </summary>
@@ -183,8 +198,9 @@ public class ContactService(
             return VersionConflictResult(uniqueId, existing, currentVersionTag, odinContext);
         }
 
-        // Owner edits never touch ext_data (peer-only); pass null so any stored ext_data is preserved.
-        var newVersionTag = await OverwriteAsync(existing, content, ContactMergeSource.Api, null, writeContext);
+        // Owner edits never touch ext_data or the peer photo (both peer-only); pass null for each so the
+        // stored payloads are preserved.
+        var newVersionTag = await OverwriteAsync(existing, content, ContactMergeSource.Api, null, null, writeContext);
         return new ContactWriteResult
         {
             Outcome = ContactWriteOutcome.Updated,
@@ -634,8 +650,14 @@ public class ContactService(
     /// converges any straggler). Overwritten values are logged to <c>merge_log</c> tagged with
     /// <paramref name="source"/>.
     /// </summary>
+    /// <param name="peerImage">
+    /// The peer's own published photo, stored under <see cref="PeerImagePayloadKey"/> and never mixed
+    /// with the user's chosen <see cref="ProfileImagePayloadKey"/>. <c>null</c> leaves any stored peer
+    /// photo untouched; <see cref="PeerContactImage.None"/> removes it; an instance carrying bytes
+    /// replaces it (skipped when the digest matches what is already stored).
+    /// </param>
     public async Task<Guid> MergeAsync(PeerContactContent content, ContactMergeSource source, IOdinContext odinContext,
-        ContactExtData extData = null)
+        ContactExtData extData = null, PeerContactImage peerImage = null)
     {
         OdinValidationUtils.AssertNotNull(content, nameof(content));
         OdinValidationUtils.AssertIsTrue(!string.IsNullOrWhiteSpace(content.OdinId), "MergeAsync requires content.OdinId");
@@ -657,16 +679,16 @@ public class ContactService(
                 var created = Merge(new ContactContent(), content);
                 var (_, versionTag) = await WriteNewAsync(uniqueId, created, writeContext);
 
-                // The create path writes content only; if the peer also brought ext_data, persist it in
-                // a follow-up write now that the file exists (rare: a brand-new contact that already
-                // carries bios). Content is unchanged on this second pass, so only the ext_data payload
-                // is added.
-                if (extData is { IsEmpty: false })
+                // The create path writes content only; if the peer also brought ext_data or a photo,
+                // persist those in a follow-up write now that the file exists (rare: a brand-new contact
+                // that already carries bios/an avatar). Content is unchanged on this second pass, so only
+                // the payload(s) are added.
+                if (extData is { IsEmpty: false } || peerImage is { IsRemoval: false })
                 {
                     var fresh = await GetForWritingAsync(uniqueId, writeContext);
                     if (fresh != null)
                     {
-                        versionTag = await OverwriteAsync(fresh, content, source, extData, writeContext);
+                        versionTag = await OverwriteAsync(fresh, content, source, extData, peerImage, writeContext);
                     }
                 }
 
@@ -675,7 +697,7 @@ public class ContactService(
 
             try
             {
-                return await OverwriteAsync(existing, content, source, extData, writeContext);
+                return await OverwriteAsync(existing, content, source, extData, peerImage, writeContext);
             }
             catch (OdinClientException e) when (e.ErrorCode == OdinClientErrorCode.VersionTagMismatch)
             {
@@ -743,7 +765,7 @@ public class ContactService(
     }
 
     private async Task<Guid> OverwriteAsync(ServerFileHeader existing, PeerContactContent incoming, ContactMergeSource source,
-        ContactExtData extData, IOdinContext writeContext)
+        ContactExtData extData, PeerContactImage peerImage, IOdinContext writeContext)
     {
         var file = existing.FileMetadata.File;
         var storageKey = writeContext.PermissionsContext.GetDriveStorageKey(DriveId);
@@ -759,7 +781,11 @@ public class ContactService(
         // extended data; otherwise the stored ext_data payload (if any) is carried forward untouched.
         var writeExtData = extData is { IsEmpty: false };
 
-        if (overwrites.Count == 0 && !writeExtData)
+        // peer_pic is likewise peer-only. Resolving the action up front keeps an unchanged photo from
+        // forcing a write: a repeat sync of the same image is a no-op, not a version-tag advance.
+        var peerImageAction = ResolvePeerImageAction(existing, peerImage);
+
+        if (overwrites.Count == 0 && !writeExtData && peerImageAction == PeerImageAction.Leave)
         {
             // Nothing to log (first-time fills / no-ops) and no ext_data change. Content-only update.
             // The content IV must still rotate — re-encrypting different plaintext under the same
@@ -773,14 +799,57 @@ public class ContactService(
             return existing.FileMetadata.VersionTag.GetValueOrDefault();
         }
 
-        // A payload changed (merge_log to append and/or ext_data to replace): write the merged content
-        // AND the affected payload(s) in ONE transaction so the change and its history land together (or
-        // not at all). The merge_log is only read when there's an overwrite to append to it.
+        // A payload changed (merge_log to append, ext_data to replace, and/or the peer photo to write or
+        // drop): write the merged content AND the affected payload(s) in ONE transaction so the change
+        // and its history land together (or not at all). The merge_log is only read when there's an
+        // overwrite to append to it.
         var existingLog = overwrites.Count > 0
             ? await ReadMergeLogAsync(existing, keyHeader, writeContext)
             : null;
         return await WriteMergedAsync(existing, merged, keyHeader.AesKey, existingLog, overwrites, source, extData,
-            existing.FileMetadata.VersionTag.GetValueOrDefault(), writeContext);
+            peerImage, peerImageAction, existing.FileMetadata.VersionTag.GetValueOrDefault(), writeContext);
+    }
+
+    /// <summary>
+    /// What this merge should do with the <see cref="PeerImagePayloadKey"/> payload.
+    /// </summary>
+    private enum PeerImageAction
+    {
+        /// <summary>Nothing to do — nothing was determined, or the stored photo already matches.</summary>
+        Leave,
+
+        /// <summary>Write (or replace) the peer photo.</summary>
+        Write,
+
+        /// <summary>Drop the stored peer photo — the peer has none we can see.</summary>
+        Delete
+    }
+
+    /// <summary>
+    /// Decides the peer-photo action, comparing the incoming photo's digest against the one recorded on
+    /// the stored payload descriptor so an unchanged photo costs nothing. A null
+    /// <paramref name="peerImage"/> means the caller determined nothing this run and always leaves the
+    /// stored payload alone; <see cref="PeerContactImage.None"/> is the explicit removal signal.
+    /// </summary>
+    private static PeerImageAction ResolvePeerImageAction(ServerFileHeader existing, PeerContactImage peerImage)
+    {
+        if (peerImage == null)
+        {
+            return PeerImageAction.Leave;
+        }
+
+        var stored = existing.FileMetadata.Payloads?.FirstOrDefault(p => p.KeyEquals(PeerImagePayloadKey));
+
+        if (peerImage.IsRemoval)
+        {
+            return stored == null ? PeerImageAction.Leave : PeerImageAction.Delete;
+        }
+
+        // A stored descriptor written before the digest existed has no DescriptorContent; treat it as a
+        // mismatch so the next sync heals it (and records a digest for the sync after that).
+        return stored?.DescriptorContent == peerImage.ComputeHash()
+            ? PeerImageAction.Leave
+            : PeerImageAction.Write;
     }
 
     /// <summary>
@@ -789,12 +858,14 @@ public class ContactService(
     /// <see cref="DriveStorageServiceBase.UpdateBatchAsync"/> commit (one version-tag advance, one change
     /// notification). The contact's AES key is reused; the content key-header IV is rotated (a hard
     /// requirement for encrypted updates), and each rewritten payload gets its own IV. Payloads this
-    /// write doesn't touch (the profile image, and whichever of merge_log/ext_data isn't being written)
-    /// are carried forward unchanged.
+    /// write doesn't touch are carried forward unchanged — in particular the <b>user's</b> profile image
+    /// (<see cref="ProfileImagePayloadKey"/>), which no merge ever writes; the peer's photo lives in its
+    /// own <see cref="PeerImagePayloadKey"/> slot.
     /// </summary>
     private async Task<Guid> WriteMergedAsync(ServerFileHeader existing, ContactContent merged,
         SensitiveByteArray aesKey, List<ContactMergeLogEntry> existingLog, Dictionary<string, string> overwrites,
-        ContactMergeSource source, ContactExtData extData, Guid currentVersionTag, IOdinContext writeContext)
+        ContactMergeSource source, ContactExtData extData, PeerContactImage peerImage, PeerImageAction peerImageAction,
+        Guid currentVersionTag, IOdinContext writeContext)
     {
         var file = existing.FileMetadata.File;
 
@@ -824,10 +895,30 @@ public class ContactService(
                 { Key = ContactExtData.PayloadKey, OperationType = PayloadUpdateOperationType.AppendOrOverwrite });
         }
 
-        // Carry forward every payload this write isn't rewriting (e.g. the profile image, and whichever
-        // of merge_log/ext_data wasn't touched). Payloads not named in PayloadInstruction are preserved.
+        // 4) peer_pic: the peer's own photo — written when it changed, dropped when the peer no longer
+        // publishes one we can see. Never touches the user's prfl_pic override either way.
+        if (peerImageAction == PeerImageAction.Write)
+        {
+            rewritten.Add(await StagePeerImagePayloadAsync(file, peerImage, aesKey, writeContext));
+            instructions.Add(new PayloadInstruction
+                { Key = PeerImagePayloadKey, OperationType = PayloadUpdateOperationType.AppendOrOverwrite });
+        }
+        else if (peerImageAction == PeerImageAction.Delete)
+        {
+            instructions.Add(new PayloadInstruction
+                { Key = PeerImagePayloadKey, OperationType = PayloadUpdateOperationType.DeletePayload });
+        }
+
+        // Carry forward every payload this write isn't rewriting (e.g. the user's profile image, and
+        // whichever of merge_log/ext_data wasn't touched) — but not one being deleted. Payloads not named
+        // in PayloadInstruction are preserved.
+        var deleting = instructions
+            .Where(i => i.OperationType == PayloadUpdateOperationType.DeletePayload)
+            .Select(i => i.Key)
+            .ToList();
+
         var carried = (existing.FileMetadata.Payloads ?? new List<PayloadDescriptor>())
-            .Where(p => !rewritten.Any(r => p.KeyEquals(r.Key)))
+            .Where(p => !rewritten.Any(r => p.KeyEquals(r.Key)) && !deleting.Any(p.KeyEquals))
             .ToList();
 
         // New metadata: merged content + the rewritten payload descriptors. VersionTag carries the
@@ -871,6 +962,60 @@ public class ContactService(
         {
             await fileSystem.Storage.CleanupUploadTemporaryFiles(file, rewritten, writeContext);
         }
+    }
+
+    /// <summary>
+    /// Encrypts the peer's photo and each of its thumbnails under the file AES key — sharing <b>one</b>
+    /// fresh payload IV, the same convention <see cref="WriteImagePayloadAsync"/> and the profile service
+    /// follow — stages them, and returns the descriptor. The image digest rides on
+    /// <see cref="PayloadDescriptor.DescriptorContent"/> so the next sync can tell an unchanged photo
+    /// from a new one without re-reading the payload.
+    /// </summary>
+    private async Task<PayloadDescriptor> StagePeerImagePayloadAsync(InternalDriveFileId file, PeerContactImage image,
+        SensitiveByteArray aesKey, IOdinContext writeContext)
+    {
+        var iv = ByteArrayUtil.GetRndByteArray(16);
+        var uid = UnixTimeUtcUnique.Now();
+
+        byte[] Encrypt(byte[] plain) => new KeyHeader { Iv = iv, AesKey = aesKey }.EncryptDataAes(plain);
+
+        var imageExtension = TenantPathManager.GetBasePayloadFileNameAndExtension(PeerImagePayloadKey, uid);
+        var imageBytesWritten = await fileSystem.Storage.WriteUploadStream(file, imageExtension,
+            new MemoryStream(Encrypt(image.Content)), writeContext);
+
+        var thumbnailDescriptors = new List<ThumbnailDescriptor>();
+        foreach (var thumbnail in image.Thumbnails ?? [])
+        {
+            if (thumbnail.Content is not { Length: > 0 } || thumbnail.PixelWidth <= 0 || thumbnail.PixelHeight <= 0)
+            {
+                continue;
+            }
+
+            var thumbExtension = TenantPathManager.GetThumbnailFileNameAndExtension(
+                PeerImagePayloadKey, uid, thumbnail.PixelWidth, thumbnail.PixelHeight);
+            var thumbBytesWritten = await fileSystem.Storage.WriteUploadStream(file, thumbExtension,
+                new MemoryStream(Encrypt(thumbnail.Content)), writeContext);
+
+            thumbnailDescriptors.Add(new ThumbnailDescriptor
+            {
+                PixelWidth = thumbnail.PixelWidth,
+                PixelHeight = thumbnail.PixelHeight,
+                ContentType = thumbnail.ContentType,
+                BytesWritten = thumbBytesWritten
+            });
+        }
+
+        return new PayloadDescriptor
+        {
+            Key = PeerImagePayloadKey,
+            Uid = uid,
+            Iv = iv,
+            ContentType = image.ContentType,
+            BytesWritten = imageBytesWritten,
+            LastModified = UnixTimeUtc.Now(),
+            DescriptorContent = image.ComputeHash(),
+            Thumbnails = thumbnailDescriptors
+        };
     }
 
     /// <summary>

--- a/src/services/Odin.Services/Contacts/PeerContactImage.cs
+++ b/src/services/Odin.Services/Contacts/PeerContactImage.cs
@@ -1,0 +1,101 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Odin.Services.Contacts;
+
+/// <summary>
+/// A peer's own published profile photo, fetched from their <c>ProfileDrive</c> by
+/// <see cref="ContactEnrichmentService"/> and stored on our contact under
+/// <see cref="ContactService.PeerImagePayloadKey"/>.
+///
+/// <para>
+/// Deliberately <b>separate</b> from <see cref="ContactService.ProfileImagePayloadKey"/>: that payload
+/// holds the photo the <i>user</i> picked for this contact and enrichment must never touch it. Keeping
+/// the two independently addressable is what lets a client show the user's override while still being
+/// able to fall back to the peer's real photo when the override is removed.
+/// </para>
+///
+/// <para>
+/// Bytes here are <b>plaintext</b> — the peer query returns the payload re-encrypted to our shared
+/// secret and the enrichment service decrypts it; the contact write then re-encrypts under the contact
+/// file's own AES key. Instances are one of two shapes:
+/// <list type="bullet">
+/// <item><b>A photo</b> — <see cref="Content"/> non-empty; replaces any stored peer photo.</item>
+/// <item><see cref="None"/> — the peer has no photo we can see; removes the stored peer photo.</item>
+/// </list>
+/// A <c>null</c> <see cref="PeerContactImage"/> is distinct from <see cref="None"/>: it means "we did
+/// not determine anything this run" and leaves the stored payload untouched.
+/// </para>
+/// </summary>
+public sealed class PeerContactImage
+{
+    /// <summary>
+    /// The peer published no photo visible to us — drop whatever peer photo we hold. Distinct from a
+    /// null instance, which means "unknown; change nothing".
+    /// </summary>
+    public static readonly PeerContactImage None = new();
+
+    /// <summary>Plaintext image bytes. Empty/null marks this instance as a removal.</summary>
+    public byte[]? Content { get; init; }
+
+    /// <summary>MIME type of <see cref="Content"/>, e.g. <c>image/jpeg</c>.</summary>
+    public string? ContentType { get; init; }
+
+    /// <summary>Plaintext renditions the peer published alongside the full-size image.</summary>
+    public List<PeerContactImageThumbnail> Thumbnails { get; init; } = new();
+
+    /// <summary>True when this instance means "the peer has no photo" rather than carrying one.</summary>
+    public bool IsRemoval => Content is not { Length: > 0 };
+
+    /// <summary>
+    /// Stable digest over the image and every thumbnail, recorded on the stored payload descriptor
+    /// (<see cref="Odin.Services.Drives.DriveCore.Storage.PayloadDescriptor.DescriptorContent"/>) so a
+    /// later sync can recognize an unchanged photo and skip the rewrite — no version-tag advance and no
+    /// change notification for a no-op. Thumbnails are folded in dimension-order so the digest does not
+    /// depend on the order the peer happened to list them.
+    /// </summary>
+    public string ComputeHash()
+    {
+        using var sha = SHA256.Create();
+
+        void Fold(byte[]? bytes)
+        {
+            var length = BitConverter.GetBytes(bytes?.Length ?? 0);
+            sha.TransformBlock(length, 0, length.Length, null, 0);
+            if (bytes is { Length: > 0 })
+            {
+                sha.TransformBlock(bytes, 0, bytes.Length, null, 0);
+            }
+        }
+
+        Fold(Content);
+        foreach (var thumbnail in Thumbnails.OrderBy(t => t.PixelWidth).ThenBy(t => t.PixelHeight))
+        {
+            var dimensions = BitConverter.GetBytes(thumbnail.PixelWidth)
+                .Concat(BitConverter.GetBytes(thumbnail.PixelHeight))
+                .ToArray();
+            sha.TransformBlock(dimensions, 0, dimensions.Length, null, 0);
+            Fold(thumbnail.Content);
+        }
+
+        sha.TransformFinalBlock([], 0, 0);
+        return Convert.ToBase64String(sha.Hash!);
+    }
+}
+
+/// <summary>
+/// One rendition of a <see cref="PeerContactImage"/>. Plaintext, like its parent; the contact write
+/// encrypts image and thumbnails together under a single payload IV (the convention
+/// <see cref="ContactImageThumbnail"/> and <c>ProfileAttributeService</c> already follow).
+/// </summary>
+public sealed class PeerContactImageThumbnail
+{
+    public int PixelWidth { get; init; }
+    public int PixelHeight { get; init; }
+    public string? ContentType { get; init; }
+    public byte[]? Content { get; init; }
+}

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/ContactTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/ContactTests.cs
@@ -26,6 +26,7 @@ using Odin.Services.Drives;
 using Odin.Services.Drives.DriveCore.Query;
 using Odin.Services.Drives.DriveCore.Storage;
 using Odin.Services.Drives.FileSystem.Base.Upload;
+using Odin.Services.Profile;
 using Odin.Services.PublicPage.Profile;
 using Odin.Services.Membership.Connections;
 using Odin.Services.Peer.Encryption;
@@ -795,6 +796,148 @@ public class ContactTests : V2Fixture
         var ss = owner.SharedSecret;
         var fileKey = header.SharedSecretEncryptedKeyHeader.DecryptAesToKeyHeader(ref ss);
         return new KeyHeader { Iv = descriptor.Iv, AesKey = fileKey.AesKey }.Decrypt(cipher);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // enrichment / sync — the peer's own photo (peer_pic), kept apart from the user's (prfl_pic)
+    // -----------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Sync_StoresPeerPhoto_InItsOwnPayload_AndLeavesTheUsersChoiceAlone()
+    {
+        var sam = await LoginAsOwner(Identities.Sam);
+        var frodo = await LoginAsOwner(Identities.Frodo);
+
+        // Sam publishes a Connected-only photo — the case circles are supposed to make possible.
+        var (samImage, samThumb) = await SeedProfilePhotoAsync(sam, ProfileAttributeVisibility.Connected);
+
+        var contacts = new V2ContactsClient(frodo.Identity, frodo.Factory);
+        var create = await contacts.CreateAsync(new CreateContactRequest
+        {
+            Content = new ContactContent { OdinId = Identities.Sam, Name = new ContactName { DisplayName = "Sam" } }
+        });
+        var uid = create.Content!.UniqueId;
+
+        // Frodo also picks his own photo for this contact — sync must never touch it.
+        var (userImage, _) = await SetSampleImageAsync(frodo, contacts, uid, create.Content.VersionTag);
+
+        Assert.That((await frodo.Connections.SendConnectionRequest(sam.Identity)).IsSuccessStatusCode, Is.True);
+        Assert.That((await sam.Connections.AcceptConnectionRequest(frodo.Identity)).IsSuccessStatusCode, Is.True);
+
+        var sync = await contacts.SyncAsync(Identities.Sam);
+        Assert.That(sync.StatusCode, Is.EqualTo(HttpStatusCode.Accepted));
+
+        var header = await GetByUniqueIdAsync(frodo, uid);
+        var peer = header!.FileMetadata.Payloads?.FirstOrDefault(p => p.Key == ContactService.PeerImagePayloadKey);
+        Assert.That(peer, Is.Not.Null, "the peer's photo should be stored under peer_pic");
+        Assert.That(peer!.ContentType, Is.EqualTo("image/jpeg"));
+        Assert.That(peer.Thumbnails, Has.Count.EqualTo(1), "the peer's rendition came across too");
+        Assert.That(peer.DescriptorContent, Is.Not.Null.And.Not.Empty, "the digest is recorded for change detection");
+
+        Assert.That(await ReadPayloadAsync(frodo, uid, ContactService.PeerImagePayloadKey), Is.EqualTo(samImage),
+            "peer photo bytes round-trip, re-encrypted under the contact file's key");
+        Assert.That(await ReadThumbnailAsync(frodo, uid, ContactService.PeerImagePayloadKey, 32), Is.EqualTo(samThumb));
+
+        // The whole point: the user's own choice is untouched and still independently readable.
+        Assert.That(await ReadImagePayloadAsync(frodo, uid), Is.EqualTo(userImage),
+            "sync must never clobber the photo the user picked for this contact");
+    }
+
+    [Test]
+    public async Task Sync_IsANoOp_WhenThePeerPhotoIsUnchanged()
+    {
+        var sam = await LoginAsOwner(Identities.Sam);
+        var frodo = await LoginAsOwner(Identities.Frodo);
+
+        await SeedProfilePhotoAsync(sam, ProfileAttributeVisibility.Connected);
+        await SeedProfileNameAsync(sam, "Samwise Gamgee");
+
+        var contacts = new V2ContactsClient(frodo.Identity, frodo.Factory);
+        var create = await contacts.CreateAsync(new CreateContactRequest
+        {
+            Content = new ContactContent { OdinId = Identities.Sam, Name = new ContactName { DisplayName = "Sam" } }
+        });
+        var uid = create.Content!.UniqueId;
+
+        Assert.That((await frodo.Connections.SendConnectionRequest(sam.Identity)).IsSuccessStatusCode, Is.True);
+        Assert.That((await sam.Connections.AcceptConnectionRequest(frodo.Identity)).IsSuccessStatusCode, Is.True);
+
+        Assert.That((await contacts.SyncAsync(Identities.Sam)).StatusCode, Is.EqualTo(HttpStatusCode.Accepted));
+        var afterFirst = await GetByUniqueIdAsync(frodo, uid);
+        var firstDescriptor = afterFirst!.FileMetadata.Payloads!.First(p => p.Key == ContactService.PeerImagePayloadKey);
+
+        // Second sync: nothing changed on Sam's side, so the photo must not be re-staged.
+        Assert.That((await contacts.SyncAsync(Identities.Sam)).StatusCode, Is.EqualTo(HttpStatusCode.Accepted));
+
+        var afterSecond = await GetByUniqueIdAsync(frodo, uid);
+        var secondDescriptor = afterSecond!.FileMetadata.Payloads!.First(p => p.Key == ContactService.PeerImagePayloadKey);
+
+        // Uid changes on every re-stage, so an unchanged Uid is proof the bytes were not rewritten.
+        // (The header itself is still rewritten — every merge rotates the content IV and advances the
+        // version tag, which is pre-existing behaviour for text sync and not what this guards.)
+        Assert.That(secondDescriptor.Uid, Is.EqualTo(firstDescriptor.Uid), "an unchanged photo must not be re-staged");
+        Assert.That(secondDescriptor.Iv, Is.EqualTo(firstDescriptor.Iv), "and its IV must not be rotated");
+    }
+
+    [Test]
+    public async Task Sync_DropsThePeerPhoto_WhenThePeerNoLongerPublishesOne()
+    {
+        var sam = await LoginAsOwner(Identities.Sam);
+        var frodo = await LoginAsOwner(Identities.Frodo);
+
+        await SeedProfilePhotoAsync(sam, ProfileAttributeVisibility.Connected);
+        await SeedProfileNameAsync(sam, "Samwise Gamgee");
+
+        var contacts = new V2ContactsClient(frodo.Identity, frodo.Factory);
+        var create = await contacts.CreateAsync(new CreateContactRequest
+        {
+            Content = new ContactContent { OdinId = Identities.Sam, Name = new ContactName { DisplayName = "Sam" } }
+        });
+        var uid = create.Content!.UniqueId;
+        var (userImage, _) = await SetSampleImageAsync(frodo, contacts, uid, create.Content.VersionTag);
+
+        Assert.That((await frodo.Connections.SendConnectionRequest(sam.Identity)).IsSuccessStatusCode, Is.True);
+        Assert.That((await sam.Connections.AcceptConnectionRequest(frodo.Identity)).IsSuccessStatusCode, Is.True);
+
+        Assert.That((await contacts.SyncAsync(Identities.Sam)).StatusCode, Is.EqualTo(HttpStatusCode.Accepted));
+        Assert.That((await GetByUniqueIdAsync(frodo, uid))!.FileMetadata.Payloads!
+            .Any(p => p.Key == ContactService.PeerImagePayloadKey), Is.True, "precondition: the peer photo synced");
+
+        // Sam deletes his photo attribute; the next sync must clear the copy we hold.
+        await DeleteProfilePhotoAsync(sam);
+        Assert.That((await contacts.SyncAsync(Identities.Sam)).StatusCode, Is.EqualTo(HttpStatusCode.Accepted));
+
+        var header = await GetByUniqueIdAsync(frodo, uid);
+        var keys = (header!.FileMetadata.Payloads ?? new List<PayloadDescriptor>()).Select(p => p.Key).ToList();
+        Assert.That(keys, Does.Not.Contain(ContactService.PeerImagePayloadKey), "the stale peer photo is dropped");
+        Assert.That(keys, Does.Contain(ContactService.ProfileImagePayloadKey), "the user's own photo survives");
+        Assert.That(await ReadImagePayloadAsync(frodo, uid), Is.EqualTo(userImage));
+    }
+
+    [Test]
+    public async Task Sync_DoesNotStoreAPeerPhoto_WhenTheContactIsNotConnected()
+    {
+        var sam = await LoginAsOwner(Identities.Sam);
+        var frodo = await LoginAsOwner(Identities.Frodo);
+
+        // Anonymous so it is genuinely published — the point is that enrichment does not fetch photos
+        // over the public path at all, not that the ACL blocked it.
+        await SeedProfilePhotoAsync(sam, ProfileAttributeVisibility.Anonymous);
+        await SeedProfileNameAsync(sam, "Samwise Gamgee");
+
+        var contacts = new V2ContactsClient(frodo.Identity, frodo.Factory);
+        var create = await contacts.CreateAsync(new CreateContactRequest
+        {
+            Content = new ContactContent { OdinId = Identities.Sam, Name = new ContactName { DisplayName = "Sam" } }
+        });
+        var uid = create.Content!.UniqueId;
+
+        // No connection → the public-card fallback, which carries no image.
+        Assert.That((await contacts.SyncAsync(Identities.Sam)).StatusCode, Is.EqualTo(HttpStatusCode.Accepted));
+
+        var header = await GetByUniqueIdAsync(frodo, uid);
+        Assert.That((header!.FileMetadata.Payloads ?? new List<PayloadDescriptor>())
+            .Any(p => p.Key == ContactService.PeerImagePayloadKey), Is.False);
     }
 
     // -----------------------------------------------------------------------------------------
@@ -1599,6 +1742,94 @@ public class ContactTests : V2Fixture
             new UploadManifest(),
             []);
         Assert.That(seed.IsSuccessStatusCode, Is.True, "seeding the profile attribute should succeed");
+    }
+
+    /// <summary>
+    /// Publishes a Photo attribute (image + one 32px rendition) on the identity's ProfileDrive at the
+    /// given visibility, via the real profile API — the same path a client uses. Returns the plaintext
+    /// bytes so a test can assert they arrive intact on the other side.
+    /// </summary>
+    private static async Task<(byte[] image, byte[] thumb)> SeedProfilePhotoAsync(OwnerSession identity,
+        ProfileAttributeVisibility visibility)
+    {
+        var image = Enumerable.Range(0, 96).Select(i => (byte)(i * 5 + 3)).ToArray();
+        var thumb = Enumerable.Range(0, 24).Select(i => (byte)(i * 11 + 7)).ToArray();
+
+        var resp = await new V2ProfileClient(identity.Identity, identity.Factory).SetPhotoAttributeAsync(
+            new SetPhotoAttributeRequest
+            {
+                Visibility = visibility,
+                ContentType = "image/jpeg",
+                Content = image,
+                Thumbnails =
+                [
+                    new ProfilePhotoThumbnail
+                    {
+                        PixelWidth = 32, PixelHeight = 32, ContentType = "image/jpeg", Content = thumb
+                    }
+                ]
+            });
+
+        Assert.That(resp.IsSuccessStatusCode, Is.True, $"seeding the photo attribute failed: {resp.StatusCode}");
+        return (image, thumb);
+    }
+
+    /// <summary>Deletes every Photo attribute on the identity's ProfileDrive.</summary>
+    private static async Task DeleteProfilePhotoAsync(OwnerSession identity)
+    {
+        var reader = new DriveReaderV2Client(identity.Identity, identity.Factory);
+        var batch = await reader.GetBatchAsync(SystemDriveConstants.ProfileDrive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1
+            {
+                TargetDrive = SystemDriveConstants.ProfileDrive,
+                FileType = [ContactProfileAttributes.AttributeFileType],
+                TagsMatchAtLeastOne = [BuiltInProfileAttributes.Photo]
+            },
+            ResultOptionsRequest = QueryBatchResultOptionsRequest.Default
+        });
+
+        Assert.That(batch.IsSuccessStatusCode, Is.True);
+
+        var writer = new DriveWriterV2Client(identity.Identity, identity.Factory);
+        foreach (var result in batch.Content!.SearchResults)
+        {
+            var deleted = await writer.SoftDeleteFile(SystemDriveConstants.ProfileDrive.Alias, result.FileId);
+            Assert.That(deleted.IsSuccessStatusCode, Is.True, "deleting the photo attribute should succeed");
+        }
+    }
+
+    /// <summary>Reads and decrypts an arbitrary contact payload (file AES key under the descriptor's IV).</summary>
+    private static async Task<byte[]> ReadPayloadAsync(OwnerSession owner, Guid uid, string payloadKey)
+    {
+        var header = await GetByUniqueIdAsync(owner, uid);
+        var descriptor = header!.FileMetadata.Payloads!.First(p => p.Key == payloadKey);
+
+        var reader = new DriveReaderV2Client(owner.Identity, owner.Factory);
+        var resp = await reader.GetPayloadByUniqueIdAsync(uid, ContactDriveId, payloadKey);
+        Assert.That(resp.IsSuccessStatusCode, Is.True, $"{payloadKey} payload should be readable");
+
+        var ss = owner.SharedSecret;
+        var fileKey = header.SharedSecretEncryptedKeyHeader.DecryptAesToKeyHeader(ref ss);
+        return new KeyHeader { Iv = descriptor.Iv, AesKey = fileKey.AesKey }
+            .Decrypt(await resp.Content!.ReadAsByteArrayAsync());
+    }
+
+    /// <summary>Reads and decrypts one thumbnail rendition of a contact payload (same IV as its payload).</summary>
+    private static async Task<byte[]> ReadThumbnailAsync(OwnerSession owner, Guid uid, string payloadKey, int size)
+    {
+        var header = await GetByUniqueIdAsync(owner, uid);
+        var descriptor = header!.FileMetadata.Payloads!.First(p => p.Key == payloadKey);
+
+        var reader = new DriveReaderV2Client(owner.Identity, owner.Factory);
+        var resp = await reader.GetThumbnailUniqueIdAsync(uid, ContactDriveId, size, size, payloadKey,
+            directMatchOnly: true);
+        Assert.That(resp.IsSuccessStatusCode, Is.True, $"{payloadKey} {size}px thumbnail should be readable");
+
+        var ss = owner.SharedSecret;
+        var fileKey = header.SharedSecretEncryptedKeyHeader.DecryptAesToKeyHeader(ref ss);
+        return new KeyHeader { Iv = descriptor.Iv, AesKey = fileKey.AesKey }
+            .Decrypt(await resp.Content!.ReadAsByteArrayAsync());
     }
 
     private static async Task<Odin.Services.Apps.SharedSecretEncryptedFileHeader> GetByUniqueIdAsync(

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/PeerContactImageTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/PeerContactImageTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Odin.Services.Contacts;
+
+namespace Odin.Hosting.Tests.V2.Ported.Connections;
+
+/// <summary>
+/// Pure-logic tests for <see cref="PeerContactImage"/>'s digest — the value recorded on the stored
+/// payload descriptor that lets a repeat sync of an unchanged photo be a no-op instead of a rewrite.
+/// No host required.
+/// </summary>
+[TestFixture]
+public class PeerContactImageTests
+{
+    private static PeerContactImage Image(byte[] content, params PeerContactImageThumbnail[] thumbnails)
+    {
+        return new PeerContactImage
+        {
+            Content = content,
+            ContentType = "image/jpeg",
+            Thumbnails = new List<PeerContactImageThumbnail>(thumbnails)
+        };
+    }
+
+    private static PeerContactImageThumbnail Thumb(int size, byte[] content)
+    {
+        return new PeerContactImageThumbnail
+        {
+            PixelWidth = size,
+            PixelHeight = size,
+            ContentType = "image/jpeg",
+            Content = content
+        };
+    }
+
+    [Test]
+    public void ComputeHash_IsStableForIdenticalImages()
+    {
+        var a = Image([1, 2, 3], Thumb(32, [9, 9]));
+        var b = Image([1, 2, 3], Thumb(32, [9, 9]));
+
+        Assert.That(a.ComputeHash(), Is.EqualTo(b.ComputeHash()), "same bytes → same digest → sync is a no-op");
+    }
+
+    [Test]
+    public void ComputeHash_ChangesWhenImageChanges()
+    {
+        var a = Image([1, 2, 3]);
+        var b = Image([1, 2, 4]);
+
+        Assert.That(a.ComputeHash(), Is.Not.EqualTo(b.ComputeHash()));
+    }
+
+    [Test]
+    public void ComputeHash_ChangesWhenOnlyAThumbnailChanges()
+    {
+        var a = Image([1, 2, 3], Thumb(32, [9, 9]));
+        var b = Image([1, 2, 3], Thumb(32, [9, 8]));
+
+        Assert.That(a.ComputeHash(), Is.Not.EqualTo(b.ComputeHash()),
+            "a rendition change must still trigger a rewrite");
+    }
+
+    [Test]
+    public void ComputeHash_ChangesWhenThumbnailDimensionsChange()
+    {
+        var a = Image([1, 2, 3], Thumb(32, [9, 9]));
+        var b = Image([1, 2, 3], Thumb(64, [9, 9]));
+
+        Assert.That(a.ComputeHash(), Is.Not.EqualTo(b.ComputeHash()));
+    }
+
+    [Test]
+    public void ComputeHash_IgnoresThumbnailOrder()
+    {
+        var a = Image([1, 2, 3], Thumb(32, [9]), Thumb(64, [8]));
+        var b = Image([1, 2, 3], Thumb(64, [8]), Thumb(32, [9]));
+
+        Assert.That(a.ComputeHash(), Is.EqualTo(b.ComputeHash()),
+            "the peer's listing order must not force a pointless rewrite");
+    }
+
+    [Test]
+    public void ComputeHash_DistinguishesThumbnailBoundaries()
+    {
+        // Same concatenated bytes, different split — the length prefix must keep these apart.
+        var a = Image([1, 2, 3], Thumb(32, [9, 9]));
+        var b = Image([1, 2, 3, 9], Thumb(32, [9]));
+
+        Assert.That(a.ComputeHash(), Is.Not.EqualTo(b.ComputeHash()));
+    }
+
+    [Test]
+    public void None_IsARemoval()
+    {
+        Assert.That(PeerContactImage.None.IsRemoval, Is.True);
+        Assert.That(Image([1]).IsRemoval, Is.False);
+        Assert.That(Image([]).IsRemoval, Is.True, "empty content is a removal, not a zero-byte photo");
+    }
+}


### PR DESCRIPTION
Closes #1615.

## Problem

Contact enrichment pulled text fields from a connected peer's ProfileDrive but never their photo — `ContactEnrichmentService`'s own class comment called the image fetch a follow-up. The only image a contact could hold was `prfl_pic`, written solely by the client via `PUT /api/v2/contacts/{uniqueId}/image`.

So "the peer's published photo" and "the photo the user picked for this contact" had no separate representation. Each client surface invented its own precedence and they disagreed — the same person could show one face in chat and another in the contact book. A photo a peer published to a circle was unreachable end to end, even though `ProfileAttributeService.SetPhotoAttributeAsync` already supports authoring one at Connected visibility.

## Change

Give the peer's photo its own slot.

- **`peer_pic` payload**, written only by enrichment. `prfl_pic` keeps its single client writer and no merge path touches it. Both stay independently addressable, so a client can prefer the user's override and still fall back to the peer's real photo when that override is removed.
- **`ContactProfileAttributes.QueryTypes` now includes `Photo`.** The attribute header carries only a `data.profileImageKey` pointer, so enrichment resolves it to the payload, fetches it plus every published thumbnail over transit, decrypts under our shared secret, and re-encrypts under the contact file's AES key — image and thumbnails sharing one payload IV, the convention `prfl_pic` and the profile service already follow.
- **Change detection.** A digest over the image and its renditions rides on the payload descriptor's `DescriptorContent`, so re-syncing an unchanged photo skips the rewrite instead of re-staging bytes.
- **Removal.** Losing sight of the photo — peer deleted it, 403, or not connected — drops the stored copy rather than leaving a gated image on screen. One exception: a peer who clears their *entire* profile keeps their photo, because enrichment skips the merge entirely when nothing usable is found.
- Peer photos capped at 2MB, matching what the profile service accepts when the attribute is authored.

Because the peer photo is ACL-resolved on the peer's side, a connected-only photo now reaches us where a public one would have before — which is what makes circle-gated avatars possible at all.

## Tests

Full `Odin.Hosting.Tests.V2` suite: **416 passed, 0 failed, 3 skipped.**

- `PeerContactImageTests` — 7 pure-logic tests on the digest: stability, sensitivity to image/rendition/dimension changes, order-independence across thumbnails, boundary handling, and the removal sentinel.
- `ContactTests` — peer photo stored in `peer_pic` while the user's `prfl_pic` survives untouched; unchanged photo not re-staged; stale photo dropped when the peer deletes theirs; nothing stored for an unconnected contact.

## Not in this change

Left outstanding on #1615:

- **Client precedence is still undefined.** The server now exposes both payloads but nothing says which wins. Until every surface agrees on `prfl_pic` → `peer_pic` → `/pub/image` → initials, chat and contact book can still disagree — the original symptom. Client-side work.
- **Merge provenance doesn't cover payloads.** `ContactMergeLog.ComputeOverwrites` flattens `Content` only, so a peer photo replacing a previous one leaves no `merge_log` trace. Not a regression — payloads were never logged.
- **No public-tier photo sync.** The `pub/profile` fallback carries no image, so an unconnected contact gets no synced photo.

## Review notes

- Integration tests use synthetic byte arrays, so the 2MB cap and the thumbnail loop are exercised only at test scale — not against a real peer with a large or multi-rendition photo.
- One test initially asserted that a no-op sync leaves the version tag alone. It doesn't: every merge rotates the content IV and rewrites the header, which is pre-existing behaviour for text sync that this change neither introduces nor promises. The assertion was narrowed to the payload's `Uid`/`Iv`, which is the actual claim being made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)