### PR TITLE
Distinguish the states behind a failed introduction preflight

### DIFF
--- a/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
+++ b/src/services/Odin.Services/Membership/Connections/CircleNetworkService.cs
@@ -50,6 +50,7 @@ namespace Odin.Services.Membership.Connections
         PublicPrivateKeyService publicPrivateKeyService,
         CircleNetworkStorage circleNetworkStorage,
         PeerOutbox peerOutbox,
+        OdinContextCache odinContextCache,
         IdentityDatabase db)
         : INotificationHandler<DriveDefinitionAddedNotification>,
             INotificationHandler<AppRegistrationChangedNotification>
@@ -1077,6 +1078,12 @@ namespace Odin.Services.Membership.Connections
             await this.GrantCircleAsync(SystemCircleConstants.ConfirmedConnectionsCircleId, odinId, odinContext);
 
             tx.Commit();
+
+            // Peer contexts are cached for an hour keyed on the caller's token, and only the
+            // finalized/blocked/deleted notifications reset that cache. Without this the confirmation
+            // is invisible to the identity that was just confirmed -- their calls keep running under the
+            // auto-connected circle (no AllowIntroductions) long after the owner acted.
+            await odinContextCache.ResetAsync();
         }
 
         public async Task<bool> ClearVerificationHashAsync(OdinId odinId, IOdinContext odinContext)

--- a/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
+++ b/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
@@ -27,6 +29,7 @@ using Odin.Services.Configuration.VersionUpgrade;
 using Odin.Services.Drives;
 using Odin.Services.Drives.Management;
 using Odin.Services.EncryptionKeyService;
+using Odin.Services.Membership.Circles;
 using Odin.Services.Peer;
 using Odin.Services.Peer.Outgoing.Drive;
 using Odin.Services.Peer.Outgoing.Drive.Transfer.Outbox;
@@ -223,12 +226,80 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         var allowsIntroductions = odinContext.PermissionsContext != null
                                   && odinContext.PermissionsContext.HasPermission(PermissionKeys.AllowIntroductions);
 
+        // AllowIntroductions is granted only by the Confirmed Connections circle, so on its own a false
+        // conflates "I revoked you", "I never confirmed you", and "I don't know you at all". Report the
+        // connection and confirmation state alongside it so the caller can tell those apart.
+        var isCallerConnected = odinContext.Caller.IsConnected;
+
+        var callerCircles = odinContext.Caller.Circles;
+        var isCallerConfirmed = isCallerConnected &&
+                                (callerCircles?.Any(c => c == SystemCircleConstants.ConfirmedConnectionsCircleId) ?? false);
+
+        // Needed to tell "never confirmed" from "confirmed and then revoked": both leave the caller out of
+        // Confirmed Connections, but only the former is still in Auto-connected.
+        var isCallerAutoConnected = isCallerConnected &&
+                                    (callerCircles?.Any(c => c == SystemCircleConstants.AutoConnectionsCircleId) ?? false);
+
+        var connectionState = isCallerConnected
+            ? PeerCallerConnectionState.Connected
+            : await ResolveCallerConnectionStateAsync(odinContext);
+
         return new PeerIntroductionPreflightResponse
         {
             IsConfigured = isConfigured,
             RequiresUpgrade = requiresUpgrade,
             AllowsIntroductions = allowsIntroductions,
+            IsCallerConnected = isCallerConnected,
+            IsCallerConfirmed = isCallerConfirmed,
+            IsCallerAutoConnected = isCallerAutoConnected,
+            CallerConnectionState = connectionState,
         };
+    }
+
+    /// <summary>
+    /// Works out why this request did not resolve a connected context. OdinContextMiddleware swallows the
+    /// distinction -- it catches the remote-ICR security exception, sets the RemoteServerIcrIssue header
+    /// and falls back to the public transit context -- so re-read the caller's ICR to recover it.
+    /// </summary>
+    private async Task<PeerCallerConnectionState> ResolveCallerConnectionStateAsync(IOdinContext odinContext)
+    {
+        var caller = odinContext.Caller.OdinId;
+        if (!caller.HasValue)
+        {
+            return PeerCallerConnectionState.Unknown;
+        }
+
+        try
+        {
+            // Same shape as VerifyConnection's caller lookup: overrideHack because this is a peer context
+            // (the caller is the remote identity, not our owner) and tryUpgradeEncryption because the
+            // upgrade path needs our own ICR key, which is not in scope here.
+            var icr = await CircleNetworkService.GetIcrAsync(caller.Value, odinContext,
+                overrideHack: true, tryUpgradeEncryption: false);
+
+            if (icr == null)
+            {
+                return PeerCallerConnectionState.NotRecognized;
+            }
+
+            // A connected ICR whose key store is unusable is a repairable fault, not a decision. Note the
+            // deliberate merge on the other branch: blocked callers land in NotRecognized along with
+            // unknown ones, so that preflight cannot be used to detect a block.
+            if (icr.IsConnected())
+            {
+                return (icr.PeerKeyStore?.IsValid() ?? false)
+                    ? PeerCallerConnectionState.Connected
+                    : PeerCallerConnectionState.NeedsRepair;
+            }
+
+            return PeerCallerConnectionState.NotRecognized;
+        }
+        catch (Exception ex)
+        {
+            // A partially-initialized server can fail this lookup; report no signal rather than guessing.
+            _logger.LogDebug(ex, "PreflightIncomingIntroductionAsync: could not resolve caller connection state");
+            return PeerCallerConnectionState.Unknown;
+        }
     }
 
     /// <summary>
