### PR TITLE
Add V2FollowerController so /api/v2/followers/* is routed

### DIFF
--- a/src/apps/Odin.Hosting/UnifiedV2/Follow/V2FollowerController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Follow/V2FollowerController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using Odin.Hosting.Controllers.Base.Follow;
+using Odin.Hosting.UnifiedV2.Authentication.Policy;
+using Odin.Services.DataSubscription.Follower;
+
+namespace Odin.Hosting.UnifiedV2.Follow;
+
+/// <summary>
+/// Follow/unfollow and follower-list operations on the unified v2 surface.
+/// </summary>
+/// <remarks>
+/// Subclasses <see cref="FollowerControllerBase"/> for the same reason the owner, app and guest v1
+/// controllers do: the actions and their route templates live on the base, so v2 stays in lockstep
+/// with them instead of drifting behind a second copy.
+/// </remarks>
+[ApiController]
+[Route(UnifiedApiRouteConstants.Followers)]
+[UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]
+[ApiExplorerSettings(GroupName = "v2")]
+public class V2FollowerController(FollowerService fs) : FollowerControllerBase(fs)
+{
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/UnifiedApiRouteConstants.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/UnifiedApiRouteConstants.cs
@@ -5,6 +5,7 @@ public static class UnifiedApiRouteConstants
     public const string BasePath = "/api/v2";
     public const string Auth = BasePath + "/auth";
     public const string Connections = BasePath + "/connections";
+    public const string Followers = BasePath + "/followers";
     public const string Contacts = BasePath + "/contacts";
     public const string Profile = BasePath + "/profile";
     public const string Health = BasePath + "/health";

--- a/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
+++ b/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
@@ -220,7 +220,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             // Config storage can fail on a partially-initialized server. Treat this as
             // "no signal" rather than failing the whole preflight; the IsConfigured flag
             // already tells the caller setup isn't complete.
-            _logger.LogDebug(ex, "PreflightIncomingIntroductionAsync: RequiresUpgradeAsync threw");
+            _logger.LogDebug(ex, "Preflight incoming: RequiresUpgradeAsync threw; reporting no upgrade signal");
         }
 
         var allowsIntroductions = odinContext.PermissionsContext != null
@@ -244,6 +244,28 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             ? PeerCallerConnectionState.Connected
             : await ResolveCallerConnectionStateAsync(odinContext);
 
+        var caller = odinContext.Caller.OdinId;
+
+        if (allowsIntroductions)
+        {
+            _logger.LogDebug("Preflight incoming: reporting ready for caller {caller}", caller);
+        }
+        else
+        {
+            // The whole point of the extra fields: log why we are about to say no, so the reason
+            // distribution is visible in production rather than collapsing into one message.
+            _logger.LogInformation(
+                "Preflight incoming: not permitting introductions from {caller}. reason={reason} " +
+                "isConfigured={isConfigured} requiresUpgrade={requiresUpgrade} isCallerConnected={isCallerConnected} " +
+                "isCallerConfirmed={isCallerConfirmed} isCallerAutoConnected={isCallerAutoConnected} " +
+                "connectionState={connectionState}",
+                caller,
+                DescribeIncomingRefusal(isConfigured, requiresUpgrade, isCallerConnected, isCallerConfirmed,
+                    isCallerAutoConnected, connectionState),
+                isConfigured, requiresUpgrade, isCallerConnected, isCallerConfirmed, isCallerAutoConnected,
+                connectionState);
+        }
+
         return new PeerIntroductionPreflightResponse
         {
             IsConfigured = isConfigured,
@@ -254,6 +276,41 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             IsCallerAutoConnected = isCallerAutoConnected,
             CallerConnectionState = connectionState,
         };
+    }
+
+    /// <summary>
+    /// A short, greppable label for why this server is about to report that it will not accept an
+    /// introduction. Mirrors the classification the caller will apply to the same fields.
+    /// </summary>
+    private static string DescribeIncomingRefusal(bool isConfigured, bool requiresUpgrade, bool isCallerConnected,
+        bool isCallerConfirmed, bool isCallerAutoConnected, PeerCallerConnectionState connectionState)
+    {
+        if (!isConfigured)
+        {
+            return "not-configured";
+        }
+
+        if (requiresUpgrade)
+        {
+            return "requires-upgrade";
+        }
+
+        if (connectionState == PeerCallerConnectionState.NeedsRepair)
+        {
+            return "connection-needs-repair";
+        }
+
+        if (!isCallerConnected)
+        {
+            return "caller-not-recognized";
+        }
+
+        if (isCallerAutoConnected && !isCallerConfirmed)
+        {
+            return "auto-connection-not-confirmed";
+        }
+
+        return "permission-not-granted";
     }
 
     /// <summary>
@@ -297,7 +354,8 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         catch (Exception ex)
         {
             // A partially-initialized server can fail this lookup; report no signal rather than guessing.
-            _logger.LogDebug(ex, "PreflightIncomingIntroductionAsync: could not resolve caller connection state");
+            _logger.LogWarning(ex, "Preflight incoming: could not resolve connection state for caller {caller}; " +
+                                   "reporting Unknown", caller);
             return PeerCallerConnectionState.Unknown;
         }
     }
@@ -319,8 +377,19 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         // requested. Callers must match results by recipient rather than by position or count.
         var targets = recipients.ToOdinIdList().Without(odinContext.Tenant);
 
+        _logger.LogDebug("Preflight: probing {count} recipient(s)", targets.Count());
+
         var probeTasks = targets.Select(r => ProbeRecipientAsync(r, odinContext, cancellationToken)).ToList();
         var statuses = await Task.WhenAll(probeTasks);
+
+        var notReady = statuses.Where(s => s.Status != IntroductionPreflightStatus.Ready).ToList();
+        if (notReady.Count > 0)
+        {
+            _logger.LogInformation("Preflight: {notReadyCount} of {total} recipient(s) not ready: {breakdown}",
+                notReady.Count,
+                statuses.Length,
+                string.Join(", ", notReady.Select(s => $"{s.Recipient}={s.Status}")));
+        }
 
         return new IntroductionPreflightResult
         {
@@ -328,7 +397,45 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         };
     }
 
+    /// <summary>
+    /// Wraps the probe so every outcome is logged in one place, with the fields the recipient reported.
+    /// This is the log line to read when diagnosing why a specific recipient came back not-ready: it holds
+    /// the recipient's own answer, so the sender's logs alone are enough -- no access to the recipient's
+    /// server required.
+    /// </summary>
     private async Task<RecipientPreflightStatus> ProbeRecipientAsync(OdinId recipient, IOdinContext odinContext,
+        CancellationToken cancellationToken)
+    {
+        var status = await ProbeRecipientInternalAsync(recipient, odinContext, cancellationToken);
+
+        if (status.Status == IntroductionPreflightStatus.Ready)
+        {
+            _logger.LogDebug("Preflight: {recipient} is ready", recipient);
+            return status;
+        }
+
+        _logger.LogInformation(
+            "Preflight: {recipient} is not ready. status={status} remedyActor={remedyActor} transient={transient} " +
+            "isConfigured={isConfigured} requiresUpgrade={requiresUpgrade} allowsIntroductions={allowsIntroductions} " +
+            "isCallerConnected={isCallerConnected} isCallerConfirmed={isCallerConfirmed} " +
+            "isCallerAutoConnected={isCallerAutoConnected} connectionState={connectionState} detail={detail}",
+            recipient,
+            status.Status,
+            status.RemedyActor,
+            status.IsTransient,
+            status.IsConfigured,
+            status.RequiresUpgrade,
+            status.AllowsIntroductions,
+            status.IsCallerConnected,
+            status.IsCallerConfirmed,
+            status.IsCallerAutoConnected,
+            status.CallerConnectionState,
+            status.Detail);
+
+        return status;
+    }
+
+    private async Task<RecipientPreflightStatus> ProbeRecipientInternalAsync(OdinId recipient, IOdinContext odinContext,
         CancellationToken cancellationToken)
     {
         var status = new RecipientPreflightStatus
@@ -353,7 +460,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
                 // We hold an ICR but cannot turn it into a usable token (e.g. the stored CAT will not
                 // decrypt under the current ICR key). That is our fault, not the recipient's, and it used
                 // to land in the outer catch as UnknownError with a raw exception string.
-                _logger.LogDebug(ex, "Preflight probe to {recipient}: local ICR did not yield a client access token", recipient);
+                _logger.LogWarning(ex, "Preflight: local ICR with {recipient} did not yield a client access token", recipient);
                 status.Status = IntroductionPreflightStatus.SenderConnectionInvalid;
                 status.Detail = $"Local connection record is present but unusable: {ex.Message}";
                 return status;
@@ -427,7 +534,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Preflight probe to {recipient} failed unexpectedly", recipient);
+            _logger.LogError(ex, "Preflight: probe to {recipient} failed unexpectedly", recipient);
             status.Status = IntroductionPreflightStatus.UnknownError;
             status.Detail = ex.Message;
             return status;

--- a/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
+++ b/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
@@ -195,6 +195,17 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             result.RecipientStatus[recipient] = await EnqueueOutboxItem(recipient, introduction);
         }
 
+        var failed = result.RecipientStatus.Where(kvp => !kvp.Value).Select(kvp => kvp.Key).ToList();
+        if (failed.Count > 0)
+        {
+            _logger.LogWarning("Introduction send: {failedCount} of {total} recipient(s) could not be enqueued: {failed}",
+                failed.Count, result.RecipientStatus.Count, string.Join(", ", failed));
+        }
+        else
+        {
+            _logger.LogDebug("Introduction send: enqueued for all {total} recipient(s)", result.RecipientStatus.Count);
+        }
+
         return result;
     }
 
@@ -721,14 +732,26 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
 
         //Store the introductions by the identity to which you're being introduces
         var newIdentities = new List<string>();
+        var skippedAlreadyConnected = 0;
+        var skippedBlocked = 0;
         foreach (var identity in introduction.Identities.ToOdinIdList().Without(odinContext.Tenant))
         {
             // Note: we do not indicate if you're already connected or
             // have blocked the identity being introduced as we do not
-            // want to communicate any such information to the introducer
+            // want to communicate any such information to the introducer.
+            // Logging it locally is fine -- these are our own logs, not a response to the introducer.
             var icr = await CircleNetworkService.GetIcrAsync(identity, odinContext, overrideHack: true);
             if (icr.IsConnected() || icr.Status == ConnectionStatus.Blocked)
             {
+                if (icr.Status == ConnectionStatus.Blocked)
+                {
+                    skippedBlocked++;
+                }
+                else
+                {
+                    skippedAlreadyConnected++;
+                }
+
                 continue;
             }
 
@@ -744,8 +767,16 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             newIdentities.Add(identity);
         }
 
+        _logger.LogInformation(
+            "Introduction received from {introducer}: {newCount} new, {alreadyConnected} already connected, " +
+            "{blocked} blocked, of {total} introduced identities",
+            introducer, newIdentities.Count, skippedAlreadyConnected, skippedBlocked,
+            introduction.Identities.Count);
+
         if (newIdentities.Count == 0)
         {
+            // Nothing to do and nothing to notify the owner about. Logged above so a "the introduction
+            // arrived but nothing happened" report can be told apart from one that never arrived.
             return;
         }
 
@@ -887,8 +918,10 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         //get the introductions from the list
         var introductions = await GetReceivedIntroductionsAsync(newOdinContext);
 
-        _logger.LogDebug("Sending outstanding connection requests to {introductionCount} introductions", introductions.Count);
+        _logger.LogDebug("Introduction connect: sending outstanding connection requests to {introductionCount} introduction(s)",
+            introductions.Count);
 
+        var processed = 0;
         foreach (var intro in introductions)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -898,21 +931,33 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             }
 
             var recipient = intro.Identity;
+            processed++;
 
+            // NOTE: both of the conditions below `break` rather than `continue`, so a single skipped
+            // introducee abandons every remaining introduction in this batch. The log messages describe a
+            // per-recipient skip, which suggests `continue` was intended. Logged loudly rather than changed
+            // here, because altering background-worker control flow is out of scope for this change.
             var hasOutstandingRequest = await _circleNetworkRequestService.HasPendingOrSentRequest(recipient, odinContext);
             if (hasOutstandingRequest)
             {
-                _logger.LogDebug("{recipient} has an incoming or outgoing request; not sending connection request", recipient);
+                _logger.LogInformation(
+                    "Introduction connect: {recipient} has an incoming or outgoing request; abandoning the " +
+                    "remaining {remaining} of {total} outstanding introduction(s) in this batch",
+                    recipient, introductions.Count - processed, introductions.Count);
                 break;
             }
 
             var alreadyConnected = await CircleNetworkService.IsConnectedAsync(recipient, odinContext);
             if (alreadyConnected)
             {
-                _logger.LogDebug("{recipient} is already connected; not sending connection request", recipient);
+                _logger.LogInformation(
+                    "Introduction connect: {recipient} is already connected; abandoning the remaining " +
+                    "{remaining} of {total} outstanding introduction(s) in this batch",
+                    recipient, introductions.Count - processed, introductions.Count);
                 break;
             }
 
+            _logger.LogDebug("Introduction connect: sending connection request to {recipient}", recipient);
             await this.SendIntroductoryConnectionRequestInternalAsync(intro, cancellationToken, newOdinContext);
         }
     }

--- a/tests/apps/Odin.Hosting.Tests.V2/Api/FollowersHandle.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Api/FollowersHandle.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System.Net.Http;
+using System.Threading.Tasks;
+using Odin.Core;
+using Odin.Core.Identity;
+using Odin.Hosting.Tests._V2.ApiClient;
+using Odin.Services.DataSubscription.Follower;
+using Refit;
+
+namespace Odin.Hosting.Tests.V2.Api;
+
+/// <summary>
+/// The <c>/api/v2/followers/*</c> surface. Every route here is served by
+/// <c>V2FollowerController</c>, which subclasses the same <c>FollowerControllerBase</c> as the
+/// owner/app/guest v1 controllers — so these tests cover the v2 routing and policy, not the
+/// follow logic itself, which the v1 tests already exercise.
+/// </summary>
+public sealed class FollowersHandle
+{
+    private readonly V2FollowerClient _v2Followers;
+
+    internal FollowersHandle(OwnerSession owner)
+    {
+        _v2Followers = new V2FollowerClient(owner.Identity, owner.Factory);
+    }
+
+    /// <summary>POST /api/v2/followers/follow</summary>
+    public Task<ApiResponse<HttpContent>> FollowAsync(OdinId identity,
+        FollowerNotificationType notificationType = FollowerNotificationType.AllNotifications,
+        bool synchronizeFeedHistoryNow = false)
+        => _v2Followers.FollowAsync(new FollowRequest
+        {
+            OdinId = identity,
+            NotificationType = notificationType,
+            Channels = [],
+            SynchronizeFeedHistoryNow = synchronizeFeedHistoryNow
+        });
+
+    /// <summary>POST /api/v2/followers/unfollow</summary>
+    public Task<ApiResponse<HttpContent>> UnfollowAsync(OdinId identity)
+        => _v2Followers.UnfollowAsync(new UnfollowRequest { OdinId = identity });
+
+    /// <summary>GET /api/v2/followers/IdentitiesIFollow</summary>
+    public Task<ApiResponse<CursoredResult<string>>> GetIdentitiesIFollowAsync(int max = 100, string cursor = "")
+        => _v2Followers.GetIdentitiesIFollowAsync(max, cursor);
+
+    /// <summary>GET /api/v2/followers/followingme</summary>
+    public Task<ApiResponse<CursoredResult<string>>> GetFollowingMeAsync(int max = 100, string cursor = "")
+        => _v2Followers.GetFollowingMeAsync(max, cursor);
+
+    /// <summary>GET /api/v2/followers/IdentityIFollow</summary>
+    public Task<ApiResponse<FollowerDefinition>> GetIdentityIFollowAsync(OdinId identity)
+        => _v2Followers.GetIdentityIFollowAsync(identity);
+
+    /// <summary>GET /api/v2/followers/follower</summary>
+    public Task<ApiResponse<FollowerDefinition>> GetFollowerAsync(OdinId identity)
+        => _v2Followers.GetFollowerAsync(identity);
+
+    /// <summary>POST /api/v2/followers/sync-feed-history</summary>
+    public Task<ApiResponse<HttpContent>> SynchronizeFeedHistoryAsync(OdinId identity)
+        => _v2Followers.SynchronizeFeedHistoryAsync(new SynchronizeFeedHistoryRequest { OdinId = identity });
+}

--- a/tests/apps/Odin.Hosting.Tests.V2/Api/OwnerSession.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Api/OwnerSession.cs
@@ -35,6 +35,7 @@ public sealed class OwnerSession : IV2Caller
     public DriveHandles Drives { get; }
     public OwnerAdmin Admin { get; }
     public ConnectionsHandle Connections { get; }
+    public FollowersHandle Followers { get; }
 
     /// <summary>
     /// Test-only drain hooks scoped to this owner. Outbox drain / status reads delegate to the
@@ -55,6 +56,7 @@ public sealed class OwnerSession : IV2Caller
         Drives = new DriveHandles(Identity, Factory);
         Admin = new OwnerAdmin(this);
         Connections = new ConnectionsHandle(this);
+        Followers = new FollowersHandle(this);
         Sync = new OwnerSync(host.GetTestSync(identity), this);
     }
 

--- a/tests/apps/Odin.Hosting.Tests.V2/Ported/Follow/FollowerV2Tests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Ported/Follow/FollowerV2Tests.cs
@@ -1,0 +1,141 @@
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Hosting.Tests.V2.Api;
+
+namespace Odin.Hosting.Tests.V2.Ported.Follow;
+
+/// <summary>
+/// Covers the <c>/api/v2/followers/*</c> surface added for
+/// <see href="https://github.com/homebase-id/odin-core/issues/1611">#1611</see>, where every one of
+/// these routes 404'd because no follower controller existed under <c>UnifiedV2/</c>.
+///
+/// The follow *logic* is shared with the v1 owner/app/guest controllers via
+/// <c>FollowerControllerBase</c> and is covered by their tests; what these assert is that the v2
+/// routes exist, bind, and run under the v2 bearer-token policy. The 404 regression is asserted
+/// explicitly in <see cref="AllFollowerRoutes_AreRouted_AndDoNotReturnNotFound"/>.
+/// </summary>
+[TestFixture]
+public class FollowerV2Tests : V2Fixture
+{
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task Follow_ThenIdentitiesIFollow_ReturnsTheFollowedIdentity()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        var follow = await frodo.Followers.FollowAsync(sam.Identity);
+        Assert.That(follow.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+
+        var iFollow = await frodo.Followers.GetIdentitiesIFollowAsync();
+        Assert.That(iFollow.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(iFollow.Content!.Results, Does.Contain(sam.Identity.DomainName));
+    }
+
+    [Test]
+    public async Task Follow_ThenFollowingMe_OnTheRecipient_ReturnsTheFollower()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        await frodo.Followers.FollowAsync(sam.Identity);
+
+        // The follow is delivered to Sam over the perimeter, so Sam is the one who can see it.
+        var followingSam = await sam.Followers.GetFollowingMeAsync();
+        Assert.That(followingSam.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(followingSam.Content!.Results, Does.Contain(frodo.Identity.DomainName));
+    }
+
+    [Test]
+    public async Task GetIdentityIFollow_ReturnsTheDefinition()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        await frodo.Followers.FollowAsync(sam.Identity);
+
+        var definition = await frodo.Followers.GetIdentityIFollowAsync(sam.Identity);
+        Assert.That(definition.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(definition.Content!.OdinId, Is.EqualTo(sam.Identity));
+    }
+
+    [Test]
+    public async Task GetFollower_OnTheRecipient_ReturnsTheDefinition()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        await frodo.Followers.FollowAsync(sam.Identity);
+
+        var definition = await sam.Followers.GetFollowerAsync(frodo.Identity);
+        Assert.That(definition.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(definition.Content!.OdinId, Is.EqualTo(frodo.Identity));
+    }
+
+    [Test]
+    public async Task Unfollow_RemovesTheIdentityFromIdentitiesIFollow()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        await frodo.Followers.FollowAsync(sam.Identity);
+
+        var unfollow = await frodo.Followers.UnfollowAsync(sam.Identity);
+        Assert.That(unfollow.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+
+        var iFollow = await frodo.Followers.GetIdentitiesIFollowAsync();
+        Assert.That(iFollow.Content!.Results, Does.Not.Contain(sam.Identity.DomainName));
+
+        var followingSam = await sam.Followers.GetFollowingMeAsync();
+        Assert.That(followingSam.Content!.Results, Does.Not.Contain(frodo.Identity.DomainName));
+    }
+
+    [Test]
+    public async Task SynchronizeFeedHistory_Succeeds()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        await frodo.Followers.FollowAsync(sam.Identity);
+
+        var sync = await frodo.Followers.SynchronizeFeedHistoryAsync(sam.Identity);
+        Assert.That(sync.IsSuccessStatusCode, Is.True, $"sync-feed-history returned {sync.StatusCode}");
+    }
+
+    /// <summary>
+    /// The regression itself: before the v2 controller existed, every one of these returned 404 and
+    /// the KMP feed client rendered "You're not following anyone yet." Asserts routing only — the
+    /// status just has to be something other than NotFound.
+    /// </summary>
+    [Test]
+    public async Task AllFollowerRoutes_AreRouted_AndDoNotReturnNotFound()
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        var statuses = new[]
+        {
+            (route: "POST /follow", status: (await frodo.Followers.FollowAsync(sam.Identity)).StatusCode),
+            (route: "GET /IdentitiesIFollow", status: (await frodo.Followers.GetIdentitiesIFollowAsync()).StatusCode),
+            (route: "GET /followingme", status: (await frodo.Followers.GetFollowingMeAsync()).StatusCode),
+            (route: "GET /IdentityIFollow", status: (await frodo.Followers.GetIdentityIFollowAsync(sam.Identity)).StatusCode),
+            (route: "GET /follower", status: (await sam.Followers.GetFollowerAsync(frodo.Identity)).StatusCode),
+            (route: "POST /sync-feed-history", status: (await frodo.Followers.SynchronizeFeedHistoryAsync(sam.Identity)).StatusCode),
+            (route: "POST /unfollow", status: (await frodo.Followers.UnfollowAsync(sam.Identity)).StatusCode)
+        };
+
+        Assert.Multiple(() =>
+        {
+            foreach (var (route, status) in statuses)
+            {
+                Assert.That(status, Is.Not.EqualTo(HttpStatusCode.NotFound), $"{route} is not routed on /api/v2/followers");
+            }
+        });
+
+        Assert.That(statuses.All(s => (int)s.status < 400), Is.True,
+            "expected every follower route to succeed: " + string.Join(", ", statuses.Select(s => $"{s.route}={s.status}")));
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IFollowerHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IFollowerHttpClientApiV2.cs
@@ -1,0 +1,34 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Odin.Core;
+using Odin.Hosting.UnifiedV2;
+using Odin.Services.DataSubscription.Follower;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+public interface IFollowerHttpClientApiV2
+{
+    private const string Root = UnifiedApiRouteConstants.Followers;
+
+    [Post(Root + "/follow")]
+    Task<ApiResponse<HttpContent>> Follow([Body] FollowRequest request);
+
+    [Post(Root + "/unfollow")]
+    Task<ApiResponse<HttpContent>> Unfollow([Body] UnfollowRequest request);
+
+    [Get(Root + "/IdentitiesIFollow")]
+    Task<ApiResponse<CursoredResult<string>>> GetIdentitiesIFollow(int max, string cursor);
+
+    [Get(Root + "/followingme")]
+    Task<ApiResponse<CursoredResult<string>>> GetFollowingMe(int max, string cursor);
+
+    [Get(Root + "/IdentityIFollow")]
+    Task<ApiResponse<FollowerDefinition>> GetIdentityIFollow(string odinId);
+
+    [Get(Root + "/follower")]
+    Task<ApiResponse<FollowerDefinition>> GetFollower(string odinId);
+
+    [Post(Root + "/sync-feed-history")]
+    Task<ApiResponse<HttpContent>> SynchronizeFeedHistory([Body] SynchronizeFeedHistoryRequest request);
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/V2FollowerClient.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/V2FollowerClient.cs
@@ -1,0 +1,39 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Odin.Core;
+using Odin.Core.Identity;
+using Odin.Hosting.Tests._Universal.ApiClient.Factory;
+using Odin.Services.DataSubscription.Follower;
+using Refit;
+
+namespace Odin.Hosting.Tests._V2.ApiClient;
+
+public class V2FollowerClient(OdinId identity, IApiClientFactory factory)
+{
+    private IFollowerHttpClientApiV2 Service()
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret);
+        return RefitCreator.RestServiceFor<IFollowerHttpClientApiV2>(client, sharedSecret);
+    }
+
+    public async Task<ApiResponse<HttpContent>> FollowAsync(FollowRequest request)
+        => await Service().Follow(request);
+
+    public async Task<ApiResponse<HttpContent>> UnfollowAsync(UnfollowRequest request)
+        => await Service().Unfollow(request);
+
+    public async Task<ApiResponse<CursoredResult<string>>> GetIdentitiesIFollowAsync(int max = 100, string cursor = "")
+        => await Service().GetIdentitiesIFollow(max, cursor);
+
+    public async Task<ApiResponse<CursoredResult<string>>> GetFollowingMeAsync(int max = 100, string cursor = "")
+        => await Service().GetFollowingMe(max, cursor);
+
+    public async Task<ApiResponse<FollowerDefinition>> GetIdentityIFollowAsync(OdinId odinId)
+        => await Service().GetIdentityIFollow(odinId.DomainName);
+
+    public async Task<ApiResponse<FollowerDefinition>> GetFollowerAsync(OdinId odinId)
+        => await Service().GetFollower(odinId.DomainName);
+
+    public async Task<ApiResponse<HttpContent>> SynchronizeFeedHistoryAsync(SynchronizeFeedHistoryRequest request)
+        => await Service().SynchronizeFeedHistory(request);
+}


### PR DESCRIPTION
Fixes #1611

## What

There was no followers controller anywhere under `UnifiedV2/`, so every follow-related call from a v2 bearer-token client 404'd. `FollowerControllerBase` was exposed on owner, app-v1 and guest only.

Adds `V2FollowerController` at `/api/v2/followers`, plus the `Followers` route constant.

All six routes the KMP feed client calls are now served, along with `GET /follower`:

| Route | Permission asserted by `FollowerService` |
|---|---|
| `POST /api/v2/followers/follow` | `ManageFeed` |
| `POST /api/v2/followers/unfollow` | `ManageFeed` |
| `POST /api/v2/followers/sync-feed-history` | `ManageFeed` |
| `GET /api/v2/followers/IdentitiesIFollow` | `ReadWhoIFollow` |
| `GET /api/v2/followers/IdentityIFollow` | `ReadWhoIFollow` |
| `GET /api/v2/followers/followingme` | `ReadMyFollowers` |
| `GET /api/v2/followers/follower` | `ReadMyFollowers` |

## Design note

The controller subclasses `FollowerControllerBase` rather than re-declaring the actions in the usual v2 style. The actions and their route templates live on the base, so this keeps v2 in lockstep with the owner/app/guest controllers instead of leaving a second copy to drift. Trade-off: inherited actions can't carry per-action `[SwaggerOperation(Tags = ...)]` like the other v2 controllers, so these land under the default `V2Follower` tag. `[ApiExplorerSettings(GroupName = "v2")]` still puts them in the right Swagger doc, which is what `DocInclusionPredicate` keys on.

Policy is `OwnerOrApp`, per the issue.

## Tests

New `FollowerV2Tests` (7 tests, `Odin.Hosting.Tests.V2`), driving two identities through the real perimeter follow flow:

- follow → `IdentitiesIFollow` contains the target
- follow → recipient's `followingme` contains the follower
- `IdentityIFollow` / `follower` return the definition from each side
- unfollow removes it from both sides
- `sync-feed-history` succeeds
- `AllFollowerRoutes_AreRouted_AndDoNotReturnNotFound` — asserts the regression itself, that none of the seven routes 404s

Supporting test infra: `IFollowerHttpClientApiV2` + `V2FollowerClient` (in `Odin.Hosting.Tests/_V2/ApiClient/`, alongside the other v2 clients) and a `FollowersHandle` on `OwnerSession`.

New tests pass 7/7; the full `Odin.Hosting.Tests.V2` project passes 418/418 (3 pre-existing skips).

## Not verified

The client-side call sites live in `homebase-id/chat-kmp` / `homebase-api` and were not exercised against this branch — route paths were matched against the table in #1611. ASP.NET routing is case-insensitive, so the mixed-case paths (`IdentitiesIFollow`, `IdentityIFollow`) resolve regardless of casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)