### PR TITLE
Expose peer reaction reads on unified v2

### DIFF
--- a/src/apps/Odin.Hosting/UnifiedV2/Drive/Reactions/V2DrivePeerReactionController.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/Drive/Reactions/V2DrivePeerReactionController.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Odin.Hosting.Controllers.Base;
+using Odin.Hosting.UnifiedV2.Authentication.Policy;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Query;
+using Odin.Services.Drives.Reactions;
+using Odin.Services.Peer.Outgoing.Drive.Reactions;
+using Odin.Services.Util;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Odin.Hosting.UnifiedV2.Drive.Reactions;
+
+/// <summary>
+/// Reads reactions on a file hosted by another (peer) identity — the "over peer" twin of
+/// <see cref="V2DriveGroupReactionController"/>'s read actions. Without these, a client can only
+/// read its own local copy of a followed identity's post, which holds nothing but the reactions it
+/// sent itself; the post's own count (from the file header) is authoritative and disagrees.
+///
+/// Writes already go over peer via <c>GroupReactionService</c> → outbox → the perimeter controller,
+/// and are deliberately not duplicated here.
+/// </summary>
+/// <remarks>
+/// Reactions are stored per (driveId, fileId) with no file-system-type discriminator, and the
+/// remote resolves Standard-vs-Comment itself from the gtid
+/// (<c>FileSystemResolver.ResolveFileSystem(GlobalTransitIdFileIdentifier, ...)</c> probes Standard
+/// then Comment). There is no file-system-type field on the peer wire format, so unlike the local
+/// group controller these actions do not forward <c>GetHttpFileSystemResolver().GetFileSystemType()</c>
+/// — the caller's header would have nowhere to go and no effect on the answer.
+/// </remarks>
+[ApiController]
+[Route(UnifiedApiRouteConstants.PeerReactionsByGtid)]
+[UnifiedV2Authorize(UnifiedPolicies.OwnerOrApp)]
+[ApiExplorerSettings(GroupName = "v2")]
+public class V2DrivePeerReactionController(PeerReactionSenderService peerReactionSenderService) : OdinControllerBase
+{
+    /// <summary>
+    /// Lists the reactions on the peer's file.
+    /// </summary>
+    [SwaggerOperation(Tags = [SwaggerInfo.FileReaction])]
+    [HttpGet]
+    public async Task<GetReactionsResponse> GetAllReactions(
+        [FromRoute] string odinId,
+        [FromRoute] Guid driveId,
+        [FromRoute] Guid gtid,
+        [FromQuery] string cursor = null,
+        [FromQuery] int maxRecords = 100)
+    {
+        AssertIsValidOdinId(odinId, out var id);
+
+        var result = await peerReactionSenderService.GetReactionsAsync(id, new GetRemoteReactionsRequest
+        {
+            File = ToGtidFile(driveId, gtid),
+            Cursor = cursor,
+            MaxRecords = maxRecords
+        }, WebOdinContext);
+
+        // Deliberately returns the local GetReactionsResponse shape rather than the perimeter's
+        // GetReactionsPerimeterResponse, so a client can decode a peer file's reactions with the same
+        // decoder it already uses for a local one. FileId has no meaning across identities -- the
+        // caller does not have the file on its own drive -- so it is left zeroed.
+        return new GetReactionsResponse
+        {
+            Reactions = result?.Reactions?.Select(r => new Reaction
+            {
+                OdinId = r.OdinId,
+                ReactionContent = r.ReactionContent,
+                Created = r.Created,
+                FileId = default
+            }).ToList() ?? [],
+            Cursor = result?.Cursor
+        };
+    }
+
+    /// <summary>
+    /// Gets a summary of reactions for the peer's file. The cursor and max parameters are ignored.
+    /// </summary>
+    [SwaggerOperation(Tags = [SwaggerInfo.FileReaction])]
+    [HttpGet("summary")]
+    public async Task<GetReactionCountsResponse> GetReactionCountsByFile(
+        [FromRoute] string odinId,
+        [FromRoute] Guid driveId,
+        [FromRoute] Guid gtid)
+    {
+        AssertIsValidOdinId(odinId, out var id);
+
+        return await peerReactionSenderService.GetReactionCountsAsync(id, new GetRemoteReactionsRequest
+        {
+            File = ToGtidFile(driveId, gtid)
+        }, WebOdinContext);
+    }
+
+    /// <summary>
+    /// Gets the reactions a single identity left on the peer's file.
+    /// </summary>
+    [SwaggerOperation(Tags = [SwaggerInfo.FileReaction])]
+    [HttpGet("by-identity")]
+    public async Task<List<string>> GetReactionsByIdentity(
+        [FromRoute] string odinId,
+        [FromRoute] Guid driveId,
+        [FromRoute] Guid gtid,
+        [FromQuery] string identity)
+    {
+        AssertIsValidOdinId(odinId, out var id);
+        OdinValidationUtils.AssertIsValidOdinId(identity, out var reactingIdentity);
+
+        return await peerReactionSenderService.GetReactionsByIdentityAndFileAsync(id, new PeerGetReactionsByIdentityRequest
+        {
+            OdinId = id,
+            Identity = reactingIdentity,
+            File = ToGtidFile(driveId, gtid)
+        }, WebOdinContext);
+    }
+
+    // The remote resolves the drive by alias (matching the peer file-read endpoints), so Type is left empty.
+    private static GlobalTransitIdFileIdentifier ToGtidFile(Guid driveId, Guid gtid)
+    {
+        return new GlobalTransitIdFileIdentifier
+        {
+            GlobalTransitId = gtid,
+            TargetDrive = new TargetDrive { Alias = driveId, Type = Guid.Empty }
+        };
+    }
+}