@@ -244,6 +315,8 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         odinContext.PermissionsContext.AssertHasPermission(PermissionKeys.SendIntroductions);
         OdinValidationUtils.AssertValidRecipientList(recipients, allowEmpty: false);
 
+        // Note: our own identity is dropped silently, so the result can contain fewer entries than were
+        // requested. Callers must match results by recipient rather than by position or count.
         var targets = recipients.ToOdinIdList().Without(odinContext.Tenant);
 
         var probeTasks = targets.Select(r => ProbeRecipientAsync(r, odinContext, cancellationToken)).ToList();
@@ -270,7 +343,22 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             // probes contend on the same ScopedConnectionFactory and trip its parallelism guard.
             await using var childScope = _lifetimeScope.BeginLifetimeScope($"ProbeRecipient:{Guid.NewGuid()}");
 
-            var clientAuthToken = await ResolveClientAccessTokenScopedAsync(childScope, recipient, odinContext);
+            ClientAccessToken clientAuthToken;
+            try
+            {
+                clientAuthToken = await ResolveClientAccessTokenScopedAsync(childScope, recipient, odinContext);
+            }
+            catch (Exception ex)
+            {
+                // We hold an ICR but cannot turn it into a usable token (e.g. the stored CAT will not
+                // decrypt under the current ICR key). That is our fault, not the recipient's, and it used
+                // to land in the outer catch as UnknownError with a raw exception string.
+                _logger.LogDebug(ex, "Preflight probe to {recipient}: local ICR did not yield a client access token", recipient);
+                status.Status = IntroductionPreflightStatus.SenderConnectionInvalid;
+                status.Detail = $"Local connection record is present but unusable: {ex.Message}";
+                return status;
+            }
+
             if (clientAuthToken == null)
             {
                 status.Status = IntroductionPreflightStatus.NotConnected;
@@ -289,28 +377,19 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             }
             catch (TaskCanceledException)
             {
-                status.Status = IntroductionPreflightStatus.Unreachable;
+                status.Status = IntroductionPreflightStatus.RecipientTimedOut;
                 status.Detail = "Recipient did not respond";
                 return status;
             }
             catch (HttpRequestException ex)
             {
-                status.Status = IntroductionPreflightStatus.Unreachable;
-                status.Detail = ex.Message;
-                return status;
-            }
-
-            if (response.StatusCode == HttpStatusCode.Forbidden)
-            {
-                status.Status = IntroductionPreflightStatus.RecipientRejected;
-                status.Detail = "Recipient denied the preflight";
+                (status.Status, status.Detail) = ClassifyTransportFailure(ex);
                 return status;
             }
 
             if (!response.IsSuccessStatusCode || response.Content == null)
             {
-                status.Status = IntroductionPreflightStatus.Unreachable;
-                status.Detail = $"Recipient returned {(int)response.StatusCode}";
+                (status.Status, status.Detail) = ClassifyErrorResponse(response);
                 return status;
             }
 
@@ -318,6 +397,10 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             status.IsConfigured = payload.IsConfigured;
             status.RequiresUpgrade = payload.RequiresUpgrade;
             status.AllowsIntroductions = payload.AllowsIntroductions;
+            status.IsCallerConnected = payload.IsCallerConnected;
+            status.IsCallerConfirmed = payload.IsCallerConfirmed;
+            status.IsCallerAutoConnected = payload.IsCallerAutoConnected;
+            status.CallerConnectionState = payload.CallerConnectionState;
 
             if (!payload.IsConfigured)
             {
@@ -335,8 +418,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
 
             if (!payload.AllowsIntroductions)
             {
-                status.Status = IntroductionPreflightStatus.IntroductionsNotPermitted;
-                status.Detail = "Recipient has not granted AllowIntroductions to this identity";
+                (status.Status, status.Detail) = ClassifyMissingPermission(payload);
                 return status;
             }
 
@@ -350,6 +432,138 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             status.Detail = ex.Message;
             return status;
         }
