### PR TITLE
Surface S3 error details and sweep leaked test buckets

### DIFF
--- a/src/core/Odin.Core.Storage/ObjectStorage/S3AwsStorage.cs
+++ b/src/core/Odin.Core.Storage/ObjectStorage/S3AwsStorage.cs
@@ -82,12 +82,12 @@ public class S3AwsStorage : IS3Storage
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // Log ex.Message (not ex) so this stays a single line: this is the expected outcome on
-            // providers that reject bucket-level abort rules (MinIO purges stale uploads globally;
-            // Vultr needs a manual sweep), not a failure worth a stack trace.
+            // Single line, not a stack trace: this is the expected outcome on providers that reject
+            // bucket-level abort rules (MinIO purges stale uploads globally; Vultr needs a manual sweep).
+            // Not ex.Message though -- see DescribeS3Error for why that is routinely empty here.
             _logger.LogWarning(
                 "Could not install the abort-incomplete-multipart lifecycle rule on bucket '{BucketName}': " +
-                "{Error}. Continuing (expected on MinIO/Vultr).", BucketName, ex.Message);
+                "{Error}. Continuing (expected on MinIO/Vultr).", BucketName, DescribeS3Error(ex));
         }
     }
 
@@ -663,22 +663,73 @@ public class S3AwsStorage : IS3Storage
 
     private S3StorageException CreateS3StorageException(Exception exception, string message)
     {
-        var error = exception.Message;
+        return new S3StorageException($"{message} {DescribeS3Error(exception)}", exception);
+    }
 
-        if (string.IsNullOrEmpty(error))
+    //
+
+    // Renders an S3 failure as one diagnostic line. Never log AmazonS3Exception.Message on its own: the
+    // SDK only fills it in when the provider's error XML carried an <Error><Message> element, and the
+    // Ceph-based providers (Hetzner, Vultr) routinely omit it -- which is how you end up with a log line
+    // reading "...: ." and nothing else. The identifying bits (HTTP status, S3 error code, request id,
+    // host id) live on separate properties and are populated regardless, so always emit those.
+    private static string DescribeS3Error(Exception exception)
+    {
+        var parts = new List<string>();
+
+        var error = exception.Message;
+        if (string.IsNullOrWhiteSpace(error) &&
+            exception.InnerException is not Amazon.Runtime.Internal.HttpErrorResponseException)
         {
-            // This is a freaking weird, Amazon. Wth...
-            if (exception.InnerException is Amazon.Runtime.Internal.HttpErrorResponseException httpException)
+            // Skipped for HttpErrorResponseException: it carries no message of its own, so .NET renders
+            // the "Exception of type '...' was thrown." boilerplate, which reads like information and
+            // is not. Its status code is picked up further down instead.
+            error = exception.InnerException?.Message;
+        }
+        // AmazonS3Exception.Message already appends the raw response body when the SDK could not parse
+        // the error XML at all, so it is never added a second time here, only flattened and capped --
+        // that body can be an entire HTML error page.
+        parts.Add(string.IsNullOrWhiteSpace(error) ? "(provider returned no error message)" : Truncate(error, 1024));
+
+        if (exception is AmazonServiceException ase)
+        {
+            if (ase.StatusCode != default)
             {
-                error = $": S3 HTTP status={httpException.Response.StatusCode}";
+                parts.Add($"httpStatus={(int)ase.StatusCode} {ase.StatusCode}");
             }
-            else
+            // Note: when the provider omits <Error><Code>, the SDK back-fills ErrorCode with the HTTP
+            // status name, so this can echo httpStatus rather than name a real S3 error code.
+            if (!string.IsNullOrWhiteSpace(ase.ErrorCode))
             {
-                error = exception.InnerException?.Message ?? ": Unknown error";
+                parts.Add($"errorCode={ase.ErrorCode}");
+            }
+            if (!string.IsNullOrWhiteSpace(ase.RequestId))
+            {
+                parts.Add($"requestId={ase.RequestId}");
             }
         }
 
-        return new S3StorageException($"{message} {error}", exception);
+        if (exception is AmazonS3Exception { AmazonId2: not null and not "" } s3e)
+        {
+            parts.Add($"hostId={s3e.AmazonId2}");
+        }
+        else if (exception.InnerException is Amazon.Runtime.Internal.HttpErrorResponseException httpException)
+        {
+            var status = httpException.Response.StatusCode;
+            parts.Add($"httpStatus={(int)status} {status}");
+        }
+
+        parts.Add($"exception={exception.GetType().Name}");
+
+        return string.Join(", ", parts);
+    }
+
+    //
+
+    private static string Truncate(string value, int maxLength)
+    {
+        value = value.Replace("\r", "").Replace("\n", " ").Trim();
+        return value.Length <= maxLength ? value : value[..maxLength] + "...[truncated]";
     }
 
     //