--- a/src/apps/Odin.Hosting/UnifiedV2/UnifiedApiRouteConstants.cs
+++ b/src/apps/Odin.Hosting/UnifiedV2/UnifiedApiRouteConstants.cs
@@ -30,6 +30,11 @@ public static class UnifiedApiRouteConstants
     public const string PeerByUniqueId = PeerFilesRoot + "/by-uid/{uid:guid}";
     public const string PeerByGtid = PeerFilesRoot + "/by-gtid/{gtid:guid}";
 
+    // Reaction reads on a file hosted by another identity. Keyed by globalTransitId because a
+    // followed identity's post lands on the feed drive as a reference: it carries no fileId on the
+    // author's drive and no uniqueId, so the gtid is the only handle the client holds.
+    public const string PeerReactionsByGtid = PeerByGtid + "/reactions";
+
     // Temporal (time-boxed) read of a drive hosted by another identity. Parallels the peer file-read
     // chain above so temporal actions share the same templates as their non-temporal twins.
     public const string PeerTemporalRoot = PeerByDriveId + "/temporal";

--- a/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
+++ b/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
@@ -220,7 +220,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             // Config storage can fail on a partially-initialized server. Treat this as
             // "no signal" rather than failing the whole preflight; the IsConfigured flag
             // already tells the caller setup isn't complete.
-            _logger.LogDebug(ex, "PreflightIncomingIntroductionAsync: RequiresUpgradeAsync threw");
+            _logger.LogDebug(ex, "Preflight incoming: RequiresUpgradeAsync threw; reporting no upgrade signal");
         }
 
         var allowsIntroductions = odinContext.PermissionsContext != null
@@ -244,6 +244,28 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             ? PeerCallerConnectionState.Connected
             : await ResolveCallerConnectionStateAsync(odinContext);
 
+        var caller = odinContext.Caller.OdinId;
+
+        if (allowsIntroductions)
+        {
+            _logger.LogDebug("Preflight incoming: reporting ready for caller {caller}", caller);
+        }
+        else
+        {
+            // The whole point of the extra fields: log why we are about to say no, so the reason
+            // distribution is visible in production rather than collapsing into one message.
+            _logger.LogInformation(
+                "Preflight incoming: not permitting introductions from {caller}. reason={reason} " +
+                "isConfigured={isConfigured} requiresUpgrade={requiresUpgrade} isCallerConnected={isCallerConnected} " +
+                "isCallerConfirmed={isCallerConfirmed} isCallerAutoConnected={isCallerAutoConnected} " +
+                "connectionState={connectionState}",
+                caller,
+                DescribeIncomingRefusal(isConfigured, requiresUpgrade, isCallerConnected, isCallerConfirmed,
+                    isCallerAutoConnected, connectionState),
+                isConfigured, requiresUpgrade, isCallerConnected, isCallerConfirmed, isCallerAutoConnected,
+                connectionState);
+        }
+
         return new PeerIntroductionPreflightResponse
         {
             IsConfigured = isConfigured,
@@ -254,6 +276,41 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             IsCallerAutoConnected = isCallerAutoConnected,
             CallerConnectionState = connectionState,
         };