+    }
+
+    /// <summary>
+    /// Explains a <c>AllowsIntroductions == false</c>. The permission is granted only by the Confirmed
+    /// Connections circle, so on its own the flag says nothing about why -- the connection and confirmation
+    /// state the recipient reports alongside it is what separates a pending confirmation from a broken
+    /// connection from a deliberate revocation.
+    /// </summary>
+    private static (IntroductionPreflightStatus status, string detail) ClassifyMissingPermission(
+        PeerIntroductionPreflightResponse payload)
+    {
+        if (payload.CallerConnectionState == PeerCallerConnectionState.NeedsRepair)
+        {
+            return (IntroductionPreflightStatus.RecipientConnectionNeedsRepair,
+                "Recipient has a connection record for this identity but it is not usable");
+        }
+
+        if (payload.CallerConnectionState == PeerCallerConnectionState.NotRecognized)
+        {
+            return (IntroductionPreflightStatus.RecipientDoesNotRecognizeConnection,
+                "Recipient has no usable connection record for this identity");
+        }
+
+        if (payload.IsCallerConnected)
+        {
+            // Only an auto-connection that is still in the Auto-connected circle is genuinely "awaiting
+            // confirmation". A connection that is in neither system circle was confirmed and then had the
+            // circle taken away, which is a decision and belongs under IntroductionsNotPermitted.
+            if (payload.IsCallerAutoConnected && !payload.IsCallerConfirmed)
+            {
+                return (IntroductionPreflightStatus.RecipientConnectionNotConfirmed,
+                    "Recipient has not confirmed the connection, so it carries no AllowIntroductions");
+            }
+
+            return (IntroductionPreflightStatus.IntroductionsNotPermitted,
+                "Recipient is connected but has not granted AllowIntroductions to this identity");
+        }
+
+        // CallerConnectionState is Unknown and the recipient did not report being connected: either an
+        // older build that predates these fields, or one that could not determine its own state. We cannot
+        // tell the cases apart, so fall back to the pre-existing (over-broad) status rather than guess.
+        return (IntroductionPreflightStatus.IntroductionsNotPermitted,
+            "Recipient did not grant AllowIntroductions and did not report a connection state");
+    }
+
+    /// <summary>
+    /// Maps a non-success preflight response. Peers signal several distinguishable conditions that were
+    /// previously collapsed into <see cref="IntroductionPreflightStatus.Unreachable"/>.
+    /// </summary>
+    private static (IntroductionPreflightStatus status, string detail) ClassifyErrorResponse(
+        ApiResponse<PeerIntroductionPreflightResponse> response)
+    {
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return (IntroductionPreflightStatus.PreflightNotSupported,
+                "Recipient does not implement the introduction preflight endpoint");
+        }
+
+        if (response.StatusCode == HttpStatusCode.ServiceUnavailable &&
+            response.Headers.IsTrue(OdinHeaderNames.UpgradeIsRunning))
+        {
+            return (IntroductionPreflightStatus.RecipientUpgradeInProgress,
+                "Recipient identity server is running a version upgrade");
+        }
+
+        // A recipient that has never completed setup also sets the ICR-issue header on its way to this
+        // error (it cannot build a transit context either), so check the error code first: "finish your
+        // setup" is the actionable one, and it is a strictly narrower condition.
+        if (response.Error != null && response.Error.TryParseProblemDetails(out var errorCode))
+        {
+            if (errorCode is OdinClientErrorCode.NotInitialized or OdinClientErrorCode.RecipientIdentityNotConfigured)
+            {
+                return (IntroductionPreflightStatus.RecipientNotConfigured,
+                    "Recipient identity server has not completed initial setup");
+            }
+        }
+
+        if (response.Headers.IsTrue(HttpHeaderConstants.RemoteServerIcrIssue))
+        {
+            return (IntroductionPreflightStatus.RecipientDoesNotRecognizeConnection,
+                "Recipient could not resolve a connection record for this identity");
+        }
+
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            return (IntroductionPreflightStatus.RecipientRejected, "Recipient denied the preflight");
+        }
+
+        return (IntroductionPreflightStatus.Unreachable, $"Recipient returned {(int)response.StatusCode}");
+    }
+
+    /// <summary>
+    /// Separates the transport failures that used to arrive as a single <c>Unreachable</c> plus a raw
+    /// exception message. A dead domain, an expired certificate and a briefly-down server call for
+    /// completely different responses from the user.
+    /// </summary>
+    private static (IntroductionPreflightStatus status, string detail) ClassifyTransportFailure(HttpRequestException ex)
+    {
+        switch (ex.HttpRequestError)
+        {
+            case HttpRequestError.NameResolutionError:
+                return (IntroductionPreflightStatus.RecipientUnresolvable, "Recipient domain could not be resolved");
+            case HttpRequestError.SecureConnectionError:
+                return (IntroductionPreflightStatus.RecipientCertificateInvalid, "TLS handshake with recipient failed");
+        }
+
+        // HttpRequestError is not always populated (it depends on the handler), so fall back to walking the
+        // inner exception chain for the same signals.
+        for (var inner = ex.InnerException; inner != null; inner = inner.InnerException)
+        {
+            if (inner is AuthenticationException)
+            {
+                return (IntroductionPreflightStatus.RecipientCertificateInvalid, "TLS handshake with recipient failed");
+            }
+
+            if (inner is SocketException socketException)
+            {
+                switch (socketException.SocketErrorCode)
+                {
+                    case SocketError.HostNotFound:
+                    case SocketError.NoData:
+                    case SocketError.TryAgain:
+                        return (IntroductionPreflightStatus.RecipientUnresolvable, "Recipient domain could not be resolved");
+                    case SocketError.ConnectionRefused:
+                        return (IntroductionPreflightStatus.RecipientConnectionRefused, "Recipient refused the connection");
+                    case SocketError.TimedOut:
+                        return (IntroductionPreflightStatus.RecipientTimedOut, "Recipient did not respond");
+                }
+            }
+        }
+
+        return (IntroductionPreflightStatus.Unreachable, ex.Message);
     }
 
     /// <summary>

--- a/src/services/Odin.Services/Membership/Connections/Requests/IntroductionPreflightResult.cs
+++ b/src/services/Odin.Services/Membership/Connections/Requests/IntroductionPreflightResult.cs
@@ -17,13 +17,13 @@ public enum IntroductionPreflightStatus
     RecipientNotConfigured = 3,
 
     /// <summary>