--- a/tests/core/Odin.Core.Storage.Tests/ObjectStorage/S3AwsStorageTests.cs
+++ b/tests/core/Odin.Core.Storage.Tests/ObjectStorage/S3AwsStorageTests.cs
@@ -22,6 +22,11 @@ namespace Odin.Core.Storage.Tests.ObjectStorage;
 
 public class S3AwsStorageTests
 {
+    // Every bucket these tests create carries this prefix, and S3AwsStorage_CleanUpLeakedTestBuckets
+    // deletes everything that carries it -- including buckets leaked by earlier runs. Do not point
+    // these tests at an account holding anything else named this way.
+    private const string TestBucketPrefix = "zzz-ci-test";
+
     private string _accessKey = "";
     private string _secretAccessKey = "";
     private string _bucketName = "";
@@ -36,10 +41,16 @@ public class S3AwsStorageTests
         TestSecrets.Load();
 
         var runTestAgainstHetzner = Environment.GetEnvironmentVariable("ODIN_S3_RUN_HETZNER_TESTS")?.ToLower() == "true";
+        var runTestAgainstOvh = Environment.GetEnvironmentVariable("ODIN_S3_RUN_OVH_TESTS")?.ToLower() == "true";
+        if (runTestAgainstHetzner && runTestAgainstOvh)
+        {
+            throw new Exception("Both runTestAgainstHetzner and runTestAgainstOvh cannot be true at the same time.");
+        }
+
         if (runTestAgainstHetzner)
         {
-            _accessKey = Environment.GetEnvironmentVariable("ODIN_S3_ACCESS_KEY")!;
-            _secretAccessKey = Environment.GetEnvironmentVariable("ODIN_S3_SECRET_ACCESS_KEY")!;
+            _accessKey = Environment.GetEnvironmentVariable("ODIN_S3_HETZNER_ACCESS_KEY")!;
+            _secretAccessKey = Environment.GetEnvironmentVariable("ODIN_S3_HETZNER_SECRET_ACCESS_KEY")!;
 
             _s3Client = new AmazonS3Client(
                 _accessKey,
@@ -48,6 +59,23 @@ public class S3AwsStorageTests
                 {
                     ServiceURL = "https://hel1.your-objectstorage.com",
                     AuthenticationRegion = "hel1",
+                    ForcePathStyle = false,
+                    ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED,
+                    RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED
+                });
+        }
+        else if (runTestAgainstOvh)
+        {
+            _accessKey = Environment.GetEnvironmentVariable("ODIN_S3_OVH_ACCESS_KEY")!;
+            _secretAccessKey = Environment.GetEnvironmentVariable("ODIN_S3_OVH_SECRET_ACCESS_KEY")!;
+
+            _s3Client = new AmazonS3Client(
+                _accessKey,
+                _secretAccessKey,
+                new AmazonS3Config
+                {
+                    ServiceURL = "https://s3.us-east-va.io.cloud.ovh.us",
+                    AuthenticationRegion = "us-east-va",
                     ForcePathStyle = false,
                     ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED,
                     RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED
@@ -79,7 +107,7 @@ public class S3AwsStorageTests
                 });
         }
 
-        _bucketName = $"zzz-ci-test-{Guid.NewGuid():N}";
+        _bucketName = $"{TestBucketPrefix}-{Guid.NewGuid():N}";
         await CreateBucketAndWaitUntilReadyAsync(_bucketName, waitForConsistency: runTestAgainstHetzner);
 
         _testRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -105,6 +133,127 @@ public class S3AwsStorageTests
         {
             await _minioContainer.DisposeAsync();
         }
+    }
+
+    //
+
+    // Runs after every test's TearDown has already removed that test's own bucket, so anything still
+    // carrying the prefix is genuinely leaked and safe to delete. Doing it here rather than from a test
+    // body is what keeps the two from racing: a sweep inside a test would delete the bucket that the
+    // test's own TearDown is about to delete, and TearDown would then fail on a bucket that is gone.
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        // Skipped for MinIO: its container is created and disposed per test, so a leaked bucket dies with
+        // it. The endpoint is also gone by now, so sweeping would just log a failure to list buckets.
+        if (_minioContainer == null && _s3Client != null)
+        {
+            await DeleteTestBucketsAsync();
+        }
+    }
+
+    //
+
+    // Sweeps every bucket carrying the test prefix, not just the ones this run created: a run that
+    // crashes or is killed leaks its bucket, and on a shared provider account those pile up and keep
+    // billing. Best-effort per bucket -- one that refuses to go (versioned objects, a provider hiccup)
+    // is logged and skipped rather than failing the run, and the warning is what makes it visible.
+    // Assumes runs are never concurrent against the same account: this cannot tell a leaked bucket from
+    // one another run is using right now.
+    private async Task DeleteTestBucketsAsync()
+    {
+        List<string> bucketNames;
+        try
+        {
+            // Single call, no pagination, matching BucketExistsAsync: an account holding enough test
+            // buckets to truncate this listing has a bigger problem than this sweep can fix.
+            var response = await _s3Client.ListBucketsAsync();
+            bucketNames = (response.Buckets ?? new List<S3Bucket>())
+                .Select(b => b.BucketName)
+                .Where(name => name != null && name.StartsWith(TestBucketPrefix, StringComparison.Ordinal))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Could not list buckets to clean up '{Prefix}*': {Error}", TestBucketPrefix, ex.Message);
+            return;
+        }
+
+        foreach (var bucketName in bucketNames)
+        {
+            try
+            {
+                // A bucket only deletes when it is empty, and "empty" includes incomplete multipart
+                // uploads, which ListObjectsV2 does not report. These tests upload multi-part files, so a
+                // run killed mid-upload leaves parts that block every later attempt to delete the bucket.
+                // That is very likely how such buckets leaked in the first place, so abort those first.
+                await AbortAllMultipartUploadsAsync(bucketName);
+                await DeleteAllObjectsAsync(bucketName);
+                await _s3Client.DeleteBucketAsync(new DeleteBucketRequest { BucketName = bucketName });
+
+                _logger.LogDebug("Deleted test bucket '{Bucket}'", bucketName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Could not delete test bucket '{Bucket}': {Error}. Continuing.",
+                    bucketName, ex.Message);
+            }
+        }
+    }
+
+    //
+
+    private async Task AbortAllMultipartUploadsAsync(string bucketName)
+    {
+        string keyMarker = null;
+        string uploadIdMarker = null;
+
+        do
+        {
+            var response = await _s3Client.ListMultipartUploadsAsync(new ListMultipartUploadsRequest
+            {
+                BucketName     = bucketName,
+                KeyMarker      = keyMarker,
+                UploadIdMarker = uploadIdMarker
+            });
+
+            foreach (var upload in response.MultipartUploads ?? new List<MultipartUpload>())
+            {
+                await _s3Client.AbortMultipartUploadAsync(new AbortMultipartUploadRequest
+                {
+                    BucketName = bucketName,
+                    Key        = upload.Key,
+                    UploadId   = upload.UploadId
+                });
+            }
+
+            if (response.IsTruncated != true)
+            {
+                return;
+            }
+
+            keyMarker = response.NextKeyMarker;
+            uploadIdMarker = response.NextUploadIdMarker;
+        }
+        // Guard against a provider that reports truncation without advancing the markers: without this
+        // the loop would abort the same page forever.
+        while (keyMarker != null || uploadIdMarker != null);
+    }
+
+    //
+
+    // Deliberately empty. The sweep itself lives in OneTimeTearDown, which runs after any selection of
+    // tests; this exists so you can trigger it without sitting through the whole suite:
+    //
+    //   dotnet test tests/core/Odin.Core.Storage.Tests --filter \
+    //     "FullyQualifiedName~S3AwsStorageTests.S3AwsStorage_CleanUpLeakedTestBuckets"
+    //
+    // [Explicit] keeps it out of unfiltered runs. SetUp still creates a bucket for it, as for every test,
+    // and TearDown destroys it again before the sweep looks at anything.
+    [Test, Explicit]
+    public void S3AwsStorage_CleanUpLeakedTestBuckets()
+    {
+        Assert.Pass("Run OneTimeTearDown to sweep all buckets carrying the test prefix, including any leaked by earlier runs.");
     }
 
     //