+    }
+
+    /// <summary>
+    /// A short, greppable label for why this server is about to report that it will not accept an
+    /// introduction. Mirrors the classification the caller will apply to the same fields.
+    /// </summary>
+    private static string DescribeIncomingRefusal(bool isConfigured, bool requiresUpgrade, bool isCallerConnected,
+        bool isCallerConfirmed, bool isCallerAutoConnected, PeerCallerConnectionState connectionState)
+    {
+        if (!isConfigured)
+        {
+            return "not-configured";
+        }
+
+        if (requiresUpgrade)
+        {
+            return "requires-upgrade";
+        }
+
+        if (connectionState == PeerCallerConnectionState.NeedsRepair)
+        {
+            return "connection-needs-repair";
+        }
+
+        if (!isCallerConnected)
+        {
+            return "caller-not-recognized";
+        }
+
+        if (isCallerAutoConnected && !isCallerConfirmed)
+        {
+            return "auto-connection-not-confirmed";
+        }
+
+        return "permission-not-granted";
     }
 
     /// <summary>
@@ -297,7 +354,8 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         catch (Exception ex)
         {
             // A partially-initialized server can fail this lookup; report no signal rather than guessing.
-            _logger.LogDebug(ex, "PreflightIncomingIntroductionAsync: could not resolve caller connection state");
+            _logger.LogWarning(ex, "Preflight incoming: could not resolve connection state for caller {caller}; " +
+                                   "reporting Unknown", caller);
             return PeerCallerConnectionState.Unknown;
         }
     }
@@ -319,8 +377,19 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         // requested. Callers must match results by recipient rather than by position or count.
         var targets = recipients.ToOdinIdList().Without(odinContext.Tenant);
 
+        _logger.LogDebug("Preflight: probing {count} recipient(s)", targets.Count());
+
         var probeTasks = targets.Select(r => ProbeRecipientAsync(r, odinContext, cancellationToken)).ToList();
         var statuses = await Task.WhenAll(probeTasks);
+
+        var notReady = statuses.Where(s => s.Status != IntroductionPreflightStatus.Ready).ToList();
+        if (notReady.Count > 0)
+        {
+            _logger.LogInformation("Preflight: {notReadyCount} of {total} recipient(s) not ready: {breakdown}",
+                notReady.Count,
+                statuses.Length,
+                string.Join(", ", notReady.Select(s => $"{s.Recipient}={s.Status}")));
+        }
 
         return new IntroductionPreflightResult
         {
@@ -328,7 +397,45 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         };
     }
 
+    /// <summary>
+    /// Wraps the probe so every outcome is logged in one place, with the fields the recipient reported.
+    /// This is the log line to read when diagnosing why a specific recipient came back not-ready: it holds
+    /// the recipient's own answer, so the sender's logs alone are enough -- no access to the recipient's
+    /// server required.
+    /// </summary>
     private async Task<RecipientPreflightStatus> ProbeRecipientAsync(OdinId recipient, IOdinContext odinContext,
+        CancellationToken cancellationToken)
+    {
+        var status = await ProbeRecipientInternalAsync(recipient, odinContext, cancellationToken);
+
+        if (status.Status == IntroductionPreflightStatus.Ready)
+        {
+            _logger.LogDebug("Preflight: {recipient} is ready", recipient);
+            return status;
+        }
+
+        _logger.LogInformation(
+            "Preflight: {recipient} is not ready. status={status} remedyActor={remedyActor} transient={transient} " +
+            "isConfigured={isConfigured} requiresUpgrade={requiresUpgrade} allowsIntroductions={allowsIntroductions} " +
+            "isCallerConnected={isCallerConnected} isCallerConfirmed={isCallerConfirmed} " +
+            "isCallerAutoConnected={isCallerAutoConnected} connectionState={connectionState} detail={detail}",
+            recipient,
+            status.Status,
+            status.RemedyActor,
+            status.IsTransient,
+            status.IsConfigured,
+            status.RequiresUpgrade,
+            status.AllowsIntroductions,
+            status.IsCallerConnected,
+            status.IsCallerConfirmed,
+            status.IsCallerAutoConnected,
+            status.CallerConnectionState,
+            status.Detail);
+
+        return status;
+    }
+
+    private async Task<RecipientPreflightStatus> ProbeRecipientInternalAsync(OdinId recipient, IOdinContext odinContext,
         CancellationToken cancellationToken)
     {
         var status = new RecipientPreflightStatus
@@ -353,7 +460,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
                 // We hold an ICR but cannot turn it into a usable token (e.g. the stored CAT will not
                 // decrypt under the current ICR key). That is our fault, not the recipient's, and it used
                 // to land in the outer catch as UnknownError with a raw exception string.
-                _logger.LogDebug(ex, "Preflight probe to {recipient}: local ICR did not yield a client access token", recipient);
+                _logger.LogWarning(ex, "Preflight: local ICR with {recipient} did not yield a client access token", recipient);
                 status.Status = IntroductionPreflightStatus.SenderConnectionInvalid;
                 status.Detail = $"Local connection record is present but unusable: {ex.Message}";
                 return status;
@@ -427,7 +534,7 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Preflight probe to {recipient} failed unexpectedly", recipient);
+            _logger.LogError(ex, "Preflight: probe to {recipient} failed unexpectedly", recipient);
             status.Status = IntroductionPreflightStatus.UnknownError;
             status.Detail = ex.Message;
             return status;

--- a/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
+++ b/src/services/Odin.Services/Membership/Connections/Requests/CircleNetworkIntroductionService.cs
@@ -195,6 +195,17 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             result.RecipientStatus[recipient] = await EnqueueOutboxItem(recipient, introduction);
         }
 