-    /// The recipient identity server requires a version upgrade.
+    /// The recipient identity server requires a version upgrade which is not yet running.
     /// </summary>
     RecipientRequiresUpgrade = 4,
 
     /// <summary>
-    /// The recipient has not granted us the AllowIntroductions permission, so an
-    /// introduction would be rejected at the recipient.
+    /// The recipient is connected to us and has confirmed the connection, but has deliberately not
+    /// granted AllowIntroductions. This is the only status that describes a decision by the recipient.
     /// </summary>
     IntroductionsNotPermitted = 5,
 
@@ -33,14 +33,121 @@ public enum IntroductionPreflightStatus
     RecipientRejected = 6,
 
     /// <summary>
-    /// The recipient could not be reached (transport / DNS / socket failure or timeout).
+    /// The recipient could not be reached and the transport failure could not be classified further.
     /// </summary>
     Unreachable = 7,
+
+    /// <summary>
+    /// The recipient is connected to us, but only as an auto-connection (introduction- or app-originated)
+    /// that their owner has not confirmed. Nothing is broken and nothing was denied: confirming requires
+    /// the recipient owner's master key, so the connection sits in the Auto-connected circle -- which
+    /// carries no AllowIntroductions -- until they act.
+    /// </summary>
+    RecipientConnectionNotConfirmed = 8,
+
+    /// <summary>
+    /// The recipient has no usable connection record for us, so our ICR is one-sided. Deliberately also
+    /// covers the case where the recipient has blocked us: reporting that separately would disclose the
+    /// block to its target.
+    /// </summary>
+    RecipientDoesNotRecognizeConnection = 9,
+
+    /// <summary>
+    /// The recipient has a connection record for us but its peer key store is invalid, so their server
+    /// could not build a connected context for the call. Repairable.
+    /// </summary>
+    RecipientConnectionNeedsRepair = 10,
+
+    /// <summary>
+    /// Our own ICR with the recipient exists but could not produce a usable client access token. The
+    /// fault is on our side.
+    /// </summary>
+    SenderConnectionInvalid = 11,
+
+    /// <summary>
+    /// The recipient runs a build that predates the preflight endpoint, so nothing can be determined
+    /// about whether an introduction would succeed.
+    /// </summary>
+    PreflightNotSupported = 12,
+
+    /// <summary>
+    /// The recipient is currently running a version upgrade. Transient; distinct from
+    /// <see cref="RecipientRequiresUpgrade"/>, which means an upgrade is needed and is not running.
+    /// </summary>
+    RecipientUpgradeInProgress = 13,
+
+    /// <summary>
+    /// The recipient's domain could not be resolved.
+    /// </summary>
+    RecipientUnresolvable = 14,
+
+    /// <summary>
+    /// The TLS handshake with the recipient failed (expired/invalid certificate or similar).
+    /// </summary>
+    RecipientCertificateInvalid = 15,
+
+    /// <summary>
+    /// The recipient did not respond within the timeout.
+    /// </summary>
+    RecipientTimedOut = 16,
+
+    /// <summary>
+    /// The recipient's host resolved but refused the connection.
+    /// </summary>
+    RecipientConnectionRefused = 17,
 
     /// <summary>
     /// An unexpected error occurred. See <see cref="RecipientPreflightStatus.Detail"/>.
     /// </summary>
     UnknownError = 99,
+}
+
+/// <summary>
+/// What the recipient's server was able to determine about the calling identity's connection to it.
+/// Reported alongside <see cref="PeerIntroductionPreflightResponse.AllowsIntroductions"/> so the caller
+/// can tell "you were never confirmed" and "I don't know you" apart from "I decided no".
+/// </summary>
+public enum PeerCallerConnectionState
+{
+    /// <summary>
+    /// The recipient did not report a connection state -- either it runs a build that predates this
+    /// field, or it could not determine one. Callers must not infer anything from this value.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The request resolved a valid, connected ICR on the recipient's side.
+    /// </summary>
+    Connected = 1,
+
+    /// <summary>
+    /// The recipient has no usable connection record for the caller. Deliberately merges "no ICR at all",
+    /// "ICR not in a connected state", and "caller is blocked" -- see the privacy note on
+    /// <see cref="IntroductionPreflightStatus.RecipientDoesNotRecognizeConnection"/>.
+    /// </summary>
+    NotRecognized = 2,
+
+    /// <summary>
+    /// A connection record exists but its peer key store is invalid, so a connected context could not be
+    /// built for this request. Repairable, and may self-heal on the next key store upgrade.
+    /// </summary>
+    NeedsRepair = 3,
+}
+
+/// <summary>
+/// Who, if anyone, is able to act on a given <see cref="IntroductionPreflightStatus"/>. Lets a client
+/// route statuses generically instead of hard-coding a branch per status.
+/// </summary>
+public enum PreflightRemedyActor
+{
+    /// <summary>No one can act; the condition either clears on its own or cannot be determined.</summary>
+    None = 0,
+
+    /// <summary>The calling identity (or its owner) can act -- e.g. repair or re-establish the connection.</summary>
+    Caller = 1,
+
+    /// <summary>The recipient must act -- e.g. confirm the connection or finish setting up their identity.</summary>
+    Recipient = 2,
 }
 
 public class RecipientPreflightStatus