@@ -152,6 +301,12 @@ public class S3AwsStorageTests
     // MinIO is strongly consistent and skips the wait.
     private async Task CreateBucketAndWaitUntilReadyAsync(string bucketName, bool waitForConsistency)
     {
+        // Which endpoint this run is actually talking to, before anything can fail against it: the
+        // provider is picked from environment variables, so a log full of 404s is otherwise ambiguous
+        // between "the provider misbehaved" and "this ran against a different provider than you think".
+        _logger.LogDebug("Creating bucket '{Bucket}' on {ServiceUrl} (consistency wait: {Wait})",
+            bucketName, _s3Client.Config.ServiceURL, waitForConsistency);
+
         await _s3Client.PutBucketAsync(bucketName);
 
         if (!waitForConsistency)
@@ -223,7 +378,7 @@ public class S3AwsStorageTests
     [Test]
     public async Task S3AwsStorage_ItShouldCreateABucket()
     {
-        var someOtherBucketName = $"zzz-ci-test-{Guid.NewGuid():N}";
+        var someOtherBucketName = $"{TestBucketPrefix}-{Guid.NewGuid():N}";
         var bucket = new S3AwsStorage(_logger, _s3Client, someOtherBucketName);
         // CreateBucketAsync also best-effort installs the abort-incomplete-multipart lifecycle rule.
         // MinIO (the CI backend) rejects bucket-level abort rules by design (it purges stale uploads


### PR DESCRIPTION
S3 failures against Ceph-based providers logged as "...: ." and nothing else. AmazonS3Exception.Message is only populated when the provider's error XML carries an <Error><Message> element, which Hetzner and Vultr routinely omit; the identifying fields live on separate properties and are always set. DescribeS3Error now emits HTTP status, S3 error code, request id and host id, and is used by CreateS3StorageException and by the abort-incomplete-multipart warning. It replaces the previous empty-message handling, which recovered only an HTTP status and only when the inner exception happened to be HttpErrorResponseException.

Tests:
- Add OVH as a target alongside Hetzner and MinIO.
- Sweep every zzz-ci-test* bucket in OneTimeTearDown, so buckets leaked by crashed runs stop accumulating on the account. Incomplete multipart uploads are aborted first: they keep a bucket non-empty, block DeleteBucket, and are invisible to ListObjectsV2, which is the likely reason such buckets could not be deleted. Skipped for MinIO, whose container is per-test and takes any leak with it.
- Add S3AwsStorage_CleanUpLeakedTestBuckets, an explicit no-op test that exists as a filter target for triggering that sweep on its own.
- Log the endpoint and bucket name before creating a bucket, so a run's logs identify which provider it actually reached.