+        var failed = result.RecipientStatus.Where(kvp => !kvp.Value).Select(kvp => kvp.Key).ToList();
+        if (failed.Count > 0)
+        {
+            _logger.LogWarning("Introduction send: {failedCount} of {total} recipient(s) could not be enqueued: {failed}",
+                failed.Count, result.RecipientStatus.Count, string.Join(", ", failed));
+        }
+        else
+        {
+            _logger.LogDebug("Introduction send: enqueued for all {total} recipient(s)", result.RecipientStatus.Count);
+        }
+
         return result;
     }
 
@@ -721,14 +732,26 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
 
         //Store the introductions by the identity to which you're being introduces
         var newIdentities = new List<string>();
+        var skippedAlreadyConnected = 0;
+        var skippedBlocked = 0;
         foreach (var identity in introduction.Identities.ToOdinIdList().Without(odinContext.Tenant))
         {
             // Note: we do not indicate if you're already connected or
             // have blocked the identity being introduced as we do not
-            // want to communicate any such information to the introducer
+            // want to communicate any such information to the introducer.
+            // Logging it locally is fine -- these are our own logs, not a response to the introducer.
             var icr = await CircleNetworkService.GetIcrAsync(identity, odinContext, overrideHack: true);
             if (icr.IsConnected() || icr.Status == ConnectionStatus.Blocked)
             {
+                if (icr.Status == ConnectionStatus.Blocked)
+                {
+                    skippedBlocked++;
+                }
+                else
+                {
+                    skippedAlreadyConnected++;
+                }
+
                 continue;
             }
 
@@ -744,8 +767,16 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             newIdentities.Add(identity);
         }
 
+        _logger.LogInformation(
+            "Introduction received from {introducer}: {newCount} new, {alreadyConnected} already connected, " +
+            "{blocked} blocked, of {total} introduced identities",
+            introducer, newIdentities.Count, skippedAlreadyConnected, skippedBlocked,
+            introduction.Identities.Count);
+
         if (newIdentities.Count == 0)
         {
+            // Nothing to do and nothing to notify the owner about. Logged above so a "the introduction
+            // arrived but nothing happened" report can be told apart from one that never arrived.
             return;
         }
 
@@ -887,8 +918,10 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
         //get the introductions from the list
         var introductions = await GetReceivedIntroductionsAsync(newOdinContext);
 
-        _logger.LogDebug("Sending outstanding connection requests to {introductionCount} introductions", introductions.Count);
+        _logger.LogDebug("Introduction connect: sending outstanding connection requests to {introductionCount} introduction(s)",
+            introductions.Count);
 
+        var processed = 0;
         foreach (var intro in introductions)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -898,21 +931,33 @@ public class CircleNetworkIntroductionService : PeerServiceBase,
             }
 
             var recipient = intro.Identity;
+            processed++;
 
+            // NOTE: both of the conditions below `break` rather than `continue`, so a single skipped
+            // introducee abandons every remaining introduction in this batch. The log messages describe a
+            // per-recipient skip, which suggests `continue` was intended. Logged loudly rather than changed
+            // here, because altering background-worker control flow is out of scope for this change.
             var hasOutstandingRequest = await _circleNetworkRequestService.HasPendingOrSentRequest(recipient, odinContext);
             if (hasOutstandingRequest)
             {
-                _logger.LogDebug("{recipient} has an incoming or outgoing request; not sending connection request", recipient);
+                _logger.LogInformation(
+                    "Introduction connect: {recipient} has an incoming or outgoing request; abandoning the " +
+                    "remaining {remaining} of {total} outstanding introduction(s) in this batch",
+                    recipient, introductions.Count - processed, introductions.Count);
                 break;
             }
 
             var alreadyConnected = await CircleNetworkService.IsConnectedAsync(recipient, odinContext);
             if (alreadyConnected)
             {
-                _logger.LogDebug("{recipient} is already connected; not sending connection request", recipient);
+                _logger.LogInformation(
+                    "Introduction connect: {recipient} is already connected; abandoning the remaining " +
+                    "{remaining} of {total} outstanding introduction(s) in this batch",
+                    recipient, introductions.Count - processed, introductions.Count);
                 break;
             }
 