@@ -49,17 +156,109 @@ public class RecipientPreflightStatus
     public IntroductionPreflightStatus Status { get; set; }
 
     /// <summary>
-    /// Optional diagnostic string; populated for non-Ready outcomes.
+    /// Diagnostic string for logs and support; populated for non-Ready outcomes. It may contain raw
+    /// transport or exception text and is <b>not</b> user-facing copy -- clients must render text based
+    /// on <see cref="Status"/>, never on this field.
     /// </summary>
     public string Detail { get; set; }
 
     public bool IsConfigured { get; set; }
     public bool RequiresUpgrade { get; set; }
+
+    /// <summary>
+    /// Whether the recipient granted AllowIntroductions to us. A <c>false</c> here is not on its own a
+    /// statement about the recipient's intent -- read <see cref="Status"/> instead.
+    /// </summary>
     public bool AllowsIntroductions { get; set; }
+
+    /// <summary>
+    /// Whether the recipient resolved a connected context for our call (as opposed to falling back to
+    /// its anonymous/authenticated context).
+    /// </summary>
+    public bool IsCallerConnected { get; set; }
+
+    /// <summary>
+    /// Whether the recipient has us in its Confirmed Connections circle.
+    /// </summary>
+    public bool IsCallerConfirmed { get; set; }
+
+    /// <summary>
+    /// Whether the recipient has us in its Auto-connected circle. Read with <see cref="IsCallerConfirmed"/>
+    /// this separates "never confirmed" (auto-connected, awaiting the recipient owner) from "confirmed and
+    /// then revoked" (in neither system circle) -- both of which leave AllowIntroductions false.
+    /// </summary>
+    public bool IsCallerAutoConnected { get; set; }
+
+    /// <summary>
+    /// The recipient's view of our connection to it. <see cref="PeerCallerConnectionState.Unknown"/>
+    /// when the recipient did not report one.
+    /// </summary>
+    public PeerCallerConnectionState CallerConnectionState { get; set; }
+
+    /// <summary>
+    /// Who can act on <see cref="Status"/>. Derived; not sent by the recipient.
+    /// </summary>
+    public PreflightRemedyActor RemedyActor => IntroductionPreflightStatusInfo.GetRemedyActor(Status);
+
+    /// <summary>
+    /// Whether <see cref="Status"/> is expected to clear on its own, making a retry worthwhile.
+    /// Derived; not sent by the recipient.
+    /// </summary>
+    public bool IsTransient => IntroductionPreflightStatusInfo.IsTransient(Status);
+}
+
+/// <summary>
+/// Classification of <see cref="IntroductionPreflightStatus"/> values so clients can decide how to
+/// present a status without hard-coding a branch for each one.
+/// </summary>
+public static class IntroductionPreflightStatusInfo
+{
+    public static PreflightRemedyActor GetRemedyActor(IntroductionPreflightStatus status)
+    {
+        switch (status)
+        {
+            case IntroductionPreflightStatus.NotConnected:
+            case IntroductionPreflightStatus.SenderConnectionInvalid:
+            case IntroductionPreflightStatus.RecipientDoesNotRecognizeConnection:
+            case IntroductionPreflightStatus.RecipientConnectionNeedsRepair:
+                return PreflightRemedyActor.Caller;
+
+            case IntroductionPreflightStatus.RecipientNotConfigured:
+            case IntroductionPreflightStatus.RecipientRequiresUpgrade:
+            case IntroductionPreflightStatus.IntroductionsNotPermitted:
+            case IntroductionPreflightStatus.RecipientRejected:
+            case IntroductionPreflightStatus.RecipientConnectionNotConfirmed:
+            case IntroductionPreflightStatus.RecipientCertificateInvalid:
+            case IntroductionPreflightStatus.RecipientUnresolvable:
+                return PreflightRemedyActor.Recipient;
+
+            default:
+                return PreflightRemedyActor.None;
+        }
+    }
+
+    public static bool IsTransient(IntroductionPreflightStatus status)
+    {
+        switch (status)
+        {
+            case IntroductionPreflightStatus.Unreachable:
+            case IntroductionPreflightStatus.RecipientUpgradeInProgress:
+            case IntroductionPreflightStatus.RecipientTimedOut:
+            case IntroductionPreflightStatus.RecipientConnectionRefused:
+                return true;
+
+            default:
+                return false;
+        }
+    }
 }
 
 public class IntroductionPreflightResult
 {
+    /// <summary>
+    /// Per-recipient results. Note that the caller's own identity is filtered out of the request, so
+    /// this list can be shorter than the list of recipients that was submitted.
+    /// </summary>
     public List<RecipientPreflightStatus> Recipients { get; set; } = new();
 }
 
@@ -70,5 +269,36 @@ public class PeerIntroductionPreflightResponse
 {
     public bool IsConfigured { get; set; }
     public bool RequiresUpgrade { get; set; }
+
+    /// <summary>
+    /// Whether the caller holds AllowIntroductions in this request's permission context. Only meaningful
+    /// together with <see cref="IsCallerConnected"/> and <see cref="IsCallerConfirmed"/>: the permission
+    /// is granted solely by the Confirmed Connections circle, so it is also false for an unconfirmed
+    /// auto-connection and for a caller we do not recognize at all.
+    /// </summary>
     public bool AllowsIntroductions { get; set; }
+
+    /// <summary>
+    /// Whether this request resolved a connected context for the caller, rather than falling back to the
+    /// authenticated-but-unconnected context.
+    /// </summary>
+    public bool IsCallerConnected { get; set; }
+
+    /// <summary>
+    /// Whether the caller is in our Confirmed Connections circle.
+    /// </summary>
+    public bool IsCallerConfirmed { get; set; }
+
+    /// <summary>
+    /// Whether the caller is in our Auto-connected circle. Together with <see cref="IsCallerConfirmed"/>
+    /// this tells an unconfirmed auto-connection apart from a connection that was confirmed and then had
+    /// the circle revoked: the former is in Auto-connected, the latter is in neither.
+    /// </summary>
+    public bool IsCallerAutoConnected { get; set; }
+
+    /// <summary>
+    /// Our view of the caller's connection to us. Absent (<see cref="PeerCallerConnectionState.Unknown"/>)
+    /// on servers that predate this field.
+    /// </summary>
+    public PeerCallerConnectionState CallerConnectionState { get; set; }
 }

--- a/src/services/Odin.Services/Util/HttpExtensions.cs
+++ b/src/services/Odin.Services/Util/HttpExtensions.cs
@@ -24,4 +24,33 @@ public static class HttpExtensions
         var code = Enum.Parse<OdinClientErrorCode>(codeText!, true);
         return code;
     }
+
+    /// <summary>
+    /// Best-effort version of <see cref="ParseProblemDetails"/> for cases where the response might not be
+    /// problem-details at all (a proxy error page, an older peer, an empty body).
+    /// </summary>
+    public static bool TryParseProblemDetails(this ApiException apiException, out OdinClientErrorCode code)
+    {
+        code = OdinClientErrorCode.NoErrorCode;
+
+        if (string.IsNullOrWhiteSpace(apiException?.Content))
+        {
+            return false;
+        }
+
+        try
+        {
+            var pd = OdinSystemSerializer.Deserialize<ProblemDetails>(apiException.Content);
+            if (pd?.Extensions == null || !pd.Extensions.TryGetValue("errorCode", out var raw))
+            {
+                return false;
+            }
+
+            return Enum.TryParse(raw?.ToString(), true, out code);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
 }

--- a/tests/apps/Odin.Hosting.Tests.V2/Api/ConnectionsHandle.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Api/ConnectionsHandle.cs
@@ -86,6 +86,9 @@ public sealed class ConnectionsHandle
     public Task<ApiResponse<RedactedIdentityConnectionRegistration>> GetConnectionInfo(OdinId recipient)
         => _network.GetConnectionInfo(recipient);
 
+    /// <summary>Upgrades an auto-connection to a confirmed connection (owner/master-key only).</summary>
+    public Task<ApiResponse<IcrVerificationResult>> ConfirmConnection(OdinId odinId) => _network.ConfirmConnection(odinId);
+
     public Task<ApiResponse<HttpContent>> BlockConnection(OdinId odinId) => _network.BlockConnection(odinId);
     public Task<ApiResponse<HttpContent>> UnblockConnection(OdinId odinId) => _network.UnblockConnection(odinId);
     public Task<ApiResponse<HttpContent>> RevokeCircle(Guid circleId, OdinId odinId) => _network.RevokeCircle(circleId, odinId);

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/PreflightIntroductionsTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Connections/PreflightIntroductionsTests.cs
@@ -61,6 +61,114 @@ public class PreflightIntroductionsTests : V2Fixture
         Assert.That(samStatus.IsConfigured, Is.True);
         Assert.That(samStatus.RequiresUpgrade, Is.False);
         Assert.That(samStatus.AllowsIntroductions, Is.True);
+        Assert.That(samStatus.IsCallerConnected, Is.True);
+        Assert.That(samStatus.IsCallerConfirmed, Is.True);
+        Assert.That(samStatus.CallerConnectionState, Is.EqualTo(PeerCallerConnectionState.Connected));
+    }
+
+    /// <summary>
+    /// The headline case behind the "thomas does not allow introductions from you" report: an
+    /// auto-connection that the recipient's owner has never confirmed. Both sides are healthy and the
+    /// recipient decided nothing — AllowIntroductions is simply not carried by the Auto-connected circle,
+    /// and confirming requires the recipient owner's master key. This must not report as
+    /// <see cref="IntroductionPreflightStatus.IntroductionsNotPermitted"/>.
+    /// </summary>
+    [Test]
+    public async Task Preflight_WhenRecipientAutoConnectedButNotConfirmed_ReturnsRecipientConnectionNotConfirmed()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        await AutoConnectAsync(frodo, sam);
+
+        var response = await frodo.Connections.PreflightIntroductionsAsync(new IntroductionGroup
+        {
+            Message = "preflight",
+            Recipients = [sam.Identity]
+        });
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        AssertStatus(response.Content!, sam.Identity, IntroductionPreflightStatus.RecipientConnectionNotConfirmed);
+
+        var samStatus = response.Content!.Recipients.Single(r => r.Recipient == sam.Identity.DomainName);
+        Assert.That(samStatus.IsConfigured, Is.True);
+        Assert.That(samStatus.AllowsIntroductions, Is.False, "auto-connected circle carries no AllowIntroductions");
+        Assert.That(samStatus.IsCallerConnected, Is.True, "the connection is healthy on both sides");
+        Assert.That(samStatus.IsCallerConfirmed, Is.False);
+        Assert.That(samStatus.CallerConnectionState, Is.EqualTo(PeerCallerConnectionState.Connected));
+        Assert.That(samStatus.RemedyActor, Is.EqualTo(PreflightRemedyActor.Recipient));
+        Assert.That(samStatus.IsTransient, Is.False);
+    }
+
+    [Test]
+    public async Task Preflight_WhenRecipientConfirmsAutoConnection_FlipsToReady()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        await AutoConnectAsync(frodo, sam);
+
+        var before = await frodo.Connections.PreflightIntroductionsAsync(new IntroductionGroup
+        {
+            Message = "preflight",
+            Recipients = [sam.Identity]
+        });
+        AssertStatus(before.Content!, sam.Identity, IntroductionPreflightStatus.RecipientConnectionNotConfirmed);
+
+        var confirm = await sam.Connections.ConfirmConnection(frodo.Identity);
+        Assert.That(confirm.IsSuccessStatusCode, Is.True, $"confirm failed: {confirm.StatusCode}");
+
+        var after = await frodo.Connections.PreflightIntroductionsAsync(new IntroductionGroup
+        {
+            Message = "preflight",
+            Recipients = [sam.Identity]
+        });
+
+        Assert.That(after.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        AssertStatus(after.Content!, sam.Identity, IntroductionPreflightStatus.Ready);
+
+        var samStatus = after.Content!.Recipients.Single(r => r.Recipient == sam.Identity.DomainName);
+        Assert.That(samStatus.IsCallerConfirmed, Is.True);
+        Assert.That(samStatus.AllowsIntroductions, Is.True);
+    }
+
+    /// <summary>
+    /// One-sided ICR: the sender still holds a connected record but the recipient has no usable one, so
+    /// the recipient's server falls back to its authenticated-but-unconnected context. Blocking is used to
+    /// produce that state, which doubles as a check that a block is <b>not</b> disclosed to its target —
+    /// it is deliberately reported as the generic "does not recognize the connection".
+    /// </summary>
+    [Test]
+    public async Task Preflight_WhenRecipientDoesNotRecognizeConnection_DoesNotReportAsNotPermitted()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        await ConnectAsync(frodo, sam);
+
+        var block = await sam.Connections.BlockConnection(frodo.Identity);
+        Assert.That(block.IsSuccessStatusCode, Is.True, $"block failed: {block.StatusCode}");
+
+        // Frodo's side is untouched, so he still believes he is connected.
+        var frodoIcr = await frodo.Connections.GetConnectionInfo(sam.Identity);
+        Assert.That(frodoIcr.Content!.Status, Is.EqualTo(ConnectionStatus.Connected));
+
+        var response = await frodo.Connections.PreflightIntroductionsAsync(new IntroductionGroup
+        {
+            Message = "preflight",
+            Recipients = [sam.Identity]
+        });
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var samStatus = response.Content!.Recipients.Single(r => r.Recipient == sam.Identity.DomainName);
+        Assert.That(samStatus.Status, Is.EqualTo(IntroductionPreflightStatus.RecipientDoesNotRecognizeConnection),
+            $"detail={samStatus.Detail}");
+        Assert.That(samStatus.IsCallerConnected, Is.False);
+        Assert.That(samStatus.IsCallerConfirmed, Is.False);
+        Assert.That(samStatus.CallerConnectionState, Is.EqualTo(PeerCallerConnectionState.NotRecognized),
+            "blocked must be indistinguishable from unknown");
+        Assert.That(samStatus.RemedyActor, Is.EqualTo(PreflightRemedyActor.Caller));
     }
 
     [Test]