+            _logger.LogDebug("Introduction connect: sending connection request to {recipient}", recipient);
             await this.SendIntroductoryConnectionRequestInternalAsync(intro, cancellationToken, newOdinContext);
         }
     }

--- a/tests/apps/Odin.Hosting.Tests.V2/Peer/PeerReactionReadTests.cs
+++ b/tests/apps/Odin.Hosting.Tests.V2/Peer/PeerReactionReadTests.cs
@@ -1,0 +1,166 @@
+#nullable enable
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Odin.Hosting.Tests._Universal.DriveTests;
+using Odin.Hosting.Tests.V2.Api;
+using Odin.Services.Authorization.Acl;
+using Odin.Services.Drives;
+using Odin.Services.Drives.DriveCore.Query;
+
+namespace Odin.Hosting.Tests.V2.Peer;
+
+/// <summary>
+/// Covers the peer reaction READ routes added for
+/// <see href="https://github.com/homebase-id/odin-core/issues/1610">#1610</see>. Before them a
+/// client could only read its own host's copy of another identity's post, which holds nothing but
+/// the reactions it sent itself — so "who reacted" on a followed post showed only you, while the
+/// header's reaction count (correct) disagreed.
+///
+/// Setup is Sam-hosts / Frodo-reads: Sam owns the drive and the file, Sam reacts on it, and Frodo —
+/// connected with <see cref="DrivePermission.Read"/> — reads those reactions over peer. The
+/// reaction Frodo gets back is one he did not author and has no local copy of, which is exactly the
+/// case that was unreachable.
+///
+/// Reaction WRITES already go over peer via the outbox and are not re-tested here.
+/// </summary>
+[TestFixture]
+public class PeerReactionReadTests : V2Fixture
+{
+    protected override string[] HostIdentities => [Identities.Frodo, Identities.Sam];
+
+    [Test]
+    public async Task GetReactions_OverPeer_ReturnsReactionsAuthoredByTheHost()
+    {
+        var (frodo, sam, drive, gtid) = await SetupSamPostWithReactionAsync(":like:");
+
+        var response = await frodo.Drives.Peer.GetReactionsByGtidAsync(sam.Identity, drive.Alias, gtid);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"peer reaction list failed: {response.StatusCode}");
+        var reactions = response.Content!.Reactions;
+        Assert.That(reactions.Count, Is.EqualTo(1));
+        Assert.That(reactions[0].ReactionContent, Is.EqualTo(":like:"));
+        Assert.That(reactions[0].OdinId, Is.EqualTo(sam.Identity.DomainName),
+            "the reaction Frodo reads over peer is Sam's, not his own");
+    }
+
+    /// <summary>
+    /// The response deliberately uses the local <c>GetReactionsResponse</c> shape rather than the
+    /// perimeter's <c>GetReactionsPerimeterResponse</c>, so a client can decode a peer file's
+    /// reactions with the decoder it already uses locally. FileId is meaningless across identities
+    /// and comes back zeroed.
+    /// </summary>
+    [Test]
+    public async Task GetReactions_OverPeer_ReturnsTheLocalResponseShape_WithZeroedFileId()
+    {
+        var (frodo, sam, drive, gtid) = await SetupSamPostWithReactionAsync(":wave:");
+
+        var peerResponse = await frodo.Drives.Peer.GetReactionsByGtidAsync(sam.Identity, drive.Alias, gtid);
+        Assert.That(peerResponse.IsSuccessStatusCode, Is.True);
+
+        var peerReaction = peerResponse.Content!.Reactions.Single();
+        Assert.That(peerReaction.FileId.FileId, Is.EqualTo(default(System.Guid)));
+        Assert.That(peerReaction.FileId.DriveId, Is.EqualTo(default(System.Guid)));
+
+        // Same values Sam's own local read produces -- that is the point of the shape choice.
+        var localResponse = await sam.Drives.Reactions.GetAllReactionsAsync(drive.Alias, (await FileIdOf(sam, drive, gtid)));
+        Assert.That(localResponse.IsSuccessStatusCode, Is.True);
+        var localReaction = localResponse.Content!.Reactions.Single();
+        Assert.That(peerReaction.ReactionContent, Is.EqualTo(localReaction.ReactionContent));
+        Assert.That(peerReaction.OdinId, Is.EqualTo(localReaction.OdinId));
+
+        // Created is deliberately not asserted to be a real timestamp: it is 0 here, and equally 0
+        // on the local read above, because the DriveReactions table has no created column
+        // (DriveReactionsRecord: rowId/identityId/driveId/postId/identity/singleReaction) and
+        // DriveQuery.GetReactionsByFileAsync never populates Reaction.Created. That gap predates
+        // these peer routes and affects every reaction read path; fixing it needs a schema change.
+        Assert.That(peerReaction.Created, Is.EqualTo(localReaction.Created));
+    }
+
+    [Test]
+    public async Task GetReactionSummary_OverPeer_ReturnsCounts()
+    {
+        var (frodo, sam, drive, gtid) = await SetupSamPostWithReactionAsync(":like:");
+
+        var response = await frodo.Drives.Peer.GetReactionSummaryByGtidAsync(sam.Identity, drive.Alias, gtid);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"peer reaction summary failed: {response.StatusCode}");
+        Assert.That(response.Content!.Total, Is.EqualTo(1));
+        var count = response.Content.Reactions.Single();
+        Assert.That(count.ReactionContent, Is.EqualTo(":like:"));
+        Assert.That(count.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetReactionsByIdentity_OverPeer_ReturnsThatIdentitysReactions()
+    {
+        var (frodo, sam, drive, gtid) = await SetupSamPostWithReactionAsync(":like:");
+
+        var mine = await frodo.Drives.Peer.GetReactionsByIdentityAndGtidAsync(sam.Identity, drive.Alias, gtid, sam.Identity);
+        Assert.That(mine.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"peer reaction by-identity failed: {mine.StatusCode}");
+        Assert.That(mine.Content, Is.EquivalentTo(new[] { ":like:" }));
+
+        // An identity that reacted to nothing comes back empty rather than erroring.
+        var none = await frodo.Drives.Peer.GetReactionsByIdentityAndGtidAsync(sam.Identity, drive.Alias, gtid, frodo.Identity);
+        Assert.That(none.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(none.Content, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetReactions_OverPeer_ReflectsMultipleReactions()
+    {
+        var (frodo, sam, drive, gtid) = await SetupSamPostWithReactionAsync(":like:");
+        var fileId = await FileIdOf(sam, drive, gtid);
+
+        var second = await sam.Drives.Reactions.AddReactionAsync(drive.Alias, fileId, ":wave:");
+        Assert.That(second.IsSuccessStatusCode, Is.True, $"second AddReaction failed: {second.StatusCode}");
+
+        var list = await frodo.Drives.Peer.GetReactionsByGtidAsync(sam.Identity, drive.Alias, gtid);
+        Assert.That(list.Content!.Reactions.Select(r => r.ReactionContent),
+            Is.EquivalentTo(new[] { ":like:", ":wave:" }));
+
+        var summary = await frodo.Drives.Peer.GetReactionSummaryByGtidAsync(sam.Identity, drive.Alias, gtid);
+        Assert.That(summary.Content!.Total, Is.EqualTo(2));
+    }
+
+    /// <summary>
+    /// Sam hosts a drive and a post, Frodo is connected with Read on it, and Sam leaves one reaction.
+    /// Returns both sessions plus the drive and the post's GlobalTransitId — the only handle a feed
+    /// client holds for a followed identity's post.
+    /// </summary>
+    private async Task<(OwnerSession Frodo, OwnerSession Sam, TargetDrive Drive, System.Guid Gtid)>
+        SetupSamPostWithReactionAsync(string reaction)
+    {
+        var frodo = await LoginAsOwner(Identities.Frodo);
+        var sam = await LoginAsOwner(Identities.Sam);
+
+        // frodo is the "sender" here only in PeerFlow's naming: the circle it builds grants frodo
+        // access on sam's drive, which is the direction this test needs.
+        var drive = await PeerFlow.CreatePeerDriveAsync(frodo, sam, DrivePermission.Read, "reactions");
+
+        var metadata = SampleMetadataData.Create(fileType: 100, acl: AccessControlList.Connected);
+        var upload = await sam.Drives.Writer.UploadNewMetadata(drive.Alias, metadata);
+        Assert.That(upload.IsSuccessStatusCode, Is.True, $"Sam upload failed: {upload.StatusCode}");
+
+        var gtid = upload.Content!.GlobalTransitId;
+        Assert.That(gtid, Is.Not.Null, "the peer reaction routes are keyed by GlobalTransitId");
+
+        var added = await sam.Drives.Reactions.AddReactionAsync(drive.Alias, upload.Content.FileId, reaction);
+        Assert.That(added.IsSuccessStatusCode, Is.True, $"Sam AddReaction failed: {added.StatusCode}");
+
+        return (frodo, sam, drive, gtid!.Value);
+    }
+
+    private static async Task<System.Guid> FileIdOf(OwnerSession owner, TargetDrive drive, System.Guid gtid)
+    {
+        var query = await owner.Drives.Reader.GetBatchAsync(drive.Alias, new QueryBatchRequest
+        {
+            QueryParams = new FileQueryParamsV1 { GlobalTransitId = new[] { gtid } },
+            ResultOptionsRequest = new QueryBatchResultOptionsRequest { MaxRecords = 1, IncludeMetadataHeader = true }
+        });
+
+        Assert.That(query.IsSuccessStatusCode, Is.True, $"query by gtid failed: {query.StatusCode}");
+        return query.Content!.SearchResults.Single().FileId;
+    }
+}

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DrivePeerReaderV2Client.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/DrivePeerReaderV2Client.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Odin.Core.Identity;
@@ -7,6 +8,7 @@ using Odin.Hosting.Tests._Universal.ApiClient.Factory;
 using Odin.Services.Apps;
 using Odin.Services.Drives;
 using Odin.Services.Drives.FileSystem.Base;
+using Odin.Services.Drives.Reactions;
 using Odin.Services.Peer.Outgoing.Drive.Query;
 using Refit;
 
@@ -94,6 +96,32 @@ public class DrivePeerReaderV2Client(OdinId identity, IApiClientFactory factory)
         var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
         var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
         return await svc.GetThumbnailByGtid(peer.DomainName, driveId, gtid, payloadKey, width, height);
+    }
+
+    // --- Reaction reads on a peer's file (keyed by GlobalTransitId) ---
+
+    public async Task<ApiResponse<GetReactionsResponse>> GetReactionsByGtidAsync(OdinId peer, Guid driveId, Guid gtid,
+        string cursor = null, int maxRecords = 100, FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetPeerReactions(peer.DomainName, driveId, gtid, cursor, maxRecords);
+    }
+
+    public async Task<ApiResponse<GetReactionCountsResponse>> GetReactionSummaryByGtidAsync(OdinId peer, Guid driveId, Guid gtid,
+        FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetPeerReactionSummary(peer.DomainName, driveId, gtid);
+    }
+
+    public async Task<ApiResponse<List<string>>> GetReactionsByIdentityAndGtidAsync(OdinId peer, Guid driveId, Guid gtid,
+        OdinId reactingIdentity, FileSystemType fileSystemType = FileSystemType.Standard)
+    {
+        var client = factory.CreateHttpClient(identity, out var sharedSecret, fileSystemType);
+        var svc = RefitCreator.RestServiceFor<IDrivePeerQueryHttpClientApiV2>(client, sharedSecret);
+        return await svc.GetPeerReactionsByIdentity(peer.DomainName, driveId, gtid, reactingIdentity.DomainName);
     }
 
     // --- Temporal (time-boxed) read API ---

--- a/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerQueryHttpClientApiV2.cs
+++ b/tests/apps/Odin.Hosting.Tests/_V2/ApiClient/IDrivePeerQueryHttpClientApiV2.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Odin.Hosting.UnifiedV2;
 using Odin.Services.Apps;
 using Odin.Services.Drives;
+using Odin.Services.Drives.Reactions;
 using Odin.Services.Peer.Outgoing.Drive.Query;
 using Refit;
 
@@ -53,6 +55,29 @@ public interface IDrivePeerQueryHttpClientApiV2
         [AliasAs("payloadKey")] string payloadKey,
         [AliasAs("width")] int width,
         [AliasAs("height")] int height);
+
+    // --- Reaction reads on a peer's file (keyed by GlobalTransitId) ---
+
+    [Get(UnifiedApiRouteConstants.PeerReactionsByGtid)]
+    Task<ApiResponse<GetReactionsResponse>> GetPeerReactions(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("gtid:guid")] Guid gtid,
+        [Query] string cursor = null,
+        [Query] int maxRecords = 100);
+
+    [Get(UnifiedApiRouteConstants.PeerReactionsByGtid + "/summary")]
+    Task<ApiResponse<GetReactionCountsResponse>> GetPeerReactionSummary(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("gtid:guid")] Guid gtid);
+
+    [Get(UnifiedApiRouteConstants.PeerReactionsByGtid + "/by-identity")]
+    Task<ApiResponse<List<string>>> GetPeerReactionsByIdentity(
+        [AliasAs("odinId")] string odinId,
+        [AliasAs("driveId:guid")] Guid driveId,
+        [AliasAs("gtid:guid")] Guid gtid,
+        [Query] string identity);
 
     [Post(UnifiedApiRouteConstants.PeerByDriveId + "/query-batch")]
     Task<ApiResponse<QueryBatchResponse>> QueryBatch(


### PR DESCRIPTION
Fixes #1610

## What

Reaction **writes** already go over peer via `GroupReactionService` → outbox → the perimeter controller. Reaction **reads** had no peer variant on v2, so a client could only read its own host's copy of another identity's post — which holds nothing but the reactions it sent itself.

Adds `V2DrivePeerReactionController`, delegating to the existing `PeerReactionSenderService`:

| Route | Returns |
|---|---|
| `GET /api/v2/peer/{odinId}/drives/{driveId}/files/by-gtid/{gtid}/reactions?cursor=&maxRecords=` | `GetReactionsResponse` |
| `GET .../reactions/summary` | `GetReactionCountsResponse` |
| `GET .../reactions/by-identity?identity=` | `List<string>` |

Policy `OwnerOrApp`, per the issue. Writes are not duplicated.

## Decisions

**Local response shape, as requested.** The list action maps `GetReactionsPerimeterResponse` → `GetReactionsResponse` so clients reuse their existing local decoder. `FileId` has no cross-identity meaning — the caller does not have the file on its own drive — so it comes back zeroed.

**Keyed by globalTransitId.** A followed identity's post lands on the feed drive as a reference with no fileId on the author's drive and no uniqueId, so the gtid is the only handle the client holds. `PeerReactionsByGtid` extends the existing `PeerByGtid` template. Drive is addressed by alias with `Type = Guid.Empty`, matching the peer file-read endpoints.

## On the fileSystemType question raised in the issue

Verified by reading code — it is a clean lift, and the reason is that there is nothing to plumb:

- Reactions are stored per `(driveId, fileId)`. `ReactionContentService`'s three read methods take only an `InternalDriveFileId`; no file-system-type discriminator is involved, so group-written reactions and direct reads hit the same rows.
- The peer wire format has no file-system-type field (`GetRemoteReactionsRequest` is `File` / `Cursor` / `MaxRecords`).
- The remote resolves it itself: `PeerIncomingReactionService.ResolveInternalFile` → `FileSystemResolver.ResolveFileSystem(GlobalTransitIdFileIdentifier, ...)`, which probes Standard then Comment.

So unlike the local group controller, these actions deliberately do not forward `GetHttpFileSystemResolver().GetFileSystemType()` — the caller's header would have nowhere to go and no effect on the answer.

## Pre-existing gap found while testing (not fixed here)

`Reaction.Created` comes back as `0` from these routes — **and equally from the existing local reaction reads**. The `DriveReactions` table has no `created` column at all (`DriveReactionsRecord` is `rowId` / `identityId` / `driveId` / `postId` / `identity` / `singleReaction`), and `DriveQuery.GetReactionsByFileAsync` never populates the field. Fixing it needs a schema change, so it is out of scope for this issue; the test asserts peer and local agree rather than asserting a real timestamp, and carries a comment explaining why. Worth its own issue if clients need reaction timestamps.

## Tests

New `PeerReactionReadTests` (5 tests, `Odin.Hosting.Tests.V2`). Setup is Sam-hosts / Frodo-reads: Sam owns the drive and post, Sam reacts, Frodo — connected with `DrivePermission.Read` — reads over peer. The reaction Frodo gets back is one he did not author and has no local copy of, which is exactly the case that was unreachable.

- list returns the host's reaction, attributed to Sam
- response uses the local shape with zeroed FileId, matching Sam's own local read field-for-field
- summary returns counts
- by-identity returns that identity's reactions; an identity that reacted to nothing returns empty rather than erroring
- multiple reactions are reflected in both list and summary

New tests pass 5/5; full `Odin.Hosting.Tests.V2` passes 423/423 (3 pre-existing skips).

## Not verified

The KMP client call sites live in `homebase-id/chat-kmp` / `homebase-api` and were not exercised against this branch — routes were matched against the proposal in #1610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)