@@ -116,6 +224,11 @@ public class PreflightIntroductionsTests : V2Fixture
         var samStatus = response.Content!.Recipients.Single(r => r.Recipient == sam.Identity.DomainName);
         Assert.That(samStatus.IsConfigured, Is.True);
         Assert.That(samStatus.AllowsIntroductions, Is.False);
+
+        // The control case for RecipientConnectionNotConfirmed: Sam confirmed Frodo and then took the
+        // permission away, so IntroductionsNotPermitted is describing an actual decision here.
+        Assert.That(samStatus.IsCallerConnected, Is.True);
+        Assert.That(samStatus.CallerConnectionState, Is.EqualTo(PeerCallerConnectionState.Connected));
     }
 
     [Test]
@@ -198,6 +311,31 @@ public class PreflightIntroductionsTests : V2Fixture
     // -----------------------------------------------------------------------------------------
     // helpers
     // -----------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Establishes an auto-connection: <c>auto-connect</c> sends with
+    /// <see cref="ConnectionRequestOrigin.IdentityOwnerApp"/>, so the recipient grants the Auto-connected
+    /// circle rather than Confirmed Connections. Nothing upgrades that automatically -- only the recipient
+    /// owner's confirm, which needs the master key.
+    /// </summary>
+    private static async Task AutoConnectAsync(OwnerSession sender, OwnerSession recipient)
+    {
+        var response = await sender.Connections.AutoConnectAsync(new ConnectionRequestHeader
+        {
+            Id = Guid.NewGuid(),
+            Recipient = recipient.Identity,
+            Message = "auto",
+            ContactData = new ContactRequestData(),
+            CircleIds = []
+        });
+
+        Assert.That(response.IsSuccessStatusCode, Is.True, $"auto-connect to {recipient.Identity} failed: {response.StatusCode}");
+        Assert.That(response.Content!.Outcome, Is.EqualTo(AutoConnectOutcome.Connected),
+            $"auto-connect outcome: {response.Content.Outcome} / {response.Content.Detail}");
+
+        var icr = await sender.Connections.GetConnectionInfo(recipient.Identity);
+        Assert.That(icr.Content!.Status, Is.EqualTo(ConnectionStatus.Connected));
+    }
 
     private static async Task ConnectAsync(OwnerSession introducer, OwnerSession recipient)
     {


### PR DESCRIPTION
Fixes the "thomas does not allow introductions from you" report in #1613.

`AllowsIntroductions == false` was rendered as a decision by the recipient regardless of cause. The permission is granted only by the Confirmed Connections circle; the Auto-connected circle carries no permission keys, and upgrading needs the recipient owner's master key. So an ordinary unconfirmed auto-connection — healthy on both sides, with nothing decided — produced the same message as a deliberate revocation.

## What changed

**Connection state on the wire.** `PeerIntroductionPreflightResponse` now carries `IsCallerConnected`, `IsCallerConfirmed`, `IsCallerAutoConnected` and `CallerConnectionState`. The first three come from `Caller.IsConnected` / `Caller.Circles`; when the request fell back to the anonymous context there are no circles to read, so the recipient re-reads the caller's ICR to recover what `OdinContextMiddleware` discards, using the same `overrideHack: true, tryUpgradeEncryption: false` shape `VerifyConnection` already uses for a peer-context caller lookup.

`IsCallerAutoConnected` is load-bearing and was not in the original plan: revoking Confirmed Connections and never having been confirmed both leave the caller outside that circle, so `IsCallerConfirmed` alone cannot separate them. Auto-connected membership can. The existing revoke test is what surfaced this.

**Ten new statuses**, led by `RecipientConnectionNotConfirmed`, with `IntroductionsNotPermitted` narrowed to genuine revocation and `Unreachable` split into DNS / TLS / refused / timeout. Each status is tagged with `RemedyActor` and `IsTransient` so clients can route generically instead of branching per status.

**Signals the peer already sent but we ignored** are now mapped: the `RemoteServerIcrIssue` header, problem-details `errorCode`, 404, and 503 + `UpgradeIsRunning`. The error code is checked before the ICR header, because a never-provisioned recipient sets both and "finish your setup" is the narrower, actionable one. A local token failure now reports `SenderConnectionInvalid` instead of `UnknownError` plus a raw exception string.

**Bug fix: `ConfirmConnectionAsync` did not invalidate the peer context cache.** Contexts are cached for 60 minutes keyed on the caller's token, and only the finalized/blocked/deleted notifications reset that cache — confirm publishes none of them. So a confirmation was invisible to the identity just confirmed; their calls kept running under the Auto-connected circle, without `AllowIntroductions`, long after the owner acted. In the reported scenario Thomas confirms and introductions keep failing for up to an hour with no indication why. Found by the confirm-flips-to-Ready test, which failed for this reason rather than anything to do with the status enum.

## Compatibility

An older recipient omits the new fields, so `CallerConnectionState` deserializes as `Unknown`. The classifier then falls back to the pre-existing `IntroductionsNotPermitted` rather than inferring a state from a `false` that may just be an absent field.

`Detail` is now documented as diagnostics-only. Clients must map **status → copy**; it reads like a sentence today and is easy to render directly by mistake.

## Testing

Build clean. 408 tests in `Odin.Hosting.Tests.V2` and 127 connection/circle tests in `Odin.Hosting.Tests` pass.

New coverage in `PreflightIntroductionsTests`: auto-connected-but-unconfirmed → `RecipientConnectionNotConfirmed`; confirm flips preflight to `Ready`; recipient does not recognize the connection → `RecipientDoesNotRecognizeConnection`, via block, which doubles as an assertion that a block is indistinguishable from an unknown caller.

Not covered, and deliberately not faked: a genuinely never-provisioned identity (`V2Fixture` provisions every host identity), and 404/503 peer responses (no mock peer in this harness — that mapping code is written but unexercised).

## Deliberately out of scope

- **Blocked identities** fold into `NotRecognized` rather than getting a distinct status, which would disclose the block to its target. Documented on the enum and asserted in a test.
- **The same cache staleness on plain `GrantCircleAsync` / `RevokeCircleAsync`** is untouched — those run in loops during connection setup, where a full reset per call would be costly. Worth its own issue.
- **`ConnectionRequestOrigin.IdentityOwnerApp` still lands in Auto-connected**, so an app-only user cannot receive introductions until someone opens the owner console. This PR makes the error message accurate about that; it does not change the behavior. That is the open product decision (§D.1 in #1613) and is arguably the bigger problem.
- **Client copy** lives in odin-js. Until it maps the new statuses they fall through its default branch. Minimum: reserve "does not allow introductions from you" for `IntroductionsNotPermitted`, and give `RecipientConnectionNotConfirmed` confirmation-oriented copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
